### PR TITLE
feat(#75): add DateTime.timestamp and Duration +/- support

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -7,12 +7,6 @@ fun _days_31_month(month: int): bool = month == JANUARY | month == MARCH | month
 /// Returns `true` when the month has 30 days.
 fun _days_30_month(month: int): bool = month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
 
-fun _days_in_month(year: int, month: int): int =
-    if month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
-    then 30
-    else if month == FEBRUARY
-        then if _leap_year(year) then 29 else 28
-        else 31
 
 const JANUARY: int = 1
 const FEBRUARY: int = 2
@@ -106,12 +100,18 @@ fun Date.add_years_months(years: int, months: int): Date =
         else -(((-a) + b - 1) / b)
     fun __floor_mod(a: int, b: int): int = a - __floor_div(a, b) * b
     fun __min(a: int, b: int): int = if a < b then a else b
+    fun __days_in_month(year: int, month: int): int =
+        if month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
+        then 30
+        else if month == FEBRUARY
+            then if _leap_year(year) then 29 else 28
+            else 31
     ---
     let total_months = (this.year + years) * 12 + (this.month + months - 1)
     let normalized_year = __floor_div(total_months, 12)
     let normalized_month = __floor_mod(total_months, 12) + 1
     Date! {
-        day: __min(this.day, _days_in_month(normalized_year, normalized_month)),
+        day: __min(this.day, __days_in_month(normalized_year, normalized_month)),
         month: normalized_month,
         year: normalized_year
     }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -7,6 +7,22 @@ fun _days_31_month(month: int): bool = month == JANUARY | month == MARCH | month
 /// Returns `true` when the month has 30 days.
 fun _days_30_month(month: int): bool = month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
 
+fun _floor_div(a: int, b: int): int =
+    if a >= 0
+    then a / b
+    else -(((-a) + b - 1) / b)
+
+fun _floor_mod(a: int, b: int): int = a - _floor_div(a, b) * b
+
+fun _days_in_month(year: int, month: int): int =
+    if month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
+    then 30
+    else if month == FEBRUARY
+        then if _leap_year(year) then 29 else 28
+        else 31
+
+fun _min(a: int, b: int): int = if a < b then a else b
+
 const JANUARY: int = 1
 const FEBRUARY: int = 2
 const MARCH: int = 3
@@ -53,3 +69,41 @@ fun Date.last_day_of_month(): Date =
     else if _days_31_month(this.month)
         then Date! { day: 31, month: this.month, year: this.year }
         else Date! { day: 30, month: this.month, year: this.year }
+
+/// Converts this date to days since Unix epoch (`1970-01-01`).
+fun Date.to_days_since_unix_epoch(): int =
+    let y = if this.month <= FEBRUARY then this.year - 1 else this.year
+    let era = _floor_div(y, 400)
+    let yoe = y - era * 400
+    let mp = if this.month > FEBRUARY then this.month - 3 else this.month + 9
+    let doy = _floor_div(153 * mp + 2, 5) + this.day - 1
+    let doe = yoe * 365 + _floor_div(yoe, 4) - _floor_div(yoe, 100) + doy
+    era * 146097 + doe - 719468
+
+/// Converts days since Unix epoch (`1970-01-01`) to `Date`.
+fun from_days_since_unix_epoch(days_since_epoch: int): Date =
+    let z = days_since_epoch + 719468
+    let era = _floor_div(z, 146097)
+    let doe = z - era * 146097
+    let yoe = _floor_div(doe - _floor_div(doe, 1460) + _floor_div(doe, 36524) - _floor_div(doe, 146096), 365)
+    let y = yoe + era * 400
+    let doy = doe - (365 * yoe + _floor_div(yoe, 4) - _floor_div(yoe, 100))
+    let mp = _floor_div(5 * doy + 2, 153)
+    let day = doy - _floor_div(153 * mp + 2, 5) + 1
+    let month = if mp < 10 then mp + 3 else mp - 9
+    let year = if month <= FEBRUARY then y + 1 else y
+    Date! { day, month, year }
+
+/// Adds days to this date.
+fun Date.add_days(days: int): Date = from_days_since_unix_epoch(this.to_days_since_unix_epoch() + days)
+
+/// Adds years and months to this date, clamping the day to target month length.
+fun Date.add_years_months(years: int, months: int): Date =
+    let total_months = (this.year + years) * 12 + (this.month + months - 1)
+    let normalized_year = _floor_div(total_months, 12)
+    let normalized_month = _floor_mod(total_months, 12) + 1
+    Date! {
+        day: _min(this.day, _days_in_month(normalized_year, normalized_month)),
+        month: normalized_month,
+        year: normalized_year
+    }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -7,21 +7,12 @@ fun _days_31_month(month: int): bool = month == JANUARY | month == MARCH | month
 /// Returns `true` when the month has 30 days.
 fun _days_30_month(month: int): bool = month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
 
-fun _floor_div(a: int, b: int): int =
-    if a >= 0
-    then a / b
-    else -(((-a) + b - 1) / b)
-
-fun _floor_mod(a: int, b: int): int = a - _floor_div(a, b) * b
-
 fun _days_in_month(year: int, month: int): int =
     if month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
     then 30
     else if month == FEBRUARY
         then if _leap_year(year) then 29 else 28
         else 31
-
-fun _min(a: int, b: int): int = if a < b then a else b
 
 const JANUARY: int = 1
 const FEBRUARY: int = 2
@@ -72,24 +63,34 @@ fun Date.last_day_of_month(): Date =
 
 /// Converts this date to days since Unix epoch (`1970-01-01`).
 fun Date.to_days_since_unix_epoch(): int =
+    fun __floor_div(a: int, b: int): int =
+        if a >= 0
+        then a / b
+        else -(((-a) + b - 1) / b)
+    ---
     let y = if this.month <= FEBRUARY then this.year - 1 else this.year
-    let era = _floor_div(y, 400)
+    let era = __floor_div(y, 400)
     let yoe = y - era * 400
     let mp = if this.month > FEBRUARY then this.month - 3 else this.month + 9
-    let doy = _floor_div(153 * mp + 2, 5) + this.day - 1
-    let doe = yoe * 365 + _floor_div(yoe, 4) - _floor_div(yoe, 100) + doy
+    let doy = __floor_div(153 * mp + 2, 5) + this.day - 1
+    let doe = yoe * 365 + __floor_div(yoe, 4) - __floor_div(yoe, 100) + doy
     era * 146097 + doe - 719468
 
 /// Converts days since Unix epoch (`1970-01-01`) to `Date`.
 fun from_days_since_unix_epoch(days_since_epoch: int): Date =
+    fun __floor_div(a: int, b: int): int =
+        if a >= 0
+        then a / b
+        else -(((-a) + b - 1) / b)
+    ---
     let z = days_since_epoch + 719468
-    let era = _floor_div(z, 146097)
+    let era = __floor_div(z, 146097)
     let doe = z - era * 146097
-    let yoe = _floor_div(doe - _floor_div(doe, 1460) + _floor_div(doe, 36524) - _floor_div(doe, 146096), 365)
+    let yoe = __floor_div(doe - __floor_div(doe, 1460) + __floor_div(doe, 36524) - __floor_div(doe, 146096), 365)
     let y = yoe + era * 400
-    let doy = doe - (365 * yoe + _floor_div(yoe, 4) - _floor_div(yoe, 100))
-    let mp = _floor_div(5 * doy + 2, 153)
-    let day = doy - _floor_div(153 * mp + 2, 5) + 1
+    let doy = doe - (365 * yoe + __floor_div(yoe, 4) - __floor_div(yoe, 100))
+    let mp = __floor_div(5 * doy + 2, 153)
+    let day = doy - __floor_div(153 * mp + 2, 5) + 1
     let month = if mp < 10 then mp + 3 else mp - 9
     let year = if month <= FEBRUARY then y + 1 else y
     Date! { day, month, year }
@@ -99,11 +100,18 @@ fun Date.add_days(days: int): Date = from_days_since_unix_epoch(this.to_days_sin
 
 /// Adds years and months to this date, clamping the day to target month length.
 fun Date.add_years_months(years: int, months: int): Date =
+    fun __floor_div(a: int, b: int): int =
+        if a >= 0
+        then a / b
+        else -(((-a) + b - 1) / b)
+    fun __floor_mod(a: int, b: int): int = a - __floor_div(a, b) * b
+    fun __min(a: int, b: int): int = if a < b then a else b
+    ---
     let total_months = (this.year + years) * 12 + (this.month + months - 1)
-    let normalized_year = _floor_div(total_months, 12)
-    let normalized_month = _floor_mod(total_months, 12) + 1
+    let normalized_year = __floor_div(total_months, 12)
+    let normalized_month = __floor_mod(total_months, 12) + 1
     Date! {
-        day: _min(this.day, _days_in_month(normalized_year, normalized_month)),
+        day: __min(this.day, _days_in_month(normalized_year, normalized_month)),
         month: normalized_month,
         year: normalized_year
     }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -1,4 +1,5 @@
 from /capy/lang/Result import {*}
+from /capy/lang/Math import { * }
 
 /// Checks whether a year is a leap year in the Gregorian calendar.
 fun _leap_year(year: int): bool = (year % 4 == 0 & year % 100 != 0) | year % 400 == 0
@@ -66,9 +67,7 @@ fun Date.last_day_of_month(): Date =
 /// Converts this date to days since Unix epoch (`1970-01-01`).
 fun Date.to_days_since_unix_epoch(): int =
     fun __floor_div(a: int, b: int): int =
-        if a >= 0
-        then a / b
-        else -(((-a) + b - 1) / b)
+        floor_div(a, b)
     ---
     let y = if this.month <= FEBRUARY then this.year - 1 else this.year
     let era = __floor_div(y, 400)
@@ -81,9 +80,7 @@ fun Date.to_days_since_unix_epoch(): int =
 /// Converts days since Unix epoch (`1970-01-01`) to `Date`.
 fun from_days_since_unix_epoch(days_since_epoch: int): Date =
     fun __floor_div(a: int, b: int): int =
-        if a >= 0
-        then a / b
-        else -(((-a) + b - 1) / b)
+        floor_div(a, b)
     ---
     let z = days_since_epoch + __UNIX_EPOCH_CIVIL_OFFSET_DAYS
     let era = __floor_div(z, __DAYS_PER_400_YEARS)
@@ -103,9 +100,7 @@ fun Date.add_days(days: int): Date = from_days_since_unix_epoch(this.to_days_sin
 /// Adds years and months to this date, clamping the day to target month length.
 fun Date.add_years_months(years: int, months: int): Date =
     fun __floor_div(a: int, b: int): int =
-        if a >= 0
-        then a / b
-        else -(((-a) + b - 1) / b)
+        floor_div(a, b)
     fun __floor_mod(a: int, b: int): int = a - __floor_div(a, b) * b
     fun __min(a: int, b: int): int = if a < b then a else b
     fun __days_in_month(year: int, month: int): int =

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -7,7 +7,6 @@ fun _days_31_month(month: int): bool = month == JANUARY | month == MARCH | month
 /// Returns `true` when the month has 30 days.
 fun _days_30_month(month: int): bool = month == APRIL | month == JUNE | month == SEPTEMBER | month == NOVEMBER
 
-
 const JANUARY: int = 1
 const FEBRUARY: int = 2
 const MARCH: int = 3
@@ -20,6 +19,15 @@ const SEPTEMBER: int = 9
 const OCTOBER: int = 10
 const NOVEMBER: int = 11
 const DECEMBER: int = 12
+
+const __DAYS_PER_400_YEARS: int = 146097
+const __DAYS_PER_YEAR: int = 365
+const __UNIX_EPOCH_CIVIL_OFFSET_DAYS: int = 719468
+const __DAYS_PER_4_YEARS_MINUS_1: int = 1460
+const __DAYS_PER_100_YEARS_MINUS_1: int = 36524
+const __DAYS_PER_400_YEARS_MINUS_1: int = 146096
+const __MONTH_TO_DAY_NUMERATOR: int = 153
+const __MONTH_TO_DAY_BIAS: int = 2
 
 /// Calendar date represented by day, month and year.
 ///
@@ -66,9 +74,9 @@ fun Date.to_days_since_unix_epoch(): int =
     let era = __floor_div(y, 400)
     let yoe = y - era * 400
     let mp = if this.month > FEBRUARY then this.month - 3 else this.month + 9
-    let doy = __floor_div(153 * mp + 2, 5) + this.day - 1
-    let doe = yoe * 365 + __floor_div(yoe, 4) - __floor_div(yoe, 100) + doy
-    era * 146097 + doe - 719468
+    let doy = __floor_div(__MONTH_TO_DAY_NUMERATOR * mp + __MONTH_TO_DAY_BIAS, 5) + this.day - 1
+    let doe = yoe * __DAYS_PER_YEAR + __floor_div(yoe, 4) - __floor_div(yoe, 100) + doy
+    era * __DAYS_PER_400_YEARS + doe - __UNIX_EPOCH_CIVIL_OFFSET_DAYS
 
 /// Converts days since Unix epoch (`1970-01-01`) to `Date`.
 fun from_days_since_unix_epoch(days_since_epoch: int): Date =
@@ -77,14 +85,14 @@ fun from_days_since_unix_epoch(days_since_epoch: int): Date =
         then a / b
         else -(((-a) + b - 1) / b)
     ---
-    let z = days_since_epoch + 719468
-    let era = __floor_div(z, 146097)
-    let doe = z - era * 146097
-    let yoe = __floor_div(doe - __floor_div(doe, 1460) + __floor_div(doe, 36524) - __floor_div(doe, 146096), 365)
+    let z = days_since_epoch + __UNIX_EPOCH_CIVIL_OFFSET_DAYS
+    let era = __floor_div(z, __DAYS_PER_400_YEARS)
+    let doe = z - era * __DAYS_PER_400_YEARS
+    let yoe = __floor_div(doe - __floor_div(doe, __DAYS_PER_4_YEARS_MINUS_1) + __floor_div(doe, __DAYS_PER_100_YEARS_MINUS_1) - __floor_div(doe, __DAYS_PER_400_YEARS_MINUS_1), __DAYS_PER_YEAR)
     let y = yoe + era * 400
-    let doy = doe - (365 * yoe + __floor_div(yoe, 4) - __floor_div(yoe, 100))
-    let mp = __floor_div(5 * doy + 2, 153)
-    let day = doy - __floor_div(153 * mp + 2, 5) + 1
+    let doy = doe - (__DAYS_PER_YEAR * yoe + __floor_div(yoe, 4) - __floor_div(yoe, 100))
+    let mp = __floor_div(5 * doy + __MONTH_TO_DAY_BIAS, __MONTH_TO_DAY_NUMERATOR)
+    let day = doy - __floor_div(__MONTH_TO_DAY_NUMERATOR * mp + __MONTH_TO_DAY_BIAS, 5) + 1
     let month = if mp < 10 then mp + 3 else mp - 9
     let year = if month <= FEBRUARY then y + 1 else y
     Date! { day, month, year }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -20,31 +20,67 @@ fun DateTime.timestamp(): long =
 /// Adds a `Duration` to this `DateTime`.
 fun DateTime.plus(duration: Duration): DateTime =
     const __seconds_in_day: int = __SECONDS_IN_DAY_INT
-    fun __floor_div(a: int, b: int): int =
-        floor_div(a, b)
+    const __minutes_in_day: int = 24 * 60
+    fun __floor_div(a: int, b: int): int = floor_div(a, b)
+    fun __floor_mod(a: int, b: int): int = floor_mod(a, b)
     ---
     let date_with_months = this.date.add_years_months(duration.years(), duration.months())
-    let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
-    let total_seconds = this.time.to_seconds() + delta_seconds
-    let day_carry = __floor_div(total_seconds, __seconds_in_day)
+
+    let days_from_hours = __floor_div(duration.hours(), 24)
+    let days_from_minutes = __floor_div(duration.minutes(), __minutes_in_day)
+    let days_from_seconds = __floor_div(duration.seconds(), __seconds_in_day)
+
+    let remainder_hours = __floor_mod(duration.hours(), 24)
+    let remainder_minutes = __floor_mod(duration.minutes(), __minutes_in_day)
+    let remainder_seconds = __floor_mod(duration.seconds(), __seconds_in_day)
+
+    let intra_day_seconds = remainder_hours * 3600 + remainder_minutes * 60 + remainder_seconds
+    let total_seconds = this.time.to_seconds() + intra_day_seconds
+    let day_carry_from_clock = __floor_div(total_seconds, __seconds_in_day)
+
+    let normalized_day_delta =
+        duration.days()
+        + days_from_hours
+        + days_from_minutes
+        + days_from_seconds
+        + day_carry_from_clock
+
     DateTime {
-        date: date_with_months.add_days(duration.days() + day_carry),
-        time: this.time.add_seconds(delta_seconds)
+        date: date_with_months.add_days(normalized_day_delta),
+        time: this.time.add_seconds(intra_day_seconds)
     }
 
 /// Adds a `Duration` to this `DateTime` using `+` infix syntax.
 fun DateTime.`+`(duration: Duration): DateTime =
     const __seconds_in_day: int = __SECONDS_IN_DAY_INT
-    fun __floor_div(a: int, b: int): int =
-        floor_div(a, b)
+    const __minutes_in_day: int = 24 * 60
+    fun __floor_div(a: int, b: int): int = floor_div(a, b)
+    fun __floor_mod(a: int, b: int): int = floor_mod(a, b)
     ---
     let date_with_months = this.date.add_years_months(duration.years(), duration.months())
-    let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
-    let total_seconds = this.time.to_seconds() + delta_seconds
-    let day_carry = __floor_div(total_seconds, __seconds_in_day)
+
+    let days_from_hours = __floor_div(duration.hours(), 24)
+    let days_from_minutes = __floor_div(duration.minutes(), __minutes_in_day)
+    let days_from_seconds = __floor_div(duration.seconds(), __seconds_in_day)
+
+    let remainder_hours = __floor_mod(duration.hours(), 24)
+    let remainder_minutes = __floor_mod(duration.minutes(), __minutes_in_day)
+    let remainder_seconds = __floor_mod(duration.seconds(), __seconds_in_day)
+
+    let intra_day_seconds = remainder_hours * 3600 + remainder_minutes * 60 + remainder_seconds
+    let total_seconds = this.time.to_seconds() + intra_day_seconds
+    let day_carry_from_clock = __floor_div(total_seconds, __seconds_in_day)
+
+    let normalized_day_delta =
+        duration.days()
+        + days_from_hours
+        + days_from_minutes
+        + days_from_seconds
+        + day_carry_from_clock
+
     DateTime {
-        date: date_with_months.add_days(duration.days() + day_carry),
-        time: this.time.add_seconds(delta_seconds)
+        date: date_with_months.add_days(normalized_day_delta),
+        time: this.time.add_seconds(intra_day_seconds)
     }
 
 /// Subtracts a `Duration` from this `DateTime`.

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -1,6 +1,7 @@
 from /capy/date_time/Date import { * }
 from /capy/date_time/Time import { * }
 from /capy/date_time/Duration import { * }
+from /capy/lang/Math import { * }
 
 /// Combination of a calendar date and time of day.
 data DateTime { date: Date, time: Time }
@@ -20,9 +21,7 @@ fun DateTime.timestamp(): long =
 fun DateTime.plus(duration: Duration): DateTime =
     const __seconds_in_day: int = __SECONDS_IN_DAY_INT
     fun __floor_div(a: int, b: int): int =
-        if a >= 0
-        then a / b
-        else -(((-a) + b - 1) / b)
+        floor_div(a, b)
     ---
     let date_with_months = this.date.add_years_months(duration.years(), duration.months())
     let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
@@ -37,9 +36,7 @@ fun DateTime.plus(duration: Duration): DateTime =
 fun DateTime.`+`(duration: Duration): DateTime =
     const __seconds_in_day: int = __SECONDS_IN_DAY_INT
     fun __floor_div(a: int, b: int): int =
-        if a >= 0
-        then a / b
-        else -(((-a) + b - 1) / b)
+        floor_div(a, b)
     ---
     let date_with_months = this.date.add_years_months(duration.years(), duration.months())
     let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -14,6 +14,20 @@ fun _floor_div(a: int, b: int): int =
     then a / b
     else -(((-a) + b - 1) / b)
 
+
+fun _compare(left: DateTime, right: DateTime): int =
+    let left_days = left.date.to_days_since_unix_epoch()
+    let right_days = right.date.to_days_since_unix_epoch()
+    if left_days > right_days
+    then 1
+    else if left_days < right_days
+        then -1
+        else if left.time.to_seconds() > right.time.to_seconds()
+            then 1
+            else if left.time.to_seconds() < right.time.to_seconds()
+                then -1
+                else 0
+
 fun _plus_datetime(datetime: DateTime, duration: Duration): DateTime =
     const __seconds_in_day: int = 24 * 3600
     ---
@@ -44,3 +58,22 @@ fun DateTime.minus(duration: Duration): DateTime = _minus_datetime(this, duratio
 
 /// Subtracts a `Duration` from this `DateTime` using `-` infix syntax.
 fun DateTime.`-`(duration: Duration): DateTime = _minus_datetime(this, duration)
+
+
+/// Returns `true` when this date-time is after `other`.
+fun DateTime.greater_than(other: DateTime): bool = _compare(this, other) > 0
+
+/// Returns `true` when this date-time is before `other`.
+fun DateTime.less_than(other: DateTime): bool = _compare(this, other) < 0
+
+/// Comparison function used by `>`.
+fun DateTime.greater(other: DateTime): bool = this.greater_than(other)
+
+/// Comparison function used by `<`.
+fun DateTime.less(other: DateTime): bool = this.less_than(other)
+
+/// Returns `true` when this date-time is before `other`.
+fun DateTime.`<`(other: DateTime): bool = this.less_than(other)
+
+/// Returns `true` when this date-time is after `other`.
+fun DateTime.`>`(other: DateTime): bool = this.greater_than(other)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -9,13 +9,16 @@ data DateTime { date: Date, time: Time }
 fun unix_epoch(): DateTime =
     DateTime { date: UNIX_DATE, time: MIDNIGHT }
 
+const __SECONDS_IN_DAY_INT: int = 24 * 3600
+const __SECONDS_IN_DAY_LONG: long = 86400L
+
 /// Returns Unix timestamp (seconds since `1970-01-01T00:00:00Z`).
 fun DateTime.timestamp(): long =
-    this.date.to_days_since_unix_epoch() * 86400L + this.time.to_seconds()
+    this.date.to_days_since_unix_epoch() * __SECONDS_IN_DAY_LONG + this.time.to_seconds()
 
 /// Adds a `Duration` to this `DateTime`.
 fun DateTime.plus(duration: Duration): DateTime =
-    const __seconds_in_day: int = 24 * 3600
+    const __seconds_in_day: int = __SECONDS_IN_DAY_INT
     fun __floor_div(a: int, b: int): int =
         if a >= 0
         then a / b
@@ -32,7 +35,7 @@ fun DateTime.plus(duration: Duration): DateTime =
 
 /// Adds a `Duration` to this `DateTime` using `+` infix syntax.
 fun DateTime.`+`(duration: Duration): DateTime =
-    const __seconds_in_day: int = 24 * 3600
+    const __seconds_in_day: int = __SECONDS_IN_DAY_INT
     fun __floor_div(a: int, b: int): int =
         if a >= 0
         then a / b

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -9,62 +9,65 @@ data DateTime { date: Date, time: Time }
 fun unix_epoch(): DateTime =
     DateTime { date: UNIX_DATE, time: MIDNIGHT }
 
-fun _floor_div(a: int, b: int): int =
-    if a >= 0
-    then a / b
-    else -(((-a) + b - 1) / b)
-
-
-fun _compare(left: DateTime, right: DateTime): int =
-    let left_days = left.date.to_days_since_unix_epoch()
-    let right_days = right.date.to_days_since_unix_epoch()
-    if left_days > right_days
-    then 1
-    else if left_days < right_days
-        then -1
-        else if left.time.to_seconds() > right.time.to_seconds()
-            then 1
-            else if left.time.to_seconds() < right.time.to_seconds()
-                then -1
-                else 0
-
-fun _plus_datetime(datetime: DateTime, duration: Duration): DateTime =
-    const __seconds_in_day: int = 24 * 3600
-    ---
-    let date_with_months = datetime.date.add_years_months(duration.years(), duration.months())
-    let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
-    let total_seconds = datetime.time.to_seconds() + delta_seconds
-    let day_carry = _floor_div(total_seconds, __seconds_in_day)
-    DateTime {
-        date: date_with_months.add_days(duration.days() + day_carry),
-        time: datetime.time.add_seconds(delta_seconds)
-    }
-
-fun _minus_datetime(datetime: DateTime, duration: Duration): DateTime =
-    _plus_datetime(datetime, duration.negate())
-
 /// Returns Unix timestamp (seconds since `1970-01-01T00:00:00Z`).
-fun DateTime.timestamp(): int =
-    this.date.to_days_since_unix_epoch() * 86400 + this.time.to_seconds()
+fun DateTime.timestamp(): long =
+    this.date.to_days_since_unix_epoch() * 86400L + this.time.to_seconds()
 
 /// Adds a `Duration` to this `DateTime`.
-fun DateTime.plus(duration: Duration): DateTime = _plus_datetime(this, duration)
+fun DateTime.plus(duration: Duration): DateTime =
+    const __seconds_in_day: int = 24 * 3600
+    fun __floor_div(a: int, b: int): int =
+        if a >= 0
+        then a / b
+        else -(((-a) + b - 1) / b)
+    ---
+    let date_with_months = this.date.add_years_months(duration.years(), duration.months())
+    let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
+    let total_seconds = this.time.to_seconds() + delta_seconds
+    let day_carry = __floor_div(total_seconds, __seconds_in_day)
+    DateTime {
+        date: date_with_months.add_days(duration.days() + day_carry),
+        time: this.time.add_seconds(delta_seconds)
+    }
 
 /// Adds a `Duration` to this `DateTime` using `+` infix syntax.
-fun DateTime.`+`(duration: Duration): DateTime = _plus_datetime(this, duration)
+fun DateTime.`+`(duration: Duration): DateTime =
+    const __seconds_in_day: int = 24 * 3600
+    fun __floor_div(a: int, b: int): int =
+        if a >= 0
+        then a / b
+        else -(((-a) + b - 1) / b)
+    ---
+    let date_with_months = this.date.add_years_months(duration.years(), duration.months())
+    let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
+    let total_seconds = this.time.to_seconds() + delta_seconds
+    let day_carry = __floor_div(total_seconds, __seconds_in_day)
+    DateTime {
+        date: date_with_months.add_days(duration.days() + day_carry),
+        time: this.time.add_seconds(delta_seconds)
+    }
 
 /// Subtracts a `Duration` from this `DateTime`.
-fun DateTime.minus(duration: Duration): DateTime = _minus_datetime(this, duration)
+fun DateTime.minus(duration: Duration): DateTime = this.plus(duration.negate())
 
 /// Subtracts a `Duration` from this `DateTime` using `-` infix syntax.
-fun DateTime.`-`(duration: Duration): DateTime = _minus_datetime(this, duration)
-
+fun DateTime.`-`(duration: Duration): DateTime = this.plus(duration.negate())
 
 /// Returns `true` when this date-time is after `other`.
-fun DateTime.greater_than(other: DateTime): bool = _compare(this, other) > 0
+fun DateTime.greater_than(other: DateTime): bool =
+    if this.date.to_days_since_unix_epoch() > other.date.to_days_since_unix_epoch()
+    then true
+    else if this.date.to_days_since_unix_epoch() < other.date.to_days_since_unix_epoch()
+        then false
+        else this.time.to_seconds() > other.time.to_seconds()
 
 /// Returns `true` when this date-time is before `other`.
-fun DateTime.less_than(other: DateTime): bool = _compare(this, other) < 0
+fun DateTime.less_than(other: DateTime): bool =
+    if this.date.to_days_since_unix_epoch() < other.date.to_days_since_unix_epoch()
+    then true
+    else if this.date.to_days_since_unix_epoch() > other.date.to_days_since_unix_epoch()
+        then false
+        else this.time.to_seconds() < other.time.to_seconds()
 
 /// Comparison function used by `>`.
 fun DateTime.greater(other: DateTime): bool = this.greater_than(other)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -1,5 +1,6 @@
 from /capy/date_time/Date import { * }
 from /capy/date_time/Time import { * }
+from /capy/date_time/Duration import { * }
 
 /// Combination of a calendar date and time of day.
 data DateTime { date: Date, time: Time }
@@ -8,11 +9,38 @@ data DateTime { date: Date, time: Time }
 fun unix_epoch(): DateTime =
     DateTime { date: UNIX_DATE, time: MIDNIGHT }
 
-/*
-fun DateTime.timestamp(): int =
+fun _floor_div(a: int, b: int): int =
+    if a >= 0
+    then a / b
+    else -(((-a) + b - 1) / b)
+
+fun _plus_datetime(datetime: DateTime, duration: Duration): DateTime =
     const __seconds_in_day: int = 24 * 3600
     ---
-    let days_since_epoch = this.date.to_days() - unix_epoch() | dt => dt.date.to_days()
-    let seconds_since_midnight = this.time.to_seconds()
-    days_since_epoch * __seconds_in_day + seconds_since_midnight
-*/
+    let date_with_months = datetime.date.add_years_months(duration.years(), duration.months())
+    let delta_seconds = duration.hours() * 3600 + duration.minutes() * 60 + duration.seconds()
+    let total_seconds = datetime.time.to_seconds() + delta_seconds
+    let day_carry = _floor_div(total_seconds, __seconds_in_day)
+    DateTime {
+        date: date_with_months.add_days(duration.days() + day_carry),
+        time: datetime.time.add_seconds(delta_seconds)
+    }
+
+fun _minus_datetime(datetime: DateTime, duration: Duration): DateTime =
+    _plus_datetime(datetime, duration.negate())
+
+/// Returns Unix timestamp (seconds since `1970-01-01T00:00:00Z`).
+fun DateTime.timestamp(): int =
+    this.date.to_days_since_unix_epoch() * 86400 + this.time.to_seconds()
+
+/// Adds a `Duration` to this `DateTime`.
+fun DateTime.plus(duration: Duration): DateTime = _plus_datetime(this, duration)
+
+/// Adds a `Duration` to this `DateTime` using `+` infix syntax.
+fun DateTime.`+`(duration: Duration): DateTime = _plus_datetime(this, duration)
+
+/// Subtracts a `Duration` from this `DateTime`.
+fun DateTime.minus(duration: Duration): DateTime = _minus_datetime(this, duration)
+
+/// Subtracts a `Duration` from this `DateTime` using `-` infix syntax.
+fun DateTime.`-`(duration: Duration): DateTime = _minus_datetime(this, duration)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -349,3 +349,54 @@ fun from_iso_8601(iso: string): Result[Duration] =
             has_time_component: false
         })
     }
+
+
+/// Returns this duration with all components negated.
+fun Duration.negate(): Duration =
+    match this with
+    case WeekDuration { weeks } -> WeekDuration { weeks: 0 - weeks }
+    case DateDuration { years, months, days, hours, minutes, seconds } ->
+        DateDuration {
+            years: 0 - years,
+            months: 0 - months,
+            days: 0 - days,
+            hours: 0 - hours,
+            minutes: 0 - minutes,
+            seconds: 0 - seconds
+        }
+
+/// Returns year component (`0` for week durations).
+fun Duration.years(): int =
+    match this with
+    case WeekDuration -> 0
+    case DateDuration { years, _, _, _, _, _ } -> years
+
+/// Returns month component (`0` for week durations).
+fun Duration.months(): int =
+    match this with
+    case WeekDuration -> 0
+    case DateDuration { _, months, _, _, _, _ } -> months
+
+/// Returns day component (`weeks * 7` for week durations).
+fun Duration.days(): int =
+    match this with
+    case WeekDuration { weeks } -> weeks * 7
+    case DateDuration { _, _, days, _, _, _ } -> days
+
+/// Returns hour component (`0` for week durations).
+fun Duration.hours(): int =
+    match this with
+    case WeekDuration -> 0
+    case DateDuration { _, _, _, hours, _, _ } -> hours
+
+/// Returns minute component (`0` for week durations).
+fun Duration.minutes(): int =
+    match this with
+    case WeekDuration -> 0
+    case DateDuration { _, _, _, _, minutes, _ } -> minutes
+
+/// Returns second component (`0` for week durations).
+fun Duration.seconds(): int =
+    match this with
+    case WeekDuration -> 0
+    case DateDuration { _, _, _, _, _, seconds } -> seconds

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -12,3 +12,16 @@ fun digits(number: int): int =
 fun abs(number: long): long = if number < 0 then -number else number
 
 fun abs(number: int): int = if number < 0 then -number else number
+
+/// Floor division for integers.
+///
+/// Unlike `/`, this always rounds toward negative infinity.
+fun floor_div(a: int, b: int): int =
+    if a >= 0
+    then a / b
+    else -(((-a) + b - 1) / b)
+
+/// Floor modulo for integers.
+///
+/// Result is always in `[0, b)` when `b > 0`.
+fun floor_mod(a: int, b: int): int = a - floor_div(a, b) * b

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -16,12 +16,18 @@ fun abs(number: int): int = if number < 0 then -number else number
 /// Floor division for integers.
 ///
 /// Unlike `/`, this always rounds toward negative infinity.
+/// `b` must be non-zero.
 fun floor_div(a: int, b: int): int =
-    if a >= 0
-    then a / b
-    else -(((-a) + b - 1) / b)
+    let q = a / b
+    let r = a % b
+    if r == 0
+    then q
+    else if (r > 0 & b < 0) | (r < 0 & b > 0)
+        then q - 1
+        else q
 
 /// Floor modulo for integers.
 ///
-/// Result is always in `[0, b)` when `b > 0`.
+/// Result has the same sign as divisor `b` (or is zero).
+/// `b` must be non-zero.
 fun floor_mod(a: int, b: int): int = a - floor_div(a, b) * b

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
@@ -18,7 +18,8 @@ fun tests(): TestFile =
         [_test_unix_epoch()]
         + _test_timestamp()
         + _test_plus()
-        + _test_minus())
+        + _test_minus()
+        + _test_comparisons())
 
 fun _test_unix_epoch(): TestCase =
     test("unix_epoch() should return the correct DateTime for 1 January 1970 at 00:00:00",
@@ -75,3 +76,31 @@ fun _test_minus(): list[TestCase] =
                 assert_that(actual.date).is_equal_to(expected.date),
                 assert_that(actual.time).is_equal_to(expected.time),
             ]))
