### PR TITLE
fix: prefer concrete overloads over any in overload tie-breaks

### DIFF
--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -2688,9 +2688,24 @@ public class CapybaraExpressionCompiler {
             if (coerceArgument(new CompiledVariable("__specificity__", candidateParam), currentBestParam) == null) {
                 return false;
             }
-            strictlyMoreSpecific = true;
+            var candidateIsBroad = isBroadSpecificityType(candidateParam);
+            var currentBestIsBroad = isBroadSpecificityType(currentBestParam);
+            if (candidateIsBroad && !currentBestIsBroad) {
+                return false;
+            }
+            if (!candidateIsBroad && currentBestIsBroad) {
+                strictlyMoreSpecific = true;
+                continue;
+            }
+            if (!candidateIsBroad && !currentBestIsBroad) {
+                strictlyMoreSpecific = true;
+            }
         }
         return strictlyMoreSpecific;
+    }
+
+    private boolean isBroadSpecificityType(CompiledType type) {
+        return !isResolvedTypeForInference(type);
     }
 
     private Set<String> methodOwnerCandidates(CompiledType receiverType) {

--- a/integration-tests/src/main/capybara/dev/capylang/test/Extension.cfun
+++ b/integration-tests/src/main/capybara/dev/capylang/test/Extension.cfun
@@ -37,3 +37,9 @@ fun weighted_labeled_point_score(point: WeightedLabeledPoint3D): float =
 fun weighted_labeled_point_label(point: WeightedLabeledPoint3D): string = point.label + ":" + point.tag
 
 fun overload_prefers_most_concrete(point: WeightedLabeledPoint3D): float = length(point)
+
+fun overload_any_vs_parent(point: Point): string = "point"
+
+fun overload_any_vs_parent(value: any): string = "any"
+
+fun overload_any_prefers_parent(point: Point3D): string = overload_any_vs_parent(point)

--- a/integration-tests/src/test/java/dev/capylang/test/ExtensionTest.java
+++ b/integration-tests/src/test/java/dev/capylang/test/ExtensionTest.java
@@ -59,6 +59,11 @@ class ExtensionTest {
     }
 
     @Test
+    void overloadPrefersParentOverAnyWhenCoercionsTie() {
+        assertThat(Extension.overloadAnyPrefersParent(new Extension.Point3D(3.0f, 4.0f, 5.0f))).isEqualTo("point");
+    }
+
+    @Test
     void createsMultiExtendedDataByNamedFields() {
         var result = Extension.newLabeledPoint(1.0f, 2.0f, "origin");
 


### PR DESCRIPTION
### Motivation
- Overload tie-breaking used `coerceArgument` which treats `any` and unresolved generic shapes as compatible, allowing broad signatures to win ties against concrete ones.
- The change makes overload resolution prefer concrete parameter types (parent/data types) over broad types (`any` / unresolved generics) when coercion counts are equal.

### Description
- Update `isSignatureMoreSpecific` in `CapybaraExpressionCompiler` to detect "broad" specificity types and avoid counting broad types as more specific than concrete ones, adding `isBroadSpecificityType` which uses `isResolvedTypeForInference`.
- Behavior: if candidate param is broad and current best is concrete the candidate is rejected; if candidate is concrete and current best is broad the candidate is considered strictly more specific.
- Add a regression snippet to `integration-tests/src/main/capybara/dev/capylang/test/Extension.cfun` introducing `overload_any_vs_parent` overloads (`Point` vs `any`) and a call-site `overload_any_prefers_parent` to exercise the tie.
- Add an integration assertion in `integration-tests/src/test/java/dev/capylang/test/ExtensionTest.java` that verifies the `Point` overload is selected instead of the `any` overload.

### Testing
- Ran the focused integration test: `./gradlew :integration-tests:test --tests dev.capylang.test.ExtensionTest`, which completed successfully (BUILD SUCCESSFUL).
- The updated `ExtensionTest` assertion verifying `overloadAnyPrefersParent` passed in the integration run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d75a2f08e88320a5d54b7457642879)