### PR TITLE
feat: require `---` separator after local definitions in function bodies

### DIFF
--- a/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
+++ b/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
@@ -65,6 +65,7 @@
     <dict><key>name</key><string>constant.numeric.capybara</string><key>match</key><string>\b(?:0[xX][0-9a-fA-F]+|\d+[lL]|\d+\.\d*(?:[eE][+\-]?\d+)?[fFdD]?|\d+[eE][+\-]?\d+[fFdD]?|\d+)\b</string></dict>
     <dict><key>name</key><string>constant.language.boolean.capybara</string><key>match</key><string>\b(true|false)\b</string></dict>
     <dict><key>name</key><string>constant.language.unimplemented.capybara</string><key>match</key><string>\?\?\?</string></dict>
+    <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
       <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)(fun)(\s+)(__[A-Za-z0-9_]+)</string>

--- a/Intellij/syntaxes/Capybara.tmLanguage
+++ b/Intellij/syntaxes/Capybara.tmLanguage
@@ -65,6 +65,7 @@
     <dict><key>name</key><string>constant.numeric.capybara</string><key>match</key><string>\b(?:0[xX][0-9a-fA-F]+|\d+[lL]|\d+\.\d*(?:[eE][+\-]?\d+)?[fFdD]?|\d+[eE][+\-]?\d+[fFdD]?|\d+)\b</string></dict>
     <dict><key>name</key><string>constant.language.boolean.capybara</string><key>match</key><string>\b(true|false)\b</string></dict>
     <dict><key>name</key><string>constant.language.unimplemented.capybara</string><key>match</key><string>\?\?\?</string></dict>
+    <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
       <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)(fun)(\s+)(__[A-Za-z0-9_]+)</string>

--- a/Intellij/syntaxes/capybara.tmLanguage.json
+++ b/Intellij/syntaxes/capybara.tmLanguage.json
@@ -147,6 +147,10 @@
         {
           "name": "constant.language.unimplemented.capybara",
           "match": "\\?\\?\\?"
+        },
+        {
+          "name": "punctuation.separator.local-definitions.capybara",
+          "match": "---"
         }
       ]
     },

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -15,7 +15,8 @@ definition:
     | constDeclaration;
 
 functionDeclaration: docComment* VISIBILITY? 'fun' functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody;
-functionBody: localDefinition* expression;
+functionBody: expression
+            | localDefinition+ '---' expression;
 localDefinition: localFunctionDeclaration
                | localTypeDeclaration
                | localDataDeclaration

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -232,6 +232,7 @@ class JavaExpressionEvaluatorTest {
                         match parse.value with
                         case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
                         case None -> Error { "missing" }
+                    ---
                     __unwrap(__Parse { buffer: "", value: Some { value } }) | parsed => Success { parsed.value }
                 """);
 

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -157,6 +157,7 @@ class CapybaraParserTest {
         var module = parseSuccess(new RawModule("Test", "/parser", """
                 fun foo(x: string): bool =
                     const __white_space = { " ", "\\t", "\\n" }
+                    ---
                     __white_space ? x
                 """));
 
@@ -177,6 +178,7 @@ class CapybaraParserTest {
         var result = new CapybaraParser().parseModule(new RawModule("Test", "/parser", """
                 fun foo(x: string): bool =
                     const white_space = { " ", "\\t", "\\n" }
+                    ---
                     x == ""
                 """));
 
@@ -198,6 +200,7 @@ class CapybaraParserTest {
                 fun foo(): int =
                     const __white_space = 1
                     const __white_space = 2
+                    ---
                     __white_space
                 """));
 
@@ -279,6 +282,7 @@ class CapybaraParserTest {
                 fun parse(): int =
                     fun __parse_positive_digit(value: int): int = value
                     fun __parse_positive_digit(value: int): int = value + 1
+                    ---
                     0
                 """);
 
@@ -302,11 +306,24 @@ class CapybaraParserTest {
                     /// Internal accumulate
                     fun __accumulate(n: int, acc: int): int =
                         if n <= 0 then acc else __accumulate(n-1, acc+n)
+                    ---
                     __accumulate(n, 0)
                 """));
 
         var localFunction = findFunction("__accumulate__local_fun_0_accumulate", module.functional());
         assertThat(localFunction.comments()).containsExactly("Internal accumulate");