+
+
+fun _test_comparisons(): list[TestCase] =
+    let first = _at(0, 0)
+    let second = _at(0, 1)
+    let third = _at(1, 0)
+    [
+        test("greater_than should return true when this DateTime is later",
+            assert_all([
+                assert_that(second.greater_than(first)).is_equal_to(true),
+                assert_that(first.greater_than(second)).is_equal_to(false),
+            ])),
+        test("less_than should return true when this DateTime is earlier",
+            assert_all([
+                assert_that(first.less_than(second)).is_equal_to(true),
+                assert_that(second.less_than(first)).is_equal_to(false),
+            ])),
+        test("operator > should compare DateTime values",
+            assert_all([
+                assert_that(second > first).is_equal_to(true),
+                assert_that(first > second).is_equal_to(false),
+            ])),
+        test("operator < should compare DateTime values",
+            assert_all([
+                assert_that(second < third).is_equal_to(true),
+                assert_that(third < second).is_equal_to(false),
+            ])),
+    ]

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
@@ -35,13 +35,13 @@ fun _test_unix_epoch(): TestCase =
 
 fun _test_timestamp(): list[TestCase] =
     [
-        (_at(0, 0), 0),
-        (_at(1, 0), 86400),
-        (_at(0, 3600), 3600),
-        (_at(0, 60), 60),
-        (_at(0, 1), 1),
-        (_at(-1, 86399), -1),
-        (_at(1, 3600), 90000),
+        (_at(0, 0), 0L),
+        (_at(1, 0), 86400L),
+        (_at(0, 3600), 3600L),
+        (_at(0, 60), 60L),
+        (_at(0, 1), 1L),
+        (_at(-1, 86399), -1L),
+        (_at(1, 3600), 90000L),
     ] | (datetime, expected) => test(
         "{datetime}.timestamp() should return the correct Unix timestamp",
         assert_that(datetime.timestamp()).is_equal_to(expected))
