### PR TITLE
refactor: move toString value helper into capybara-lib

### DIFF
--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -424,31 +424,6 @@ public final class JavaGenerator implements Generator {
                     .append(mapRecordFieldToStringValue(field));
         }
         body.append(" + \" }\"; }\n");
-        body.append("private static java.lang.String __capybaraToStringValue(java.lang.Object value) {\n");
-        body.append("if (value == null) { return \"null\"; }\n");
-        body.append("if (value instanceof java.lang.String __capybaraStringValue) {\n");
-        body.append("return \"\\\"\" + __capybaraStringValue.replace(\"\\\\\", \"\\\\\\\\\").replace(\"\\\"\", \"\\\\\\\"\") + \"\\\"\";\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.lang.Enum<?> __capybaraEnumValue) {\n");
-        body.append("return \"INSTANCE\".equals(__capybaraEnumValue.name())\n");
-        body.append("? __capybaraEnumValue.getDeclaringClass().getSimpleName()\n");
-        body.append(": __capybaraEnumValue.name();\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.util.Map<?, ?> __capybaraMapValue) {\n");
-        body.append("return __capybaraMapValue.entrySet().stream()\n");
-        body.append(".map(__capybaraEntry -> java.lang.String.valueOf(__capybaraEntry.getKey()) + \"=\" + __capybaraToStringValue(__capybaraEntry.getValue()))\n");
-        body.append(".collect(java.util.stream.Collectors.joining(\",\", \"{\", \"}\"));\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.util.Collection<?> __capybaraCollectionValue) {\n");
-        body.append("return __capybaraCollectionValue.stream()\n");
-        body.append(".map(__capybaraItem -> __capybaraToStringValue(__capybaraItem))\n");
-        body.append(".collect(java.util.stream.Collectors.joining(\",\", \"[\", \"]\"));\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.util.Map.Entry<?, ?> __capybaraEntryValue) {\n");
-        body.append("return java.lang.String.valueOf(__capybaraEntryValue.getKey()) + \"=\" + __capybaraToStringValue(__capybaraEntryValue.getValue());\n");
-        body.append("}\n");
-        body.append("return java.lang.String.valueOf(value);\n");
-        body.append("}\n");
         return body.toString();
     }
 
@@ -462,7 +437,7 @@ public final class JavaGenerator implements Generator {
     }
 
     private String mapRecordFieldToStringValue(JavaRecord.JavaRecordField field) {
-        return "__capybaraToStringValue(" + field.name() + ")";
+        return "dev.capylang.CapybaraToStringUtil.toStringValue(" + field.name() + ")";
     }
 
     private String mapJavaEnum(JavaEnum javaEnum) {

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -207,6 +207,20 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldUseCapybaraToStringUtilForGeneratedRecordToString() {
+        var program = compileProgram("Pretty", "/foo/bar", """
+                data Pretty { value: string }
+                """);
+
+        var generated = new JavaGenerator().generate(program).modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated).contains("dev.capylang.CapybaraToStringUtil.toStringValue(value)");
+        assertThat(generated).doesNotContain("private static java.lang.String __capybaraToStringValue");
+    }
+
+    @Test
     void shouldImportOptionTypesAsClassesInsteadOfStaticMembers() {
         var program = compileProgram("LocalOption", "/foo/bar", """
                 from /capy/lang/Option import { Option, Some, None }

--- a/lib/capybara-lib/src/main/java/dev/capylang/CapybaraToStringUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/CapybaraToStringUtil.java
@@ -1,0 +1,38 @@
+package dev.capylang;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class CapybaraToStringUtil {
+    private CapybaraToStringUtil() {
+    }
+
+    public static String toStringValue(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String stringValue) {
+            return "\"" + stringValue.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        }
+        if (value instanceof Enum<?> enumValue) {
+            return "INSTANCE".equals(enumValue.name())
+                    ? enumValue.getDeclaringClass().getSimpleName()
+                    : enumValue.name();
+        }
+        if (value instanceof Map<?, ?> mapValue) {
+            return mapValue.entrySet().stream()
+                    .map(entry -> String.valueOf(entry.getKey()) + "=" + toStringValue(entry.getValue()))
+                    .collect(Collectors.joining(",", "{", "}"));
+        }
+        if (value instanceof Collection<?> collectionValue) {
+            return collectionValue.stream()
+                    .map(CapybaraToStringUtil::toStringValue)
+                    .collect(Collectors.joining(",", "[", "]"));
+        }
+        if (value instanceof Map.Entry<?, ?> entryValue) {
+            return String.valueOf(entryValue.getKey()) + "=" + toStringValue(entryValue.getValue());
+        }
+        return String.valueOf(value);
+    }
+}

--- a/lib/capybara-lib/src/test/java/dev/capylang/CapybaraToStringUtilTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/CapybaraToStringUtilTest.java
@@ -1,0 +1,20 @@
+package dev.capylang;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CapybaraToStringUtilTest {
+    @Test
+    void shouldEscapeStrings() {
+        assertEquals("\"va\\\\\\\"lue\"", CapybaraToStringUtil.toStringValue("va\\\"lue"));
+    }
+
+    @Test
+    void shouldFormatCollectionsAndMaps() {
+        assertEquals("{x=[1,\"two\"]}", CapybaraToStringUtil.toStringValue(Map.of("x", List.of(1, "two"))));
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize value->string formatting used by generated record `toString()` logic to avoid duplicating a private helper inside each generated type.
- Keep generated Java smaller and consistent by delegating formatting responsibilities to the runtime library in `capybara-lib`.

### Description
- Added `dev.capylang.CapybaraToStringUtil` in `lib/capybara-lib` with `public static String toStringValue(Object)` that handles `null`, `String` escaping, `Enum`, `Map`, `Collection`, and `Map.Entry` cases. (`lib/capybara-lib/src/main/java/dev/capylang/CapybaraToStringUtil.java`)
- Updated the Java generator to stop emitting the inline `__capybaraToStringValue` helper and instead call `dev.capylang.CapybaraToStringUtil.toStringValue(...)` for record field stringification. (`compiler/src/main/java/dev/capylang/generator/JavaGenerator.java`)
- Added a unit test for the new util covering string escaping and nested map/list formatting. (`lib/capybara-lib/src/test/java/dev/capylang/CapybaraToStringUtilTest.java`)
- Added a compiler generator test asserting generated record `toString()` uses the shared util and that the old private helper is no longer emitted. (`compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java`)

### Testing
- Attempted to run `./gradlew :compiler:test :lib:capybara-lib:test`, but the Gradle wrapper download failed due to a proxy `HTTP/1.1 403 Forbidden` error, so wrapper-based execution did not complete.
- Ran `gradle :compiler:test :lib:capybara-lib:test` with the local Gradle, which failed due to a local JVM/Gradle compatibility issue: `Unsupported class file major version 69`, so tests could not be executed in this environment.
- No automated tests ran to completion in the current environment; the added tests are included and should pass when run in a CI or developer environment with working Gradle wrapper and compatible JDK/tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6237ca114832087bdfc725973b266)