+    }
+
+    @Test
+    @DisplayName("should reject missing separator after local definitions")
+    void rejectMissingSeparatorAfterLocalDefinitions() {
+        var result = new CapybaraParser().parseModule(new RawModule("Test", "/parser", """
+                fun foo(n: int): int =
+                    fun __inc(x: int): int = x + 1
+                    __inc(n)
+                """));
+
+        assertThat(result).isInstanceOf(Result.Error.class);
     }
 
     @Test
@@ -596,6 +613,7 @@ class CapybaraParserTest {
                     data __Parse[T] { buffer: string, value: T }
                     fun __parse_pre_release(version: string): Result[__Parse[string]] = Success { __Parse { version, "rc1" } }
                     fun __parse_build(version: string): Result[__Parse[string]] = Success { __Parse { version, "001" } }
+                    ---
                     let raw_sem_ver = SemVer { None {}, None {} }
                     let parse_patch: __Parse[string] = __Parse { version, "1.2.3" }
                     match parse_patch.buffer[0] with
@@ -648,6 +666,7 @@ class CapybaraParserTest {
                     data __Parse[T] { buffer: string, value: T }
                     fun __parse_tail(buffer: string): Result[__Parse[string]] = Success { __Parse { buffer, "tail" } }
                     fun __parse_build(buffer: string): Result[__Parse[string]] = Success { __Parse { buffer, "build" } }
+                    ---
                     let parse_patch: __Parse[string] = __Parse { input, "base" }
                     match parse_patch.buffer[0] with
                     case Some { ch } when ch == "-" -> {

--- a/integration-tests/src/main/capybara/dev/capylang/test/Consts.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/Consts.cfun
@@ -26,10 +26,12 @@ fun uses_private_const(): int = _HIDDEN + 1
 fun local_consts(x: int): int =
     const __BASE = 10
     const __INC: int = 5
+    ---
     x + __BASE + __INC
 
 fun local_private_named_const(x: string): bool =
     const __white_space: set[string] = { " ", "\t", "\n" }
+    ---
     __white_space ? x
 
 fun primitives_summary(): string =

--- a/integration-tests/src/main/capybara/dev/capylang/test/EmptyLiteralInference.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/EmptyLiteralInference.cfun
@@ -9,6 +9,7 @@ fun reverse_ints(values: list[int]): list[int] =
             match left[0] with
             case Some { v } -> __rev(left[1:], [v] + acc)
             case None -> acc
+    ---
     __rev(values, [])
 
 fun duplicate_strings(values: list[string]): list[string] =
@@ -19,6 +20,7 @@ fun duplicate_strings(values: list[string]): list[string] =
             match left[0] with
             case Some { v } -> __dup(left[1:], acc + [v, v])
             case None -> acc
+    ---
     __dup(values, [])
 
 fun empty_list_of_type_param(v: T): list[T] =

--- a/integration-tests/src/main/capybara/dev/capylang/test/GeneratorSemVer.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/GeneratorSemVer.cfun
@@ -17,6 +17,7 @@ fun parse_local_option(value: int): Result[int] =
         match parse.value with
         case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
         case None -> Error { "missing value" }
+    ---
     __unwrap(__Parse { buffer: "", value: Some { value } })
     | parsed => Success { parsed.value }
 
@@ -26,6 +27,7 @@ fun parse_local_option_none(): Result[int] =
         match parse.value with
         case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
         case None -> Error { "missing value" }
+    ---
     let none_value: Option[int] = None {}
     __unwrap(__Parse { buffer: "", value: none_value })
     | parsed => Success { parsed.value }
@@ -34,6 +36,7 @@ fun parse_local_semver_build(version: string): Result[string] =
     data __Parse[T] { buffer: string, value: T }
     fun __parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer: "", value: buffer } }
+    ---
     let parse: __Parse[SemVer] = __Parse {
         buffer: version,
         value: SemVer { major: 1, build_metadata: None {} }
@@ -52,6 +55,7 @@ fun parse_local_semver_build_and_increment(version: string): Result[int] =
     data __Parse[T] { buffer: string, value: T }
     fun __parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer: "", value: buffer } }