@@ -85,22 +85,22 @@ fun _test_comparisons(): list[TestCase] =
     [
         test("greater_than should return true when this DateTime is later",
             assert_all([
-                assert_that(second.greater_than(first)).is_equal_to(true),
-                assert_that(first.greater_than(second)).is_equal_to(false),
+                assert_that(second.greater_than(first)).is_true(),
+                assert_that(first.greater_than(second)).is_false(),
             ])),
         test("less_than should return true when this DateTime is earlier",
             assert_all([
-                assert_that(first.less_than(second)).is_equal_to(true),
-                assert_that(second.less_than(first)).is_equal_to(false),
+                assert_that(first.less_than(second)).is_true(),
+                assert_that(second.less_than(first)).is_false(),
             ])),
         test("operator > should compare DateTime values",
             assert_all([
-                assert_that(second > first).is_equal_to(true),
-                assert_that(first > second).is_equal_to(false),
+                assert_that(second > first).is_true(),
+                assert_that(first > second).is_false(),
             ])),
         test("operator < should compare DateTime values",
             assert_all([
-                assert_that(second < third).is_equal_to(true),
-                assert_that(third < second).is_equal_to(false),
+                assert_that(second < third).is_true(),
+                assert_that(third < second).is_false(),
             ])),
     ]

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
@@ -55,6 +55,7 @@ fun _test_plus(): list[TestCase] =
         ("plus with date duration and carry", base.plus(DateDuration { years: 0, months: 0, days: 1, hours: 1, minutes: 30, seconds: 0 }), _at(1, 5400)),
         ("plus should clamp month day", DateTime { date: jan_31_2024, time: MIDNIGHT }.plus(DateDuration { years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0 }), DateTime { date: jan_31_2024.add_years_months(0, 1), time: MIDNIGHT }),
         ("operator + should delegate to plus", base + DateDuration { years: 0, months: 0, days: 0, hours: 25, minutes: 0, seconds: 0 }, _at(1, 3600)),
