### PR TITLE
refactor: move record toString value formatter into capybara-lib util

### DIFF
--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -424,31 +424,6 @@ public final class JavaGenerator implements Generator {
                     .append(mapRecordFieldToStringValue(field));
         }
         body.append(" + \" }\"; }\n");
-        body.append("private static java.lang.String __capybaraToStringValue(java.lang.Object value) {\n");
-        body.append("if (value == null) { return \"null\"; }\n");
-        body.append("if (value instanceof java.lang.String __capybaraStringValue) {\n");
-        body.append("return \"\\\"\" + __capybaraStringValue.replace(\"\\\\\", \"\\\\\\\\\").replace(\"\\\"\", \"\\\\\\\"\") + \"\\\"\";\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.lang.Enum<?> __capybaraEnumValue) {\n");
-        body.append("return \"INSTANCE\".equals(__capybaraEnumValue.name())\n");
-        body.append("? __capybaraEnumValue.getDeclaringClass().getSimpleName()\n");
-        body.append(": __capybaraEnumValue.name();\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.util.Map<?, ?> __capybaraMapValue) {\n");
-        body.append("return __capybaraMapValue.entrySet().stream()\n");
-        body.append(".map(__capybaraEntry -> java.lang.String.valueOf(__capybaraEntry.getKey()) + \"=\" + __capybaraToStringValue(__capybaraEntry.getValue()))\n");
-        body.append(".collect(java.util.stream.Collectors.joining(\",\", \"{\", \"}\"));\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.util.Collection<?> __capybaraCollectionValue) {\n");
-        body.append("return __capybaraCollectionValue.stream()\n");
-        body.append(".map(__capybaraItem -> __capybaraToStringValue(__capybaraItem))\n");
-        body.append(".collect(java.util.stream.Collectors.joining(\",\", \"[\", \"]\"));\n");
-        body.append("}\n");
-        body.append("if (value instanceof java.util.Map.Entry<?, ?> __capybaraEntryValue) {\n");
-        body.append("return java.lang.String.valueOf(__capybaraEntryValue.getKey()) + \"=\" + __capybaraToStringValue(__capybaraEntryValue.getValue());\n");
-        body.append("}\n");
-        body.append("return java.lang.String.valueOf(value);\n");
-        body.append("}\n");
         return body.toString();
     }
 
@@ -462,7 +437,7 @@ public final class JavaGenerator implements Generator {
     }
 
     private String mapRecordFieldToStringValue(JavaRecord.JavaRecordField field) {
-        return "__capybaraToStringValue(" + field.name() + ")";
+        return "dev.capylang.CapybaraToStringUtil.__capybaraToStringValue(" + field.name() + ")";
     }
 
     private String mapJavaEnum(JavaEnum javaEnum) {

--- a/lib/capybara-lib/src/main/java/dev/capylang/CapybaraToStringUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/CapybaraToStringUtil.java
@@ -1,0 +1,38 @@
+package dev.capylang;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class CapybaraToStringUtil {
+    private CapybaraToStringUtil() {
+    }
+
+    public static String __capybaraToStringValue(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof String capybaraStringValue) {
+            return "\"" + capybaraStringValue.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        }
+        if (value instanceof Enum<?> capybaraEnumValue) {
+            return "INSTANCE".equals(capybaraEnumValue.name())
+                    ? capybaraEnumValue.getDeclaringClass().getSimpleName()
+                    : capybaraEnumValue.name();
+        }
+        if (value instanceof Map<?, ?> capybaraMapValue) {
+            return capybaraMapValue.entrySet().stream()
+                    .map(capybaraEntry -> String.valueOf(capybaraEntry.getKey()) + "=" + __capybaraToStringValue(capybaraEntry.getValue()))
+                    .collect(Collectors.joining(",", "{", "}"));
+        }
+        if (value instanceof Collection<?> capybaraCollectionValue) {
+            return capybaraCollectionValue.stream()
+                    .map(CapybaraToStringUtil::__capybaraToStringValue)
+                    .collect(Collectors.joining(",", "[", "]"));
+        }
+        if (value instanceof Map.Entry<?, ?> capybaraEntryValue) {
+            return String.valueOf(capybaraEntryValue.getKey()) + "=" + __capybaraToStringValue(capybaraEntryValue.getValue());
+        }
+        return String.valueOf(value);
+    }
+}

--- a/lib/capybara-lib/src/test/java/dev/capylang/CapybaraToStringUtilTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/CapybaraToStringUtilTest.java
@@ -1,0 +1,49 @@
+package dev.capylang;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CapybaraToStringUtilTest {
+    @Test
+    void shouldRenderNull() {
+        assertEquals("null", CapybaraToStringUtil.__capybaraToStringValue(null));
+    }
+
+    @Test
+    void shouldEscapeStringValues() {
+        assertEquals("\"hello \\\"capy\\\"\\\\lang\"", CapybaraToStringUtil.__capybaraToStringValue("hello \"capy\"\\lang"));
+    }
+
+    @Test
+    void shouldRenderEnumSingletonByTypeName() {
+        assertEquals("SingletonEnum", CapybaraToStringUtil.__capybaraToStringValue(SingletonEnum.INSTANCE));
+    }
+
+    @Test
+    void shouldRenderEnumNamedValueByName() {
+        assertEquals("SECOND", CapybaraToStringUtil.__capybaraToStringValue(NamedEnum.SECOND));
+    }
+
+    @Test
+    void shouldRenderMapAndCollectionValuesRecursively() {
+        var nested = new LinkedHashMap<String, Object>();
+        nested.put("k", List.of("v", NamedEnum.FIRST));
+        nested.put("entry", Map.entry("x", "y"));
+
+        assertEquals("{k=[\"v\",FIRST],entry=x=\"y\"}", CapybaraToStringUtil.__capybaraToStringValue(nested));
+    }
+
+    private enum SingletonEnum {
+        INSTANCE
+    }
+
+    private enum NamedEnum {
+        FIRST,
+        SECOND
+    }
+}


### PR DESCRIPTION
### Motivation
- Avoid emitting the same `__capybaraToStringValue` helper into every generated record and centralize field value formatting in the runtime.
- Make the string-formatting behavior easier to test and evolve by moving it into a shared library module.

### Description
- Added `dev.capylang.CapybaraToStringUtil` in `lib/capybara-lib` that implements `__capybaraToStringValue(Object)` for nulls, escaped strings, enum formatting, maps, collections, map entries, and fallback values.
- Updated the Java generator to stop emitting a private `__capybaraToStringValue` and instead generate calls to `dev.capylang.CapybaraToStringUtil.__capybaraToStringValue(...)` from records.
- Added `CapybaraToStringUtilTest` in `lib/capybara-lib` covering null rendering, string escaping, enum singleton/name behavior, and recursive map/collection formatting.

### Testing
- Added unit tests `lib/capybara-lib/src/test/java/dev/capylang/CapybaraToStringUtilTest.java` but they were not run to completion in this environment.
- `bash ./gradlew :lib:capybara-lib:test :compiler:test` failed due to Gradle wrapper download being blocked by a network proxy (`HTTP 403`).
- `JAVA_HOME=$HOME/.local/share/mise/installs/java/21.0.2 gradle :lib:capybara-lib:test :compiler:test` failed due to plugin resolution in the restricted environment, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6238d92c88320a9e566a9ca025514)