+    ---
     let parse: __Parse[SemVer] = __Parse {
         buffer: version,
         value: SemVer { major: 1, build_metadata: None {} }

--- a/integration-tests/src/main/capybara/dev/capylang/test/GroupedExpression.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/GroupedExpression.cfun
@@ -17,7 +17,7 @@ fun grouped_guarded_match_is_exhaustive(input: string): Result[string] =
         Success { __Parse { buffer, "tail" } }
     fun __parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "build" } }
-
+    ---
     let parse_patch: __Parse[string] = __Parse { input, "base" }
     match parse_patch.buffer[0] with
     case Some { ch } when ch == '-' -> {
@@ -48,7 +48,7 @@ fun semver_style_mixed_case_pipe_bodies(input: string): Result[string] =
         Success { __Parse { buffer, "rc1" } }
     fun __parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "001" } }
-
+    ---
     let parse_patch: __Parse[string] = __Parse { input, "1.2.3" }
     let raw_sem_ver = "1.2.3"
     match parse_patch.buffer[0] with
@@ -80,7 +80,7 @@ fun inner_ungrouped_pipe_in_match_inside_lambda(input: string): Result[string] =
         Success { __Parse { buffer, "rc1" } }
     fun __parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "001" } }
-
+    ---
     let parse_patch: __Parse[string] = __Parse { input, "1.2.3" }
     let raw_sem_ver = "1.2.3"
     match parse_patch.buffer[0] with

--- a/integration-tests/src/main/capybara/dev/capylang/test/LocalFunctionDocComments.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/LocalFunctionDocComments.cfun
@@ -3,4 +3,5 @@ fun accumulate(n: int): int =
     /// Internal accumulate
     fun __accumulate(n: int, acc: int): int =
         if n <= 0 then acc else __accumulate(n - 1, acc + n)
+    ---
     __accumulate(n, 0)

--- a/integration-tests/src/main/capybara/dev/capylang/test/LocalFunctions.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/LocalFunctions.cfun
@@ -3,6 +3,7 @@ fun sum_down(x: int): int =
         if x <= 0
         then sum
         else __sum_down(x - 1, sum + x)
+    ---
     __sum_down(x, 0)
 
 fun parity(x: int): bool =
@@ -14,10 +15,12 @@ fun parity(x: int): bool =
         if n == 0
         then false
         else __is_even(n - 1)
+    ---
     __is_even(x)
 
 fun local_with_let(x: int): int =
     fun __inc(y: int): int =
         let z = y + 1
         z
+    ---
     __inc(x)

--- a/integration-tests/src/main/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -10,6 +10,7 @@ fun foo_me(name: string): string =
         case __Foo { foo } -> foo
         case __Boo { boo } -> boo
         case __Unknown { unkn } -> unkn
+    ---
     let x =
         match name with
         case "foo" -> __Foo { "xyz" }
@@ -19,6 +20,7 @@ fun foo_me(name: string): string =
 
 fun local_data_with_imported_result(v: int): string =
     data __Entry { key: string, value: Result[int] }
+    ---
     let entry = __Entry { "k", Success { value: v } }
     match entry.value with
     case Success { value } -> "ok:" + value
@@ -28,12 +30,14 @@ fun local_data_used_in_local_function(v: int): string =
     data __Parse[T] { value: T }
     fun __unwrap(parse: __Parse[int]): string =
         "value:" + parse.value
+    ---
     __unwrap(__Parse { v })
 
 fun local_generic_data_used_in_local_function_return_type(v: int): string =
     data __Parse[T] { value: T }
     fun __parse(value: int): Result[__Parse[int]] =
         Success { __Parse { value } }
+    ---
     match __parse(v) with
     case Success { value } -> "value:" + value.value
     case Error { message } -> "error:" + message
@@ -42,6 +46,7 @@ fun local_generic_data_field_access_followed_by_index(buffer: string): string =
     data __Parse[T] { buffer: string, value: T }
     fun __parse(value: string): Result[__Parse[int]] =
         Success { __Parse { buffer: value, value: 1 } }