+        ("plus should handle very large hour component without overflow", base.plus(DateDuration { years: 0, months: 0, days: 0, hours: 600000, minutes: 0, seconds: 0 }), _at(25000, 0)),
     ] | (name, actual, expected) =>
         test(name,
             assert_all([

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
@@ -1,14 +1,24 @@
 from /capy/date_time/DateTime import { * }
 from /capy/date_time/Time import { * }
 from /capy/date_time/Date import { * }
+from /capy/date_time/Duration import { * }
 from /capy/test/Assert import { * }
-from /capy/lang/Math import { * }
 from /capy/test/CapyTest import { * }
 
+fun _at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
+    let epoch_date = UNIX_DATE
+    let midnight = MIDNIGHT
+    DateTime {
+        date: epoch_date.add_days(days_since_epoch),
+        time: midnight.add_seconds(seconds_since_midnight)
+    }
+
 fun tests(): TestFile =
-    test_file('/capy/date_time/Time.cfun',
-        [_test_unix_epoch()
-        /*, _test_timestamp()*/])
+    test_file('/capy/date_time/DateTime.cfun',
+        [_test_unix_epoch()]
+        + _test_timestamp()
+        + _test_plus()
+        + _test_minus())
 
 fun _test_unix_epoch(): TestCase =
     test("unix_epoch() should return the correct DateTime for 1 January 1970 at 00:00:00",
@@ -22,16 +32,46 @@ fun _test_unix_epoch(): TestCase =
             assert_that(epoch.time.second).is_equal_to(0),
         ]))
 
-/*
 fun _test_timestamp(): list[TestCase] =
     [
-        (DateTime { date: Date { year: 1970, month: 1, day: 1 }, time: Time { hour: 0, minute: 0, second: 0 } }, 0),
-        (DateTime { date: Date { year: 1970, month: 1, day: 2 }, time: Time { hour: 0, minute: 0, second: 0 } }, 86400),
-        (DateTime { date: Date { year: 1970, month: 1, day: 1 }, time: Time { hour: 1, minute: 0, second: 0 } }, 3600),
-        (DateTime { date: Date { year: 1970, month: 1, day: 1 }, time: Time { hour: 0, minute: 1, second: 0 } }, 60),
-        (DateTime { date: Date { year: 1970, month: 1, day: 1 }, time: Time { hour: 0, minute: 0, second: 1 } }, 1),
-        (DateTime { date: Date { year: 1970, month: 1, day: 2 }, time: Time { hour: 1, minute: 0, second: 0 } }, 90000),
+        (_at(0, 0), 0),
+        (_at(1, 0), 86400),
+        (_at(0, 3600), 3600),
+        (_at(0, 60), 60),
+        (_at(0, 1), 1),
+        (_at(-1, 86399), -1),
+        (_at(1, 3600), 90000),
     ] | (datetime, expected) => test(
         "{datetime}.timestamp() should return the correct Unix timestamp",
-        assert_that(datetime | dt => Success { dt.timestamp() }).succeeds(expected))
-*/
+        assert_that(datetime.timestamp()).is_equal_to(expected))
+
+fun _test_plus(): list[TestCase] =
+    let base = _at(0, 0)
+    let epoch_date = UNIX_DATE
+    let jan_31_2024 = epoch_date.add_years_months(54, 0).add_days(30)
+    [
+        ("plus with week duration", base.plus(WeekDuration { weeks: 2 }), _at(14, 0)),
+        ("plus with date duration and carry", base.plus(DateDuration { years: 0, months: 0, days: 1, hours: 1, minutes: 30, seconds: 0 }), _at(1, 5400)),
+        ("plus should clamp month day", DateTime { date: jan_31_2024, time: MIDNIGHT }.plus(DateDuration { years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0 }), DateTime { date: jan_31_2024.add_years_months(0, 1), time: MIDNIGHT }),
+        ("operator + should delegate to plus", base + DateDuration { years: 0, months: 0, days: 0, hours: 25, minutes: 0, seconds: 0 }, _at(1, 3600)),
+    ] | (name, actual, expected) =>
+        test(name,
+            assert_all([
+                assert_that(actual.date).is_equal_to(expected.date),
+                assert_that(actual.time).is_equal_to(expected.time),
+            ]))
+
+fun _test_minus(): list[TestCase] =
+    let base = _at(1, 0)
+    let epoch_date = UNIX_DATE
+    let mar_31_2024 = epoch_date.add_years_months(54, 2).add_days(30)
+    [
+        ("minus with week duration", base.minus(WeekDuration { weeks: 1 }), _at(-6, 0)),
+        ("minus with date duration and borrow", base.minus(DateDuration { years: 0, months: 0, days: 0, hours: 1, minutes: 0, seconds: 1 }), _at(0, 82799)),
+        ("operator - should delegate to minus", DateTime { date: mar_31_2024, time: MIDNIGHT } - DateDuration { years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0 }, DateTime { date: mar_31_2024.add_years_months(0, -1), time: MIDNIGHT }),
+    ] | (name, actual, expected) =>
+        test(name,
+            assert_all([
+                assert_that(actual.date).is_equal_to(expected.date),
+                assert_that(actual.time).is_equal_to(expected.time),
+            ]))

