### PR TITLE
feat(#0): add ISO 8601 time interval parsing

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -1,0 +1,166 @@
+from /capy/date_time/Date import { * }
+from /capy/date_time/Time import { * }
+from /capy/date_time/DateTime import { * }
+from /capy/date_time/Duration import { * }
+from /capy/lang/Result import { * }
+
+/// Interval boundary represented as either a date (`YYYY-MM-DD`) or a UTC date-time (`YYYY-MM-DDTHH:MM:SSZ`).
+type TimePoint = DatePoint | DateTimePoint
+
+data DatePoint { date: Date }
+data DateTimePoint { date_time: DateTime }
+
+/// ISO 8601 time interval representations.
+///
+/// Supported forms:
+/// - `<start>/<end>`
+/// - `<start>/<duration>`
+/// - `<duration>/<end>`
+///
+/// The separator can be `/` (default) or `--` (by mutual agreement).
+type TimeInterval = StartEndInterval | StartDurationInterval | DurationEndInterval
+
+data StartEndInterval { start: TimePoint, end: TimePoint }
+data StartDurationInterval { start: TimePoint, duration: Duration }
+data DurationEndInterval { duration: Duration, end: TimePoint }
+
+/// Parses an ISO 8601 time interval.
+fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
+    data __Parse[T] { buffer: string, value: T }
+    fun __invalid(message: string): string = "Invalid ISO 8601 interval format: " + message
+    fun __parse_positive_digit(value: string): Result[__Parse[int]] =
+        match value[0] with
+        case None -> Error { __invalid("unexpected end of string while parsing digits") }
+        case Some { '1' } -> Success { __Parse { buffer: value[1:], value: 1 } }
+        case Some { '2' } -> Success { __Parse { buffer: value[1:], value: 2 } }
+        case Some { '3' } -> Success { __Parse { buffer: value[1:], value: 3 } }
+        case Some { '4' } -> Success { __Parse { buffer: value[1:], value: 4 } }
+        case Some { '5' } -> Success { __Parse { buffer: value[1:], value: 5 } }
+        case Some { '6' } -> Success { __Parse { buffer: value[1:], value: 6 } }
+        case Some { '7' } -> Success { __Parse { buffer: value[1:], value: 7 } }
+        case Some { '8' } -> Success { __Parse { buffer: value[1:], value: 8 } }
+        case Some { '9' } -> Success { __Parse { buffer: value[1:], value: 9 } }
+        case Some { char } -> Error { __invalid("expected digit between `1` and `9`, got `" + char + "`") }
+    fun __parse_digit(value: string): Result[__Parse[int]] =
+        match value[0] with
+        case None -> Error { __invalid("unexpected end of string while parsing digits") }
+        case Some { '0' } -> Success { __Parse { buffer: value[1:], value: 0 } }
+        case Some -> __parse_positive_digit(value)
+    fun __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
+        match value[0] with
+        case Some { char } ->
+            if match char with
+               case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' -> true
+               case _ -> false
+            then {
+                let parse_digit <- __parse_digit(value)
+                __parse_rest_digits(parse_digit.buffer, parsed * 10 + parse_digit.value)
+            }
+            else Success { __Parse { buffer: value, value: parsed } }
+        case _ -> Success { __Parse { buffer: value, value: parsed } }
+    fun __parse_digits(value: string): Result[__Parse[int]] =
+        let parse <- __parse_digit(value)
+        __parse_rest_digits(parse.buffer, parse.value)
+    fun __parse_exact_digits(value: string, label: string): Result[int] =
+        let parse <- __parse_digits(value)
+        if parse.buffer.is_empty
+        then Success { parse.value }
+        else Error { __invalid("expected digits for " + label + ", got `" + value + "`") }
+    fun __is_exact_digits(value: string): bool =
+        match __parse_exact_digits(value, "value") with
+        case Success -> true
+        case Error -> false
+
+    fun __parse_date(value: string): Result[Date] =
+        if value.size != 10
+        then Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
+        else if value[4:5] != "-" | value[7:8] != "-"
+            then Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
+            else if !(__is_exact_digits(value[0:4]) & __is_exact_digits(value[5:7]) & __is_exact_digits(value[8:10]))
+                then Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
+                else {
+                    let year <- __parse_exact_digits(value[0:4], "year")
+                    let month <- __parse_exact_digits(value[5:7], "month")
+                    let day <- __parse_exact_digits(value[8:10], "day")
+                    Date { day, month, year }
+                }
+
+    fun __parse_time(value: string): Result[Time] =
+        if value.size != 9
+        then Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
+        else if value[2:3] != ":" | value[5:6] != ":" | value[8:9] != "Z"
+            then Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
+            else if !(__is_exact_digits(value[0:2]) & __is_exact_digits(value[3:5]) & __is_exact_digits(value[6:8]))
+                then Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
+                else {
+                    let hour <- __parse_exact_digits(value[0:2], "hour")
+                    let minute <- __parse_exact_digits(value[3:5], "minute")
+                    let second <- __parse_exact_digits(value[6:8], "second")
+                    Time { hour, minute, second }
+                }
+
+    fun __parse_time_point(value: string): Result[TimePoint] =
+        if value ? "T"
+        then if value.size < 11
+            then Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
+            else if value[10:11] != "T"
+                then Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
+                else {
+                    let date <- __parse_date(value[0:10])
+                    let time <- __parse_time(value[11:])
+                    Success { DateTimePoint { date_time: DateTime { date, time } } }
+                }
+        else {
+            let date <- __parse_date(value)
+            Success { DatePoint { date } }
+        }
+
+    fun __find_separator(value: string, left: string): Result[tuple[string, string, int]] =
+        match value[0] with
+        case None -> Error { __invalid("missing interval separator (`/` or `--`)") }
+        case Some { char } ->
+            if char == "/"
+            then Success { (left, value[1:], 1) }
+            else if char == "-"
+            then match value[1] with
+                 case Some { '-' } -> Success { (left, value[2:], 2) }
+                 case _ -> __find_separator(value[1:], left + "-")
+            else __find_separator(value[1:], left + char)
+
+    fun __has_additional_separator(value: string, previous_dash: bool): bool =
+        match value[0] with
+        case None -> false
+        case Some { '/' } -> true
+        case Some { '-' } ->
+            if previous_dash
+            then true
+            else __has_additional_separator(value[1:], true)
+        case Some -> __has_additional_separator(value[1:], false)
+    ---
+    let separator <- __find_separator(iso, "")
+    let left = separator[0]
+    let right = separator[1]
+
+    if left.is_empty | right.is_empty
+    then Error { __invalid("both interval parts must be present") }
+    else if __has_additional_separator(right, false)
+    then Error { __invalid("interval must contain exactly one separator (`/` or `--`)") }
+    else if left.starts_with("P") & right.starts_with("P")
+    then Error { __invalid("an interval cannot contain duration on both sides") }
+    else if left.starts_with("P")
+    then {
+        let duration <- from_iso_8601(left)
+        let end <- __parse_time_point(right)
+        Success { DurationEndInterval { duration, end } }
+    }
+    else if right.starts_with("P")
+    then {
+        let start <- __parse_time_point(left)
+        let duration <- from_iso_8601(right)
+        Success { StartDurationInterval { start, duration } }
+    }
+    else {
+        let start <- __parse_time_point(left)
+        let end <- __parse_time_point(right)
+        Success { StartEndInterval { start, end } }
+    }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -14,9 +14,40 @@ from /capy/lang/Result import { * }
 /// The separator can be `/` (default) or `--` (by mutual agreement).
 type TimeInterval = StartEndInterval | StartDurationInterval | DurationEndInterval
 
-data StartEndInterval { start: any, end: any }
-data StartDurationInterval { start: any, duration: Duration }
-data DurationEndInterval { duration: Duration, end: any }
+type TimePoint = DatePoint | DateTimePoint
+
+data DatePoint { date: Date }
+data DateTimePoint { date_time: DateTime }
+
+data StartEndInterval { start: TimePoint, end: TimePoint }
+data StartDurationInterval { start: TimePoint, duration: Duration }
+data DurationEndInterval { duration: Duration, end: TimePoint }
+
+fun __pad_2(value: int): string =
+    if value < 10
+    then "0" + value
+    else "" + value
+
+fun __format_date(date: Date): string =
+    date.year + "-" + __pad_2(date.month) + "-" + __pad_2(date.day)
+
+fun __format_time(time: Time): string =
+    __pad_2(time.hour) + ":" + __pad_2(time.minute) + ":" + __pad_2(time.second) + "Z"
+
+fun __format_time_point(value: TimePoint): string =
+    match value with
+    case DatePoint { date } -> __format_date(date)
+    case DateTimePoint { date_time } -> __format_date(date_time.date) + "T" + __format_time(date_time.time)
+
+/// Formats this interval as ISO 8601 (`/` separator).
+fun TimeInterval.to_iso8601_interval(): string =
+    match this with
+    case StartEndInterval { start, end } ->
+        __format_time_point(start) + "/" + __format_time_point(end)
+    case StartDurationInterval { start, duration } ->
+        __format_time_point(start) + "/" + duration.to_iso_8601()
+    case DurationEndInterval { duration, end } ->
+        duration.to_iso_8601() + "/" + __format_time_point(end)
 
 /// Parses an ISO 8601 time interval.
 fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
@@ -97,15 +128,15 @@ fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
         then Success { DateTime { date: date.value, time: time.value } }
         else Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
 
-    fun __parse_time_point(value: string): Result[any] =
+    fun __parse_time_point(value: string): Result[TimePoint] =
         if value ? "T"
         then {
             let date_time <- __parse_date_time(value)
-            Success { date_time }
+            Success { DateTimePoint { date_time } }
         }
         else {
             let date <- __parse_date(value)
-            Success { date }
+            Success { DatePoint { date } }
         }
 
     fun __find_separator(value: string, left: string): Result[tuple[string, string, int]] =

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -27,17 +27,10 @@ fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
     fun __parse_digit(value: string, label: string): Result[__Parse[int]] =
         match value[0] with
         case None -> Error { __invalid("expected digit for " + label + ", got end of string") }
-        case Some { '0' } -> Success { __Parse { buffer: value[1:], value: 0 } }
-        case Some { '1' } -> Success { __Parse { buffer: value[1:], value: 1 } }
-        case Some { '2' } -> Success { __Parse { buffer: value[1:], value: 2 } }
-        case Some { '3' } -> Success { __Parse { buffer: value[1:], value: 3 } }
-        case Some { '4' } -> Success { __Parse { buffer: value[1:], value: 4 } }
-        case Some { '5' } -> Success { __Parse { buffer: value[1:], value: 5 } }
-        case Some { '6' } -> Success { __Parse { buffer: value[1:], value: 6 } }
-        case Some { '7' } -> Success { __Parse { buffer: value[1:], value: 7 } }
-        case Some { '8' } -> Success { __Parse { buffer: value[1:], value: 8 } }
-        case Some { '9' } -> Success { __Parse { buffer: value[1:], value: 9 } }
-        case Some { char } -> Error { __invalid("expected digit for " + label + ", got `" + char + "`") }
+        case Some { char } ->
+            match ("" + char).to_int() with
+            case Success { digit } -> Success { __Parse { buffer: value[1:], value: digit } }
+            case Error -> Error { __invalid("expected digit for " + label + ", got `" + char + "`") }
 
     fun __parse_2_digits(value: string, label: string): Result[__Parse[int]] =
         let tens <- __parse_digit(value, label)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -27,10 +27,13 @@ data DurationEndInterval { duration: Duration, end: TimePoint }
 /// Parses an ISO 8601 time interval.
 fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
     data __Parse[T] { buffer: string, value: T }
+
     fun __invalid(message: string): string = "Invalid ISO 8601 interval format: " + message
-    fun __parse_positive_digit(value: string): Result[__Parse[int]] =
+
+    fun __parse_digit(value: string, label: string): Result[__Parse[int]] =
         match value[0] with
-        case None -> Error { __invalid("unexpected end of string while parsing digits") }
+        case None -> Error { __invalid("expected digit for " + label + ", got end of string") }
+        case Some { '0' } -> Success { __Parse { buffer: value[1:], value: 0 } }
         case Some { '1' } -> Success { __Parse { buffer: value[1:], value: 1 } }
         case Some { '2' } -> Success { __Parse { buffer: value[1:], value: 2 } }
         case Some { '3' } -> Success { __Parse { buffer: value[1:], value: 3 } }
@@ -40,76 +43,79 @@ fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
         case Some { '7' } -> Success { __Parse { buffer: value[1:], value: 7 } }
         case Some { '8' } -> Success { __Parse { buffer: value[1:], value: 8 } }
         case Some { '9' } -> Success { __Parse { buffer: value[1:], value: 9 } }
-        case Some { char } -> Error { __invalid("expected digit between `1` and `9`, got `" + char + "`") }
-    fun __parse_digit(value: string): Result[__Parse[int]] =
-        match value[0] with
-        case None -> Error { __invalid("unexpected end of string while parsing digits") }
-        case Some { '0' } -> Success { __Parse { buffer: value[1:], value: 0 } }
-        case Some -> __parse_positive_digit(value)
-    fun __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
-        match value[0] with
-        case Some { char } ->
-            if match char with
-               case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' -> true
-               case _ -> false
-            then {
-                let parse_digit <- __parse_digit(value)
-                __parse_rest_digits(parse_digit.buffer, parsed * 10 + parse_digit.value)
-            }
-            else Success { __Parse { buffer: value, value: parsed } }
-        case _ -> Success { __Parse { buffer: value, value: parsed } }
-    fun __parse_digits(value: string): Result[__Parse[int]] =
-        let parse <- __parse_digit(value)
-        __parse_rest_digits(parse.buffer, parse.value)
-    fun __parse_exact_digits(value: string, label: string): Result[int] =
-        let parse <- __parse_digits(value)
-        if parse.buffer.is_empty
-        then Success { parse.value }
-        else Error { __invalid("expected digits for " + label + ", got `" + value + "`") }
-    fun __is_exact_digits(value: string): bool =
-        match __parse_exact_digits(value, "value") with
-        case Success -> true
-        case Error -> false
+        case Some { char } -> Error { __invalid("expected digit for " + label + ", got `" + char + "`") }
+
+    fun __parse_2_digits(value: string, label: string): Result[__Parse[int]] =
+        let tens <- __parse_digit(value, label)
+        let ones <- __parse_digit(tens.buffer, label)
+        Success { __Parse { buffer: ones.buffer, value: tens.value * 10 + ones.value } }
+
+    fun __parse_4_digits(value: string, label: string): Result[__Parse[int]] =
+        let thousands <- __parse_digit(value, label)
+        let hundreds <- __parse_digit(thousands.buffer, label)
+        let tens <- __parse_digit(hundreds.buffer, label)
+        let ones <- __parse_digit(tens.buffer, label)
+        Success { __Parse {
+            buffer: ones.buffer,
+            value: thousands.value * 1000 + hundreds.value * 100 + tens.value * 10 + ones.value
+        }}
+
+    fun __consume_symbol(value: string, expected: string, label: string): Result[string] =
+        if value.starts_with(expected)
+        then Success { value[1:] }
+        else Error { __invalid("expected `" + expected + "` after " + label) }
+
+    fun __parse_date_parts(value: string): Result[__Parse[Date]] =
+        let year <- __parse_4_digits(value, "year")
+        let after_year <- __consume_symbol(year.buffer, "-", "year")
+        let month <- __parse_2_digits(after_year, "month")
+        let after_month <- __consume_symbol(month.buffer, "-", "month")
+        let day <- __parse_2_digits(after_month, "day")
+        let parsed_date <- Date { day: day.value, month: month.value, year: year.value }
+        Success { __Parse {
+            buffer: day.buffer,
+            value: parsed_date
+        }}
+
+    fun __parse_time_parts(value: string): Result[__Parse[Time]] =
+        let hour <- __parse_2_digits(value, "hour")
+        let after_hour <- __consume_symbol(hour.buffer, ":", "hour")
+        let minute <- __parse_2_digits(after_hour, "minute")
+        let after_minute <- __consume_symbol(minute.buffer, ":", "minute")
+        let second <- __parse_2_digits(after_minute, "second")
+        let after_second <- __consume_symbol(second.buffer, "Z", "second")
+        let parsed_time <- Time { hour: hour.value, minute: minute.value, second: second.value }
+        Success { __Parse {
+            buffer: after_second,
+            value: parsed_time
+        }}
 
     fun __parse_date(value: string): Result[Date] =
-        if value.size != 10
-        then Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
-        else if value[4:5] != "-" | value[7:8] != "-"
-            then Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
-            else if !(__is_exact_digits(value[0:4]) & __is_exact_digits(value[5:7]) & __is_exact_digits(value[8:10]))
-                then Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
-                else {
-                    let year <- __parse_exact_digits(value[0:4], "year")
-                    let month <- __parse_exact_digits(value[5:7], "month")
-                    let day <- __parse_exact_digits(value[8:10], "day")
-                    Date { day, month, year }
-                }
+        let parsed <- __parse_date_parts(value)
+        if parsed.buffer.is_empty
+        then Success { parsed.value }
+        else Error { __invalid("expected date in `YYYY-MM-DD` format, got `" + value + "`") }
 
     fun __parse_time(value: string): Result[Time] =
-        if value.size != 9
-        then Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
-        else if value[2:3] != ":" | value[5:6] != ":" | value[8:9] != "Z"
-            then Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
-            else if !(__is_exact_digits(value[0:2]) & __is_exact_digits(value[3:5]) & __is_exact_digits(value[6:8]))
-                then Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
-                else {
-                    let hour <- __parse_exact_digits(value[0:2], "hour")
-                    let minute <- __parse_exact_digits(value[3:5], "minute")
-                    let second <- __parse_exact_digits(value[6:8], "second")
-                    Time { hour, minute, second }
-                }
+        let parsed <- __parse_time_parts(value)
+        if parsed.buffer.is_empty
+        then Success { parsed.value }
+        else Error { __invalid("expected time in `HH:MM:SSZ` format, got `" + value + "`") }
+
+    fun __parse_date_time(value: string): Result[DateTime] =
+        let date <- __parse_date_parts(value)
+        let after_date <- __consume_symbol(date.buffer, "T", "date")
+        let time <- __parse_time_parts(after_date)
+        if time.buffer.is_empty
+        then Success { DateTime { date: date.value, time: time.value } }
+        else Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
 
     fun __parse_time_point(value: string): Result[TimePoint] =
         if value ? "T"
-        then if value.size < 11
-            then Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
-            else if value[10:11] != "T"
-                then Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
-                else {
-                    let date <- __parse_date(value[0:10])
-                    let time <- __parse_time(value[11:])
-                    Success { DateTimePoint { date_time: DateTime { date, time } } }
-                }
+        then {
+            let date_time <- __parse_date_time(value)
+            Success { DateTimePoint { date_time } }
+        }
         else {
             let date <- __parse_date(value)
             Success { DatePoint { date } }
@@ -136,6 +142,21 @@ fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
             then true
             else __has_additional_separator(value[1:], true)
         case Some -> __has_additional_separator(value[1:], false)
+
+    fun __parse_duration_end(left: string, right: string): Result[TimeInterval] =
+        let duration <- from_iso_8601(left)
+        let end <- __parse_time_point(right)
+        Success { DurationEndInterval { duration, end } }
+
+    fun __parse_start_duration(left: string, right: string): Result[TimeInterval] =
+        let start <- __parse_time_point(left)
+        let duration <- from_iso_8601(right)
+        Success { StartDurationInterval { start, duration } }
+
+    fun __parse_start_end(left: string, right: string): Result[TimeInterval] =
+        let start <- __parse_time_point(left)
+        let end <- __parse_time_point(right)
+        Success { StartEndInterval { start, end } }
     ---
     let separator <- __find_separator(iso, "")
     let left = separator[0]
@@ -148,19 +169,7 @@ fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
     else if left.starts_with("P") & right.starts_with("P")
     then Error { __invalid("an interval cannot contain duration on both sides") }
     else if left.starts_with("P")
-    then {
-        let duration <- from_iso_8601(left)
-        let end <- __parse_time_point(right)
-        Success { DurationEndInterval { duration, end } }
-    }
+    then __parse_duration_end(left, right)
     else if right.starts_with("P")
-    then {
-        let start <- __parse_time_point(left)
-        let duration <- from_iso_8601(right)
-        Success { StartDurationInterval { start, duration } }
-    }
-    else {
-        let start <- __parse_time_point(left)
-        let end <- __parse_time_point(right)
-        Success { StartEndInterval { start, end } }
-    }
+    then __parse_start_duration(left, right)
+    else __parse_start_end(left, right)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -4,12 +4,6 @@ from /capy/date_time/DateTime import { * }
 from /capy/date_time/Duration import { * }
 from /capy/lang/Result import { * }
 
-/// Interval boundary represented as either a date (`YYYY-MM-DD`) or a UTC date-time (`YYYY-MM-DDTHH:MM:SSZ`).
-type TimePoint = DatePoint | DateTimePoint
-
-data DatePoint { date: Date }
-data DateTimePoint { date_time: DateTime }
-
 /// ISO 8601 time interval representations.
 ///
 /// Supported forms:
@@ -20,9 +14,9 @@ data DateTimePoint { date_time: DateTime }
 /// The separator can be `/` (default) or `--` (by mutual agreement).
 type TimeInterval = StartEndInterval | StartDurationInterval | DurationEndInterval
 
-data StartEndInterval { start: TimePoint, end: TimePoint }
-data StartDurationInterval { start: TimePoint, duration: Duration }
-data DurationEndInterval { duration: Duration, end: TimePoint }
+data StartEndInterval { start: any, end: any }
+data StartDurationInterval { start: any, duration: Duration }
+data DurationEndInterval { duration: Duration, end: any }
 
 /// Parses an ISO 8601 time interval.
 fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
@@ -110,15 +104,15 @@ fun from_iso_8601_interval(iso: string): Result[TimeInterval] =
         then Success { DateTime { date: date.value, time: time.value } }
         else Error { __invalid("expected date-time in `YYYY-MM-DDTHH:MM:SSZ` format, got `" + value + "`") }
 
-    fun __parse_time_point(value: string): Result[TimePoint] =
+    fun __parse_time_point(value: string): Result[any] =
         if value ? "T"
         then {
             let date_time <- __parse_date_time(value)
-            Success { DateTimePoint { date_time } }
+            Success { date_time }
         }
         else {
             let date <- __parse_date(value)
-            Success { DatePoint { date } }
+            Success { date }
         }
 
     fun __find_separator(value: string, left: string): Result[tuple[string, string, int]] =

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
@@ -1,17 +1,31 @@
 from /capy/date_time/Interval import { * }
+from /capy/lang/Result import { * }
 from /capy/test/Assert import { * }
 from /capy/test/CapyTest import { * }
 
+fun _parsed_iso(iso: string): Assert =
+    match from_iso_8601_interval(iso) with
+    case Success { interval } -> assert_that(interval.to_iso8601_interval()).is_equal_to(iso)
+    case Error -> assert_that(false).is_true()
+
+fun _parsed_iso_with_expected_output(iso: string, expected: string): Assert =
+    match from_iso_8601_interval(iso) with
+    case Success { interval } -> assert_that(interval.to_iso8601_interval()).is_equal_to(expected)
+    case Error -> assert_that(false).is_true()
+
 fun tests(): TestFile =
     let success_cases = [
-        "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z",
-        "2007-03-01/2008-05-11",
-        "2007-03-01T13:00:00Z/P1Y2M10DT2H30M",
-        "P1Y2M10DT2H30M/2008-05-11T15:30:00Z",
-        "2000-01-01--2002-12-31",
-    ] | iso =>
-        test("should parse interval `" + iso + "`",
-            assert_that(from_iso_8601_interval(iso)).succeeds())
+        test("should parse and format start/end date-time",
+            _parsed_iso("2007-03-01T13:00:00Z/2008-05-11T15:30:00Z")),
+        test("should parse and format start/end date",
+            _parsed_iso("2007-03-01/2008-05-11")),
+        test("should parse and format start/duration",
+            _parsed_iso("2007-03-01T13:00:00Z/P1Y2M10DT2H30M")),
+        test("should parse and format duration/end",
+            _parsed_iso("P1Y2M10DT2H30M/2008-05-11T15:30:00Z")),
+        test("should parse `--` separator and format canonical `/`",
+            _parsed_iso_with_expected_output("2000-01-01--2002-12-31", "2000-01-01/2002-12-31")),
+    ]
 
     let failure_cases = [
         "",
@@ -27,4 +41,11 @@ fun tests(): TestFile =
         test("should fail parsing interval `" + iso + "`",
             assert_that(from_iso_8601_interval(iso)).fails())
 
-    test_file('/capy/date_time/Interval.cfun', success_cases + failure_cases)
+    let message_cases = [
+        test("should report missing separator message",
+            assert_that(from_iso_8601_interval("2007-03-01")).fails("Invalid ISO 8601 interval format: missing interval separator (`/` or `--`)")),
+        test("should report both sides duration message",
+            assert_that(from_iso_8601_interval("P1D/P2D")).fails("Invalid ISO 8601 interval format: an interval cannot contain duration on both sides")),
+    ]
+
+    test_file('/capy/date_time/Interval.cfun', success_cases + failure_cases + message_cases)

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
@@ -1,0 +1,30 @@
+from /capy/date_time/Interval import { * }
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+
+fun tests(): TestFile =
+    let success_cases = [
+        "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z",
+        "2007-03-01/2008-05-11",
+        "2007-03-01T13:00:00Z/P1Y2M10DT2H30M",
+        "P1Y2M10DT2H30M/2008-05-11T15:30:00Z",
+        "2000-01-01--2002-12-31",
+    ] | iso =>
+        test("should parse interval `" + iso + "`",
+            assert_that(from_iso_8601_interval(iso)).succeeds())
+
+    let failure_cases = [
+        "",
+        "2007-03-01",
+        "P1D/P2D",
+        "2007-03-01/",
+        "/2008-05-11",
+        "2007-03-01/2008-05-11/2009-01-01",
+        "2007-03-01--2008-05-11/2009-01-01",
+        "2007-03-01T13:00:00/2008-05-11T15:30:00Z",
+        "2007-02-30/2008-05-11",
+    ] | iso =>
+        test("should fail parsing interval `" + iso + "`",
+            assert_that(from_iso_8601_interval(iso)).fails())
+
+    test_file('/capy/date_time/Interval.cfun', success_cases + failure_cases)


### PR DESCRIPTION
### Motivation
- Support ISO 8601 time intervals so callers can express `<start>/<end>`, `<start>/<duration>`, and `<duration>/<end>` using either `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ` endpoints and accept `/` or `--` as separator.

### Description
- Added a new parser module `lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun` that defines `TimePoint` and `TimeInterval` types and implements `from_iso_8601_interval(iso: string): Result[TimeInterval]` with validation and readable error messages.
- The parser recognizes the three interval forms, accepts `/` or `--` as the separator, parses endpoints as either a `Date` or a UTC `DateTime`, and reuses existing `Duration.from_iso_8601` for duration operands.
- Added `lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun` with success cases (date/date-time, start/duration, duration/end, `--` separator) and a set of invalid inputs to assert parse failures.
- Hardened date/time substring checks to avoid out-of-bounds reads for short/malformed inputs and ensure consistent error messages.

### Testing
- Ran `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :lib:capybara-lib:compileTestCapybaraDirect`, which completed successfully (capybara sources compiled and generated Java compiled).
- Ran `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :lib:capybara-lib:testCapybara`; compilation passed but running the generated test harness in this environment surfaced a runtime `InvocationTargetException` / test-gather failure (and an earlier StringIndexOutOfBounds during iteration) so the Capybara test execution did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e242c0c6648320acf71d3885453712)