+    ---
     match (__parse(buffer) | parse =>
         match parse.buffer[0] with
         case Some { value } -> Success { value }
@@ -51,6 +56,7 @@ fun local_generic_data_field_access_followed_by_index(buffer: string): string =
 
 fun local_generic_option_constructor_pattern_binding(v: int): int =
     data __Parse[T] { value: T }
+    ---
     let parse: __Parse[Option[int]] = __Parse { Some { v } }
     match parse.value with
     case Some { value } -> value * 10 + v

--- a/integration-tests/src/main/capybara/dev/capylang/test/SeqCollection.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/SeqCollection.cfun
@@ -43,6 +43,7 @@ fun drop_local(s: Seq[int], n: int): Seq[int] =
             match seq with
             case End -> End
             case Cons { value, rest } -> __drop(rest, left - 1)
+    ---
     __drop(s, n)
 
 fun until_local(s: Seq[int], stop: int): Seq[int] =
@@ -53,4 +54,5 @@ fun until_local(s: Seq[int], stop: int): Seq[int] =
             if value == x
             then End
             else Cons { value, __until(rest, x) }
+    ---
     __until(s, stop)

--- a/integration-tests/src/test/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/integration-tests/src/test/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -65,6 +65,7 @@ public class CompilationErrorTest {
                             type __Token = __Number | __Stop
                             data __Number { value: int }
                             data __Stop {}
+                            ---
                             let token: __Token = __Number { value }
                             match token with
                             case __Number { value } -> value
@@ -993,6 +994,7 @@ public class CompilationErrorTest {
                                     data __Foo { foo: string }
                                     data __Boo { boo: string }
                                     data __Unknown { unkn: string }
+                                    ---
                                     match name with
                                     case "foo" -> __Foo { foo: "xyz" }
                                     case "boo" -> __Boo { boo: "xyz" }
@@ -1012,6 +1014,7 @@ public class CompilationErrorTest {
                                 fun parse_semver(version: string): int =
                                     data __Parse[T] { value: T }
                                     fun __parse_digits(parse: __Parse[Option[int]]): __Parse[int] = parse.value
+                                    ---
                                     0
                                 """,
                         new Position(3, "    fun __parse_digits(parse: __Parse[Option[int]]): __Parse[int] = "),

--- a/integration-tests/src/test/java/dev/capylang/test/compilation_error/LocalConstCompilationErrorTest.java
+++ b/integration-tests/src/test/java/dev/capylang/test/compilation_error/LocalConstCompilationErrorTest.java
@@ -18,6 +18,7 @@ class LocalConstCompilationErrorTest {
                 List.of(new RawModule("LocalConst", "/foo/boo", """
                         fun foo(x: string): bool =
                             const white_space = 1
+                            ---
                             x == ""
                         """)),
                 new TreeSet<>()

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -23,6 +23,7 @@ fun from_string(string: string): Path =
                 else __segments(value[1:], "", acc + current)
             else
                 __segments(value[1:], current + c, acc)
+    ---
     let value =
         if string.starts_with('/')
         then string[1:]
@@ -101,6 +102,7 @@ fun Path.normalize(): Path =
                     case _ -> __normalize_path(root, rest, acc)
             else
                 __normalize_path(root, rest, acc + seg)
+    ---
     Path {
         root: this.root,
         prefix: this.prefix,

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -3,6 +3,7 @@ fun digits(number: int): int =
         if number < 10
         then acc
         else __digits(number / 10, acc + 1)
+    ---
     if number == -2147483648
     // abs function cannot handle -2147483648 because of overflow, so we hardcode the result for this case
     then 10

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -10,21 +10,25 @@ single End
 /// ```
 fun natural_seq(): Seq[int] =
     fun __next(i: int): Seq[int] = Cons { i, () => __next(i+1) }
+    ---
     __next(0)
 
 /// Returns an infinite Fibonacci sequence: `1, 1, 2, 3, 5, 8, 13, ...`.
 fun fibonacci_seq(): Seq[int] =
     fun __next(a: int, b: int) = Cons { b, () => __next(b, a+b) }
+    ---
     __next(0,1)
 
 /// Returns an infinite sequence of zeros.
 fun zeros_seq(): Seq[int] =
     fun __next() = Cons { 0, () => __next() }
+    ---
     __next()
 
 /// Returns an infinite sequence of ones.
 fun ones_seq(): Seq[int] =
     fun __next() = Cons { 1, () => __next() }
+    ---
     __next()
 
 /// Returns an infinite sequence of powers of `base`: `base^0, base^1, base^2, ...`.
@@ -48,6 +52,7 @@ fun Seq[T].take(n: int): list[T] =
             match seq with
             case End -> list
             case Cons { value, rest } -> __take(rest(), n-1, list + value)
+    ---
     __take(this, n, [])
 
 /// Collects the entire sequence into a `list`.
@@ -58,6 +63,7 @@ fun Seq[T].as_list(): list[T] =
         match seq with
         case End -> list
         case Cons { value, rest } -> __as_list(rest(), list + value)
+    ---
     __as_list(this, [])
 
 /// Converts a `list` into a finite `Seq`.
@@ -84,6 +90,7 @@ fun Seq[T].take_last(n: int): list[T] =
             match seq with
             case End -> list
             case Cons { value, rest } -> __take_last(rest(), max, n-1, __add_to_list(max, list, value))
+    ---
     __take_last(this, n, n, [])
 
 /// Returns a sequence containing only elements that satisfy `pred`.
@@ -100,6 +107,7 @@ fun Seq[T].filter(pred: T => bool): Seq[T] =
             if pred(value)
             then Cons { value, () => __filter(rest(), pred) }
             else __filter(rest(), pred)
+    ---
     __filter(this, pred)
 
 /// Skips the first `n` elements of the sequence.
@@ -111,6 +119,7 @@ fun Seq[T].drop(n: int): Seq[T] =
             match seq with
             case End -> End
             case Cons { value, rest } -> __drop(rest(), n - 1)
+    ---
     __drop(this, n)
 
 /// Drops elements until `pred` becomes `true`.
@@ -128,6 +137,7 @@ fun Seq[T].drop_until(pred: T => bool): Seq[T] =
             if pred(value)
             then Cons { value, rest }
             else __drop_until(rest(), pred)
+    ---
     __drop_until(this, pred)
 
 /// Returns elements from the start of the sequence until `pred` becomes `true`.
@@ -141,6 +151,7 @@ fun Seq[T].until(pred: T => bool): Seq[T] =
             if pred(value)
             then End
             else Cons { value, () => __until(rest(), pred) }
+    ---
     __until(this, pred)
 
 /// Concatenates this sequence with `other`.
@@ -151,6 +162,7 @@ fun Seq[T].`+`(other: Seq[T]): Seq[T] =
         match seq with
         case End -> other
         case Cons { value, rest } -> Cons { value, () => __add(rest(), other) }
+    ---
     __add(this, other)
 
 /// Transforms each element using `map`.
@@ -176,6 +188,7 @@ fun Seq[T].`|*`(map: T => Seq[Y]): Seq[Y] =
         case End -> End
         case Cons { value, rest } ->
             map(value) + __flat_map(rest(), map)
+    ---
     __flat_map(this, map)
 
 fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
@@ -184,6 +197,7 @@ fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
         case End -> End
         case Cons { value, rest } ->
             map(value) + __flat_map(rest(), map)
+    ---
     __flat_map(this, map)
 
 fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
@@ -191,6 +205,7 @@ fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
         match seq with
         case End -> acc
         case Cons { value, rest } -> __reduce(rest(), reducer(acc, value), reducer)
+    ---
     __reduce(this, initial, reducer)
 
 fun Seq[T].reduce_left(initial: R, reducer: (R, T) => R): R = this.reduce(initial, reducer)
@@ -211,6 +226,7 @@ fun Seq[T].zip(other: Seq[Y]): Seq[tuple[T,Y]] =
             match other with
             case End -> End
             case Cons { v2, r2 } -> Cons { (v1, v2), () => __zip(r1, r2) }
+    ---
     __zip(this, other)
 
 /// Returns the first element wrapped in `Option`.

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -36,6 +36,7 @@ fun serialize(obj: JsonObject) =
         case JsonValueArray { value } -> __serialize(value)
         case JsonBool { value } -> value + ""
         case JsonNull -> "null"
+    ---
     __serialize(obj)
 
 fun deserialize(json: string): Result[JsonObject] =
@@ -74,7 +75,7 @@ fun _deserialize_json_array(json: string): Result[_Parse[JsonArray]] =
                     parsing_string: parse_json.parsing_string
                 })
         case Some { v } ->  Error { "Expected `,` or `]`, but got `" + v + "`!" }
-
+    ---
     if json.starts_with('[]')
     then Success { _Parse { JsonArray { [] }, json[2:] } }
     else
@@ -143,7 +144,7 @@ fun _deserialize_json_number(json: string): Result[_Parse[JsonNumber]] =
                     case None -> Error { 'Expected `}`, `]` or `,`, but got end of string!' }
                     case Some { v2 } -> Error { 'Expected `}`, `]` or `,`, but got `' + v2 + '`!' }
             }
-
+    ---
     __parse_number(_Parse {'', _drop_white_space(json)})
     | parse =>
         if parse.value ? '.'
@@ -254,9 +255,9 @@ fun _parse_string(json: string): Result[_Parse[string]] =
                 case '\\' -> __parse_string_until_quotation(_Parse { parse.value + v, parse.parsing_string[1:] } , true)
                 case '"'  -> Success { _Parse { parse.value, _drop_white_space(parse.parsing_string[1:]) }} // quotation mark found, ending
                 case _    -> __parse_string_until_quotation(_Parse { parse.value + v, parse.parsing_string[1:] }, false) // quotation mark not found, parsing...
-            }
+                }
             case None -> Error { message: '"parse_string: Expected `"`, but got end of string."' }
-
+    ---
     match json[0] with
     case Some { '"' } -> __parse_string_until_quotation(_Parse { "", json[1:] },  false)
     case Some { v } -> Error { message: "parse_string: Expected `\"`, but got `" + v + "`." }
@@ -269,6 +270,7 @@ fun _drop_white_space(s: string): string =
 
 fun _is_white_space(s: string): bool =
     const __white_spaces = { " ", "\r", "\n", "\t" }
+    ---
     match s.size with
     case 0 -> true
     case 1 -> __white_spaces ? s
@@ -284,6 +286,7 @@ fun deserialize(dict: dict[any]): Result[JsonObject] =
             match e.value with
             case Error e -> e
             case Success { json } -> Success { dict + { e.key : json } }
+    ---
     let initial_result: Result[dict[Json]] = __initial_result()
     dict
         // dict[any] => dict[Result[Json]]

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -328,7 +328,7 @@ fun parse_semver(version: string): Result[SemVer] =
                    | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't'
                    | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'  -> Success { __Parse { version[1:], value } }
                 case _ -> Error { "Expected A-Z or a-z, but got `" + value + "`!" }
-
+    ---
     __parse_version_core(version)
     | version_parse =>
         if !version_parse.buffer.is_empty


### PR DESCRIPTION
### Motivation
- Make function bodies with local declarations (local `fun`, `type`, `data`, `const`) visually and syntactically explicit by requiring a clear delimiter before the final expression.
- Prevent subtle parsing/semantic ambiguities when local declarations are followed by expressions and preserve consistent code style across examples and libraries.

### Description
- Require the separator by changing the grammar rule to `functionBody: expression | localDefinition+ '---' expression;` in `compiler/src/main/antlr/Functional.g4` so local declaration blocks must be followed by `---` before the body expression. 
- Update IntelliJ syntax bundles (`Intellij/syntaxes/*` and `Intellij/Capybara.tmBundle/*`) to recognise `---` as `punctuation.separator.local-definitions.capybara` for highlighting. 
- Add/adjust parser and generator tests to use the new separator and add a negative parser test that rejects missing `---` (updates in `compiler/src/test/...`).
- Update many `.cfun` sources in `integration-tests` and `lib/capybara-lib` to insert `---` where local declarations appear, and adjust compilation-error fixtures so semantic tests continue to assert expected errors rather than failing earlier on parse errors. 

### Testing
- Ran focused compiler tests with `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest --no-daemon` and `./gradlew :compiler:test --no-daemon`, both completed successfully. 
- Ran integration suite with `./gradlew :integration-tests:test --no-daemon` which completed successfully. 
- Verified updated Java generator/parser unit tests (including `JavaExpressionEvaluatorTest` and `CapybaraParserTest`) and the updated compilation-error tests; all automated tests passed after adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a133e9cc8320bf34ac9bb5086a94)