--- a/lib/capybara-lib/src/test/capybara/capy/lang/MathTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/MathTest.cfun
@@ -31,6 +31,10 @@ fun tests(): TestFile =
         (-1, 3, -1),
         (-7, 3, -3),
         (-10, 3, -4),
+        (1, -3, -1),
+        (7, -3, -3),
+        (-1, -3, 0),
+        (-7, -3, 2),
     ] | (a, b, expected) =>
         test("floor_div(" + a + ", " + b + ") should return " + expected, _test_floor_div(a, b, expected))
 
@@ -40,6 +44,10 @@ fun tests(): TestFile =
         (-1, 3, 2),
         (-7, 3, 2),
         (-10, 3, 2),
+        (1, -3, -2),
+        (7, -3, -2),
+        (-1, -3, -1),
+        (-7, -3, -1),
     ] | (a, b, expected) =>
         test("floor_mod(" + a + ", " + b + ") should return " + expected, _test_floor_mod(a, b, expected))
 

--- a/lib/capybara-lib/src/test/capybara/capy/lang/MathTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/MathTest.cfun
@@ -1,10 +1,9 @@
 from /capy/test/Assert import { * }
 from /capy/lang/Math import { * }
-from /capy/lang/Result import { * }
 from /capy/test/CapyTest import { * }
 
 fun tests(): TestFile =
-    let test_cases = [
+    let digits_test_cases = [
         (0, 1),
         (1, 1),
         (9, 1),
@@ -22,9 +21,34 @@ fun tests(): TestFile =
         (-100, 3),
         (-999, 3),
         // min int value
-        (-2147483648, 10),]
-        | (number, expected) =>
-              test("digits(" + number + ") should return " + expected, _test_digits(number, expected))
-    test_file("/capy/lang/Math.cfun", test_cases)
+        (-2147483648, 10),
+    ] | (number, expected) =>
+        test("digits(" + number + ") should return " + expected, _test_digits(number, expected))
 
-fun _test_digits(number: int, expected: int): Assert = assert_that(digits(number) == expected).is_equal_to(true)
+    let floor_div_cases = [
+        (7, 3, 2),
+        (0, 3, 0),
+        (-1, 3, -1),
+        (-7, 3, -3),
+        (-10, 3, -4),
+    ] | (a, b, expected) =>
+        test("floor_div(" + a + ", " + b + ") should return " + expected, _test_floor_div(a, b, expected))
+
+    let floor_mod_cases = [
+        (7, 3, 1),
+        (0, 3, 0),
+        (-1, 3, 2),
+        (-7, 3, 2),
+        (-10, 3, 2),
+    ] | (a, b, expected) =>
+        test("floor_mod(" + a + ", " + b + ") should return " + expected, _test_floor_mod(a, b, expected))
+
+    test_file("/capy/lang/Math.cfun", digits_test_cases + floor_div_cases + floor_mod_cases)
+
+fun _test_digits(number: int, expected: int): Assert = assert_that(digits(number) == expected).is_true()
+
+fun _test_floor_div(a: int, b: int, expected: int): Assert =
+    assert_that(floor_div(a, b) == expected).is_true()
+
+fun _test_floor_mod(a: int, b: int, expected: int): Assert =
+    assert_that(floor_mod(a, b) == expected).is_true()


### PR DESCRIPTION
### Motivation
- Implement Unix timestamp and duration arithmetic for `DateTime` to satisfy issue #75 requiring `timestamp()`, `plus`/`+`, and `minus`/`-` operations.
- The existing date/time library lacked cross-variant `Duration` handling and calendar-aware date arithmetic needed for correct month/day behavior and day carry/borrow.
- Provide a focused standard-library change in `lib/capybara-lib` so higher layers can rely on correct DateTime semantics.

### Description
- Added `DateTime.timestamp()` and `DateTime.plus(Duration)` / `DateTime.minus(Duration)` plus infix operator overloads ``+`` and ``-`` that handle both `WeekDuration` and `DateDuration` and normalize day carry/borrow (file: `lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun`).
- Extended `Date` utilities with `Date.to_days_since_unix_epoch()`, `from_days_since_unix_epoch(...)`, `Date.add_days(...)`, and `Date.add_years_months(...)` plus supporting helpers to perform calendar-correct conversions and month-end clamping (file: `lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun`).
- Added `Duration` helpers `negate()` and component accessors `years()/months()/days()/hours()/minutes()/seconds()` to unify handling of `WeekDuration` and `DateDuration` (file: `lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun`).
- Added and expanded tests in `DateTimeTest.cfun` to cover epoch/timestamp cases (including negative timestamps), `plus`/`minus` with week and date durations, and operator parity with method calls (file: `lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun`).
- Impacted module: `lib/capybara-lib`.

### Testing
- Ran `./gradlew :lib:capybara-lib:testCapybara` which built the library and executed the Capybara tests for the modified standard library.
- The build and test run completed successfully (tests executed for `DateTime` changes and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e210dd52f88320b69a94f8a5ce45c6)