### PR TITLE
feat(#83): add `private` visibility keyword and remove required local `__` prefixes

### DIFF
--- a/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
+++ b/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
@@ -69,7 +69,7 @@
     <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)(fun)(\s+)(__[A-Za-z0-9_]+)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)(private)(\s+)(fun)(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -98,14 +98,14 @@
       </dict>
     </dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*\b</string></dict>
-    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(type|enum|data|single)\s+(__[A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun\s+(__[A-Za-z0-9_]+)</string></dict>
+    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(private)\s+(type|enum|data|single)\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(private)\s+(fun)\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:(__[A-Za-z0-9_]+)\b</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(__[A-Za-z0-9_]+)\s*(?=\()</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b([A-Za-z_][A-Za-z0-9_]*)\s*(?=\()</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\b([A-Za-z_][A-Za-z0-9_]*)\s*(?=\()</string></dict>
     <dict>
       <key>name</key><string>meta.let.declaration.capybara</string>
@@ -113,7 +113,7 @@
     </dict>
     <dict>
       <key>name</key><string>meta.const.private.capybara</string>
-      <key>match</key><string>\b(const)\s+(__[A-Za-z_][A-Za-z0-9_]*)\b</string>
+      <key>match</key><string>\b(private)\s+(const)\s+([A-Z_][A-Z0-9_]*)\b</string>
     </dict>
     <dict>
       <key>name</key><string>meta.const.capybara</string>

--- a/Intellij/syntaxes/Capybara.tmLanguage
+++ b/Intellij/syntaxes/Capybara.tmLanguage
@@ -69,7 +69,7 @@
     <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)(fun)(\s+)(__[A-Za-z0-9_]+)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)(private)(\s+)(fun)(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -98,14 +98,14 @@
       </dict>
     </dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*\b</string></dict>
-    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(type|enum|data|single)\s+(__[A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun\s+(__[A-Za-z0-9_]+)</string></dict>
+    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(private)\s+(type|enum|data|single)\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(private)\s+(fun)\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:(__[A-Za-z0-9_]+)\b</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(__[A-Za-z0-9_]+)\s*(?=\()</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b([A-Za-z_][A-Za-z0-9_]*)\s*(?=\()</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\b([A-Za-z_][A-Za-z0-9_]*)\s*(?=\()</string></dict>
     <dict>
       <key>name</key><string>meta.let.declaration.capybara</string>
@@ -113,7 +113,7 @@
     </dict>
     <dict>
       <key>name</key><string>meta.const.private.capybara</string>
-      <key>match</key><string>\b(const)\s+(__[A-Za-z_][A-Za-z0-9_]*)\b</string>
+      <key>match</key><string>\b(private)\s+(const)\s+([A-Z_][A-Z0-9_]*)\b</string>
     </dict>
     <dict>
       <key>name</key><string>meta.const.capybara</string>

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/Consts.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/Consts.cfun
@@ -1,6 +1,6 @@
 const PI: double = 3.14
 const E: double = 2.
-const _HIDDEN: int = 11
+private const HIDDEN: int = 11
 const BYTE_V: byte = 0x1A
 const INT_V: int = 42
 const LONG_V: long = 97387717187L
@@ -21,7 +21,7 @@ const ANIMAL_TYPE: Animal = Cat { age: 7 }
 
 fun pi_plus_e(): double = PI + E
 
-fun uses_private_const(): int = _HIDDEN + 1
+fun uses_private_const(): int = HIDDEN + 1
 
 fun local_consts(x: int): int =
     const __BASE = 10

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/DateTimeDifference.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/DateTimeDifference.cfun
@@ -3,7 +3,7 @@ from /capy/date_time/Date import { * }
 from /capy/date_time/Time import { * }
 from /capy/date_time/Duration import { * }
 
-fun _at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
+private fun at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
     let epoch_date = UNIX_DATE
     let midnight = MIDNIGHT
     DateTime {
@@ -12,12 +12,12 @@ fun _at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
     }
 
 fun forward_difference_iso(): string =
-    _at(1, 3661).minus(_at(0, 0)).to_iso_8601()
+    at(1, 3661).minus(at(0, 0)).to_iso_8601()
 
 fun backward_difference_iso(): string =
-    _at(0, 0).minus(_at(1, 3661)).to_iso_8601()
+    at(0, 0).minus(at(1, 3661)).to_iso_8601()
 
 fun difference_round_trips(): bool =
-    let start = _at(10, 30)
-    let finish = _at(12, 7325)
+    let start = at(10, 30)
+    let finish = at(12, 7325)
     start.plus(finish.minus(start)) == finish

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/EmptyLiteralInference.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/EmptyLiteralInference.cfun
@@ -2,26 +2,26 @@ from /capy/test/Assert import { * }
 from /capy/test/CapyTest import { * }
 
 fun reverse_ints(values: list[int]): list[int] =
-    fun __rev(left: list[int], acc: list[int]): list[int] =
+    fun rev(left: list[int], acc: list[int]): list[int] =
         if left.size == 0
         then acc
         else
             match left[0] with
-            case Some { v } -> __rev(left[1:], [v] + acc)
+            case Some { v } -> rev(left[1:], [v] + acc)
             case None -> acc
     ---
-    __rev(values, [])
+    rev(values, [])
 
 fun duplicate_strings(values: list[string]): list[string] =
-    fun __dup(left: list[string], acc: list[string]): list[string] =
+    fun dup(left: list[string], acc: list[string]): list[string] =
         if left.size == 0
         then acc
         else
             match left[0] with
-            case Some { v } -> __dup(left[1:], acc + [v, v])
+            case Some { v } -> dup(left[1:], acc + [v, v])
             case None -> acc
     ---
-    __dup(values, [])
+    dup(values, [])
 
 fun empty_list_of_type_param(v: T): list[T] =
     []

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/GeneratorSemVer.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/GeneratorSemVer.cfun
@@ -13,35 +13,35 @@ fun custom_to_string(value: string): string = Pretty { value }.to_string()
 
 fun parse_local_option(value: int): Result[int] =
     data __Parse[T] { buffer: string, value: T }
-    fun __unwrap(parse: __Parse[Option[int]]): Result[__Parse[int]] =
+    fun unwrap(parse: __Parse[Option[int]]): Result[__Parse[int]] =
         match parse.value with
         case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
         case None -> Error { "missing value" }
     ---
-    __unwrap(__Parse { buffer: "", value: Some { value } })
+    unwrap(__Parse { buffer: "", value: Some { value } })
     | parsed => Success { parsed.value }
 
 fun parse_local_option_none(): Result[int] =
     data __Parse[T] { buffer: string, value: T }
-    fun __unwrap(parse: __Parse[Option[int]]): Result[__Parse[int]] =
+    fun unwrap(parse: __Parse[Option[int]]): Result[__Parse[int]] =
         match parse.value with
         case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
         case None -> Error { "missing value" }
     ---
     let none_value: Option[int] = None {}
-    __unwrap(__Parse { buffer: "", value: none_value })
+    unwrap(__Parse { buffer: "", value: none_value })
     | parsed => Success { parsed.value }
 
 fun parse_local_semver_build(version: string): Result[string] =
     data __Parse[T] { buffer: string, value: T }
-    fun __parse_build(buffer: string): Result[__Parse[string]] =
+    fun parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer: "", value: buffer } }
     ---
     let parse: __Parse[SemVer] = __Parse {
         buffer: version,
         value: SemVer { major: 1, build_metadata: None {} }
     }
-    __parse_build(parse.buffer)
+    parse_build(parse.buffer)
     | parse_build => Success { __Parse {
         buffer: parse_build.buffer,
         value: parse.value.with(build_metadata: Some { parse_build.value })
@@ -53,14 +53,14 @@ fun parse_local_semver_build(version: string): Result[string] =
 
 fun parse_local_semver_build_and_increment(version: string): Result[int] =
     data __Parse[T] { buffer: string, value: T }
-    fun __parse_build(buffer: string): Result[__Parse[string]] =
+    fun parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer: "", value: buffer } }
     ---
     let parse: __Parse[SemVer] = __Parse {
         buffer: version,
         value: SemVer { major: 1, build_metadata: None {} }
     }
-    __parse_build(parse.buffer)
+    parse_build(parse.buffer)
     | parse_build => Success { __Parse {
         buffer: parse_build.buffer,
         value:

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/GroupedExpression.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/GroupedExpression.cfun
@@ -13,15 +13,15 @@ fun nested_pipe_in_match_branch(value: int): Result[int] =
 
 fun grouped_guarded_match_is_exhaustive(input: string): Result[string] =
     data __Parse[T] { buffer: string, value: T }
-    fun __parse_tail(buffer: string): Result[__Parse[string]] =
+    fun parse_tail(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "tail" } }
-    fun __parse_build(buffer: string): Result[__Parse[string]] =
+    fun parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "build" } }
     ---
     let parse_patch: __Parse[string] = __Parse { input, "base" }
     match parse_patch.buffer[0] with
     case Some { ch } when ch == '-' -> {
-        __parse_tail(parse_patch.buffer[1:])
+        parse_tail(parse_patch.buffer[1:])
         | parse_tail => Success { __Parse {
             buffer: parse_tail.buffer,
             value: "pre:" + parse_tail.value
@@ -30,30 +30,30 @@ fun grouped_guarded_match_is_exhaustive(input: string): Result[string] =
             match parse.buffer[0] with
             case None -> Success { parse.value }
             case Some { ch } when ch == '+' -> {
-                __parse_build(parse.buffer[1:])
+                parse_build(parse.buffer[1:])
                 | parse_build => Success { "plus:" + parse.value + ":" + parse_build.value }
             }
             case Some { ch } -> Error { "bad:" + ch }
         }
     }
     case Some { ch } when ch == '+' ->
-        __parse_build(parse_patch.buffer[1:])
+        parse_build(parse_patch.buffer[1:])
         | parse_build => Success { "plus:" + parse_build.value }
     case Some { ch } -> Success { "other:" + ch }
     case None -> Success { "none" }
 
 fun semver_style_mixed_case_pipe_bodies(input: string): Result[string] =
     data __Parse[T] { buffer: string, value: T }
-    fun __parse_pre_release(buffer: string): Result[__Parse[string]] =
+    fun parse_pre_release(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "rc1" } }
-    fun __parse_build(buffer: string): Result[__Parse[string]] =
+    fun parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "001" } }
     ---
     let parse_patch: __Parse[string] = __Parse { input, "1.2.3" }
     let raw_sem_ver = "1.2.3"
     match parse_patch.buffer[0] with
     case Some { next_char } when next_char == '-' -> {
-        __parse_pre_release(parse_patch.buffer[1:])
+        parse_pre_release(parse_patch.buffer[1:])
         | parse_pre_release => Success { __Parse {
             buffer: parse_pre_release.buffer,
             value: raw_sem_ver + "-" + parse_pre_release.value
@@ -62,30 +62,30 @@ fun semver_style_mixed_case_pipe_bodies(input: string): Result[string] =
             match parse.buffer[0] with
             case None -> Success { parse.value }
             case Some { char } when char == '+' -> {
-                __parse_build(parse.buffer[1:])
+                parse_build(parse.buffer[1:])
                 | parse_build => Success { parse.value + "+" + parse_build.value }
             }
             case Some { char } -> Error { "bad:" + char }
         }
     }
     case Some { next_char } when next_char == '+' ->
-        __parse_build(parse_patch.buffer[1:])
+        parse_build(parse_patch.buffer[1:])
         | parse_build => Success { raw_sem_ver + "+" + parse_build.value }
     case Some { next_char } -> Error { "unexpected:" + next_char }
     case None -> Success { raw_sem_ver }
 
 fun inner_ungrouped_pipe_in_match_inside_lambda(input: string): Result[string] =
     data __Parse[T] { buffer: string, value: T }
-    fun __parse_pre_release(buffer: string): Result[__Parse[string]] =
+    fun parse_pre_release(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "rc1" } }
-    fun __parse_build(buffer: string): Result[__Parse[string]] =
+    fun parse_build(buffer: string): Result[__Parse[string]] =
         Success { __Parse { buffer, "001" } }
     ---
     let parse_patch: __Parse[string] = __Parse { input, "1.2.3" }
     let raw_sem_ver = "1.2.3"
     match parse_patch.buffer[0] with
     case Some { next_char } when next_char == '-' -> {
-        __parse_pre_release(parse_patch.buffer[1:])
+        parse_pre_release(parse_patch.buffer[1:])
         | parse_pre_release => Success { __Parse {
             buffer: parse_pre_release.buffer,
             value: raw_sem_ver + "-" + parse_pre_release.value
@@ -94,13 +94,13 @@ fun inner_ungrouped_pipe_in_match_inside_lambda(input: string): Result[string] =
             match parse.buffer[0] with
             case None -> Success { parse.value }
             case Some { char } when char == '+' ->
-                __parse_build(parse.buffer[1:])
+                parse_build(parse.buffer[1:])
                 | parse_build => Success { parse.value + "+" + parse_build.value }
             case Some { char } -> Error { "bad:" + char }
         }
     }
     case Some { next_char } when next_char == '+' -> {
-        __parse_build(parse_patch.buffer[1:])
+        parse_build(parse_patch.buffer[1:])
         | parse_build => Success { raw_sem_ver + "+" + parse_build.value }
     }
     case Some { next_char } -> Error { "unexpected:" + next_char }

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/LocalFunctionDocComments.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/LocalFunctionDocComments.cfun
@@ -1,7 +1,7 @@
 /// Accumulate
 fun accumulate(n: int): int =
     /// Internal accumulate
-    fun __accumulate(n: int, acc: int): int =
-        if n <= 0 then acc else __accumulate(n - 1, acc + n)
+    fun accumulate(n: int, acc: int): int =
+        if n <= 0 then acc else accumulate(n - 1, acc + n)
     ---
-    __accumulate(n, 0)
+    accumulate(n, 0)

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/LocalFunctions.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/LocalFunctions.cfun
@@ -1,38 +1,38 @@
 fun sum_down(x: int): int =
-    fun __sum_down(x: int, sum: int): int =
+    fun sum_down(x: int, sum: int): int =
         if x <= 0
         then sum
-        else __sum_down(x - 1, sum + x)
+        else sum_down(x - 1, sum + x)
     ---
-    __sum_down(x, 0)
+    sum_down(x, 0)
 
 fun parity(x: int): bool =
-    fun __is_even(n: int): bool =
+    fun is_even(n: int): bool =
         if n == 0
         then true
-        else __is_odd(n - 1)
-    fun __is_odd(n: int): bool =
+        else is_odd(n - 1)
+    fun is_odd(n: int): bool =
         if n == 0
         then false
-        else __is_even(n - 1)
+        else is_even(n - 1)
     ---
-    __is_even(x)
+    is_even(x)
 
 fun local_with_let(x: int): int =
-    fun __inc(y: int): int =
+    fun inc(y: int): int =
         let z = y + 1
         z
     ---
-    __inc(x)
+    inc(x)
 
 fun max_local(x: int, y: int): int =
-    fun __compare(a: int, b: int): int =
+    fun compare(a: int, b: int): int =
         if a > b then a else b
     ---
-    __compare(x, y)
+    compare(x, y)
 
 fun min_local(x: int, y: int): int =
-    fun __compare(a: int, b: int): int =
+    fun compare(a: int, b: int): int =
         if a < b then a else b
     ---
-    __compare(x, y)
+    compare(x, y)

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -5,7 +5,7 @@ fun foo_me(name: string): string =
     data __Foo { foo: string }
     data __Boo { boo: string }
     data __Unknown { unkn: string }
-    fun __name(value: __Name): string =
+    fun name(value: __Name): string =
         match value with
         case __Foo { foo } -> foo
         case __Boo { boo } -> boo
@@ -16,7 +16,7 @@ fun foo_me(name: string): string =
         case "foo" -> __Foo { "xyz" }
         case "boo" -> __Boo { "zyx" }
         case _ -> __Unknown { name }
-    __name(x)
+    name(x)
 
 fun local_data_with_imported_result(v: int): string =
     data __Entry { key: string, value: Result[int] }
@@ -28,26 +28,26 @@ fun local_data_with_imported_result(v: int): string =
 
 fun local_data_used_in_local_function(v: int): string =
     data __Parse[T] { value: T }
-    fun __unwrap(parse: __Parse[int]): string =
+    fun unwrap(parse: __Parse[int]): string =
         "value:" + parse.value
     ---
-    __unwrap(__Parse { v })
+    unwrap(__Parse { v })
 
 fun local_generic_data_used_in_local_function_return_type(v: int): string =
     data __Parse[T] { value: T }
-    fun __parse(value: int): Result[__Parse[int]] =
+    fun parse(value: int): Result[__Parse[int]] =
         Success { __Parse { value } }
     ---
-    match __parse(v) with
+    match parse(v) with
     case Success { value } -> "value:" + value.value
     case Error { message } -> "error:" + message
 
 fun local_generic_data_field_access_followed_by_index(buffer: string): string =
     data __Parse[T] { buffer: string, value: T }
-    fun __parse(value: string): Result[__Parse[int]] =
+    fun parse(value: string): Result[__Parse[int]] =
         Success { __Parse { buffer: value, value: 1 } }
     ---
-    match (__parse(buffer) | parse =>
+    match (parse(buffer) | parse =>
         match parse.buffer[0] with
         case Some { value } -> Success { value }
         case None -> Error { "" }) with

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/OptionToOptional.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/OptionToOptional.cfun
@@ -25,14 +25,14 @@ fun int_option_to_message(value: Option[int]): string =
         case Some { value } -> "value=" + value,
         case None -> "missing"
 
-fun _deserialize_json_fragment(raw: string): Result[tuple[string, int]] =
+private fun deserialize_json_fragment(raw: string): Result[tuple[string, int]] =
     if raw == "ok"
     then Success { value: ("json", 7) }
     else Error { message: "failed: " + raw }
 
 fun match_deserialize(raw: string): string =
     let pair = ("prefix", raw)
-    match _deserialize_json_fragment(pair[1]) with
+    match deserialize_json_fragment(pair[1]) with
     case Error e -> "failed: " + raw
     case Success { json_tuple } -> pair[0] + ":" + json_tuple[0] + ":" + json_tuple[1]
 

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/Pipe.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/Pipe.cfun
@@ -25,9 +25,9 @@ fun any_positive(l: list[int]): bool = l |any? x => x > 0
 /// returns if all of the ints in the list is positive
 fun all_positive(l: list[int]): bool = l |all? x => x > 0
 
-fun _is_positive(x: int): bool = x > 0
-fun any_positive_ref(l: list[int]): bool = l |any? :_is_positive
-fun all_positive_ref(l: list[int]): bool = l |all? :_is_positive
+private fun is_positive(x: int): bool = x > 0
+fun any_positive_ref(l: list[int]): bool = l |any? :is_positive
+fun all_positive_ref(l: list[int]): bool = l |all? :is_positive
 
 fun reduce2(l: list[int]): int =
     l

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/ResultError.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/ResultError.cfun
@@ -20,12 +20,12 @@ fun flatmap_untyped_result(): Result[string] =
     let result: Result = Success { "success_value" }
     result |* value => Success { Success { "mapped_" + value } }
 
-fun _append_dict_entry(acc: Result[string], key: string, value: int): Result[string] =
+private fun append_dict_entry(acc: Result[string], key: string, value: int): Result[string] =
     acc | text => Success { value: text + key + ":" + value + "," }
 
-fun _empty_result(): Result[string] = Success { value: "" }
+private fun empty_result(): Result[string] = Success { value: "" }
 
 fun dict_reduce_then_map(d: dict[int]): Result[string] =
     d
-        |> _empty_result(), (acc, k, v) => _append_dict_entry(acc, k, v)
+        |> empty_result(), (acc, k, v) => append_dict_entry(acc, k, v)
         | text => Success { value: text + "done" }

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/SeqCollection.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/SeqCollection.cfun
@@ -36,23 +36,23 @@ fun sum_first_two(s: Seq[int]): int =
     case End -> 0
 
 fun drop_local(s: Seq[int], n: int): Seq[int] =
-    fun __drop(seq: Seq[int], left: int) =
+    fun drop(seq: Seq[int], left: int) =
         if left <= 0
         then seq
         else
             match seq with
             case End -> End
-            case Cons { value, rest } -> __drop(rest, left - 1)
+            case Cons { value, rest } -> drop(rest, left - 1)
     ---
-    __drop(s, n)
+    drop(s, n)
 
 fun until_local(s: Seq[int], stop: int): Seq[int] =
-    fun __until(seq: Seq[int], x: int) =
+    fun until(seq: Seq[int], x: int) =
         match seq with
         case End -> End
         case Cons { value, rest } ->
             if value == x
             then End
-            else Cons { value, __until(rest, x) }
+            else Cons { value, until(rest, x) }
     ---
-    __until(s, stop)
+    until(s, stop)

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/SimpleFunction.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/SimpleFunction.cfun
@@ -37,9 +37,9 @@ fun static_list(): list[int] = [1,2,3]
 
 fun foo(x: int): int = x + 1
 
-fun _foo(x: int): int = x + 2
+private fun hidden_foo(x: int): int = x + 2
 
-fun call_private_and_public(x: int): int = foo(x) + _foo(x)
+fun call_private_and_public(x: int): int = foo(x) + hidden_foo(x)
 
 fun typed_let_string(): string =
     {

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/TupleCollection.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/TupleCollection.cfun
@@ -17,11 +17,11 @@ fun tuple_slice_to_minus_1(): tuple[int, string] = (1, "foo", 5.0)[:-1]
 
 fun tuple_slice_on_var(t: tuple[int, string, double]): tuple[string, double] = t[1:]
 
-fun _plus_one(x: int): int = x + 1
+private fun plus_one(x: int): int = x + 1
 
-fun _times_two(x: int): int = x * 2
+private fun times_two(x: int): int = x * 2
 
-fun tuple_with_functions(): tuple[int => int, int => int] = (:_plus_one, :_times_two)
+fun tuple_with_functions(): tuple[int => int, int => int] = (:plus_one, :times_two)
 
 fun tuple_with_functions_apply_first(x: int): int =
     let funs: tuple[int => int, int => int] = tuple_with_functions()

--- a/capy/src/e2e-tests/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -1260,17 +1260,17 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "local_function_error_restores_private_names",
                         """
-                                fun parse_semver(version: string): int =
-                                    data __Parse[T] { value: T }
-                                    fun __parse_digits(parse: __Parse[Option[int]]): __Parse[int] = parse.value
-                                    ---
-                                    0
+                                    fun parse_semver(version: string): int =
+                                        data __Parse[T] { value: T }
+                                        fun parse_digits(parse: __Parse[Option[int]]): __Parse[int] = parse.value
+                                        ---
+                                        0
                                 """,
-                        new Position(3, "    fun __parse_digits(parse: __Parse[Option[int]]): __Parse[int] = "),
+                        new Position(3, 70),
                         """
                                 error: mismatched types
                                  --> /foo/boo/local_function_error_restores_private_names.cfun:%d:%d
-                                fun __parse_digits(parse: __Parse[Option[int]]): __Parse[int] = parse.value
+                                fun parse_digits(parse: __Parse[Option[int]]): __Parse[int] = parse.value
                                 %3$s^ Expected `__Parse[int]`, got `Option[int]`
                                 """
                 )

--- a/capy/src/e2e-tests/java/dev/capylang/test/compilation_error/LocalVisibilityCompilationErrorTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/compilation_error/LocalVisibilityCompilationErrorTest.java
@@ -28,6 +28,7 @@ class LocalVisibilityCompilationErrorTest {
                     local const LOCAL_OFFSET: int = 5
                     local type LocalValue = LocalNumber
                     local data LocalNumber { value: int }
+                    private fun private_add(x: int): int = x + 2
                     fun public_value(x: int): int = local_add(x) + LOCAL_OFFSET
                     """
     );
@@ -37,11 +38,12 @@ class LocalVisibilityCompilationErrorTest {
     void compilationError(
             String moduleName,
             String code,
+            String modulePath,
             List<ImportDeclaration> imports,
             String expectedFile,
             String errorMessageFragment
     ) {
-        var errors = compileProgram(code, moduleName, imports);
+        var errors = compileProgram(code, moduleName, modulePath, imports);
 
         assertThat(errors).hasSize(1);
         var error = errors.first();
@@ -58,6 +60,7 @@ class LocalVisibilityCompilationErrorTest {
                                 fun foo(): int =
                                     1
                                 """,
+                        "/foo/boo",
                         List.of(new ImportDeclaration(SUPPORT_MODULE_IMPORT, List.of("local_add"), List.of())),
                         "/foo/boo/local_function_not_visible_from_parent_package.cfun",
                         "imports unknown symbol `local_add` from module `" + SUPPORT_MODULE_IMPORT + "`"
@@ -68,9 +71,21 @@ class LocalVisibilityCompilationErrorTest {
                                 fun foo(): int =
                                     1
                                 """,
+                        "/foo/boo",
                         List.of(new ImportDeclaration(SUPPORT_MODULE_IMPORT, List.of("LocalNumber"), List.of())),
                         "/foo/boo/local_type_not_visible_from_parent_package.cfun",
                         "imports unknown symbol `LocalNumber` from module `" + SUPPORT_MODULE_IMPORT + "`"
+                ),
+                Arguments.of(
+                        "private_function_not_visible_from_sibling_module",
+                        """
+                                fun foo(): int =
+                                    1
+                                """,
+                        "/foo/boo/internal/child",
+                        List.of(new ImportDeclaration(SUPPORT_MODULE_IMPORT, List.of("private_add"), List.of())),
+                        "/foo/boo/internal/child/private_function_not_visible_from_sibling_module.cfun",
+                        "imports unknown symbol `private_add` from module `" + SUPPORT_MODULE_IMPORT + "`"
                 )
         );
     }
@@ -78,13 +93,14 @@ class LocalVisibilityCompilationErrorTest {
     private static SortedSet<Result.Error.SingleError> compileProgram(
             String fun,
             String moduleName,
+            String modulePath,
             List<ImportDeclaration> imports
     ) {
         var rawModules = new ArrayList<RawModule>();
         rawModules.add(LOCAL_SUPPORT_MODULE);
         rawModules.add(new RawModule(
                 moduleName,
-                "/foo/boo",
+                modulePath,
                 prependImports(imports, fun)
         ));
         var programResult = CapybaraCompiler.INSTANCE.compile(rawModules, new java.util.TreeSet<>());

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -46,7 +46,7 @@ fieldDeclaration: identifier ':' type
                 | SPREAD TYPE;
 genericTypeDeclaration: TYPE ('[' TYPE (',' TYPE)* ']')?;
 
-VISIBILITY: 'local';
+VISIBILITY: 'local' | 'private';
 BOOL_LITERAL: 'true' | 'false';
 COLLECTION: 'list' | 'set' | 'dict';
 NAME : [_]* [a-z] [a-zA-Z0-9_]*;

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -1124,7 +1124,7 @@ public class CapybaraCompiler {
     ) {
         var key = signatureVisibilityCacheKey(currentModulePath, ownerModule, signatures);
         return compileCache.visibleSignaturesByScope.computeIfAbsent(key, ignored -> signatures.stream()
-                .filter(signature -> signature.visibility() != Visibility.LOCAL || isVisibleFromModule(currentModulePath, ownerModule.path()))
+                .filter(signature -> signature.visibility() == null || isVisibleFromModule(currentModulePath, ownerModule.path()))
                 .toList());
     }
 
@@ -1137,7 +1137,7 @@ public class CapybaraCompiler {
         var key = visibilityCacheKey(currentModulePath, ownerModule);
         return compileCache.visibleTypesByScope.computeIfAbsent(key, ignored -> {
             var filteredTypes = types.entrySet().stream()
-                    .filter(entry -> entry.getValue().visibility() != Visibility.LOCAL
+                    .filter(entry -> entry.getValue().visibility() == null
                                      || isVisibleFromModule(currentModulePath, ownerModule.path()))
                     .collect(java.util.stream.Collectors.toMap(
                             Map.Entry::getKey,
@@ -3890,17 +3890,17 @@ public class CapybaraCompiler {
     }
 
     private String restorePrivateTypeNameForDisplay(String typeName) {
-        return replacePrivateLocalNamesInText(typeName, "__local_type_");
+        return replacePrivateLocalNamesInText(typeName, "__local_type_", true);
     }
 
     private String toUserPrivateTypeName(String typeName) {
         var marker = "__local_type_";
-        return toUserPrivateLocalName(typeName, marker);
+        return toUserPrivateLocalName(typeName, marker, true);
     }
 
     private String restorePrivateFunctionNameForDisplay(String functionName) {
-        var restoredLocalFunction = toUserPrivateLocalName(functionName, "__local_fun_");
-        return toUserPrivateLocalName(restoredLocalFunction, "__local_const_");
+        var restoredLocalFunction = toUserPrivateLocalName(functionName, "__local_fun_", false);
+        return toUserPrivateLocalName(restoredLocalFunction, "__local_const_", true);
     }
 
     private String displayFunctionName(String functionName) {
@@ -3919,12 +3919,12 @@ public class CapybaraCompiler {
             var separator = expectedFoundMatcher.group(2) == null ? ", got `" : ", but got `";
             message = "Expected `" + expected + "`" + separator + got + "`";
         }
-        var restoredLocalFunctions = replacePrivateLocalNamesInText(message, "__local_fun_");
-        var restoredLocalConsts = replacePrivateLocalNamesInText(restoredLocalFunctions, "__local_const_");
-        return replacePrivateLocalNamesInText(restoredLocalConsts, "__local_type_");
+        var restoredLocalFunctions = replacePrivateLocalNamesInText(message, "__local_fun_", false);
+        var restoredLocalConsts = replacePrivateLocalNamesInText(restoredLocalFunctions, "__local_const_", true);
+        return replacePrivateLocalNamesInText(restoredLocalConsts, "__local_type_", true);
     }
 
-    private String replacePrivateLocalNamesInText(String text, String marker) {
+    private String replacePrivateLocalNamesInText(String text, String marker, boolean withPrivatePrefix) {
         var normalized = new StringBuilder(text.length());
         var cursor = 0;
         while (cursor < text.length()) {
@@ -3952,7 +3952,10 @@ public class CapybaraCompiler {
                 continue;
             }
             normalized.append(text, cursor, qualifiedNameStart);
-            normalized.append("__").append(localSuffix.substring(underscoreIndex + 1));
+            if (withPrivatePrefix) {
+                normalized.append("__");
+            }
+            normalized.append(localSuffix.substring(underscoreIndex + 1));
             cursor = localSuffixEnd;
         }
         return normalized.toString();
@@ -3973,7 +3976,7 @@ public class CapybaraCompiler {
         return Character.isLetterOrDigit(c) || c == '_';
     }
 
-    private String toUserPrivateLocalName(String name, String marker) {
+    private String toUserPrivateLocalName(String name, String marker, boolean withPrivatePrefix) {
         var idx = name.indexOf(marker);
         if (idx < 0) {
             return name;
@@ -3986,7 +3989,7 @@ public class CapybaraCompiler {
         if (underscoreIdx < 0 || underscoreIdx + 1 >= suffix.length()) {
             return name;
         }
-        return "__" + suffix.substring(underscoreIdx + 1);
+        return (withPrivatePrefix ? "__" : "") + suffix.substring(underscoreIdx + 1);
     }
 
     private String privateTypeEscapingFunctionSignatureMessage(

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -1124,7 +1124,7 @@ public class CapybaraCompiler {
     ) {
         var key = signatureVisibilityCacheKey(currentModulePath, ownerModule, signatures);
         return compileCache.visibleSignaturesByScope.computeIfAbsent(key, ignored -> signatures.stream()
-                .filter(signature -> signature.visibility() == null || isVisibleFromModule(currentModulePath, ownerModule.path()))
+                .filter(signature -> isVisibleFromModule(currentModulePath, ownerModule.path(), signature.visibility()))
                 .toList());
     }
 
@@ -1137,8 +1137,7 @@ public class CapybaraCompiler {
         var key = visibilityCacheKey(currentModulePath, ownerModule);
         return compileCache.visibleTypesByScope.computeIfAbsent(key, ignored -> {
             var filteredTypes = types.entrySet().stream()
-                    .filter(entry -> entry.getValue().visibility() == null
-                                     || isVisibleFromModule(currentModulePath, ownerModule.path()))
+                    .filter(entry -> isVisibleFromModule(currentModulePath, ownerModule.path(), entry.getValue().visibility()))
                     .collect(java.util.stream.Collectors.toMap(
                             Map.Entry::getKey,
                             Map.Entry::getValue,
@@ -1196,6 +1195,18 @@ public class CapybaraCompiler {
         var current = normalizeModulePath(currentModulePath);
         var owner = normalizeModulePath(ownerModulePath);
         return current.equals(owner) || current.startsWith(owner + "/");
+    }
+
+    private boolean isVisibleFromModule(String currentModulePath, String ownerModulePath, Visibility visibility) {
+        if (visibility == null) {
+            return true;
+        }
+        var current = normalizeModulePath(currentModulePath);
+        var owner = normalizeModulePath(ownerModulePath);
+        return switch (visibility) {
+            case LOCAL -> isVisibleFromModule(current, owner);
+            case PRIVATE -> current.equals(owner);
+        };
     }
 
     private String normalizeModulePath(String modulePath) {

--- a/compiler/src/main/java/dev/capylang/compiler/Visibility.java
+++ b/compiler/src/main/java/dev/capylang/compiler/Visibility.java
@@ -1,5 +1,6 @@
 package dev.capylang.compiler;
 
 public enum Visibility {
-    LOCAL
+    LOCAL,
+    PRIVATE
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -452,7 +452,7 @@ public class CapybaraParser {
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
-                context.VISIBILITY() != null ? dev.capylang.compiler.Visibility.LOCAL : null,
+                visibility(context.VISIBILITY()),
                 position(context)
         );
     }
@@ -469,7 +469,7 @@ public class CapybaraParser {
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
-                context.VISIBILITY() != null ? dev.capylang.compiler.Visibility.LOCAL : null,
+                visibility(context.VISIBILITY()),
                 position(context)
         );
     }
@@ -496,6 +496,7 @@ public class CapybaraParser {
     }
 
     private Function constDeclaration(FunctionalParser.ConstDeclarationContext context) {
+        var visibility = visibility(context.VISIBILITY());
         var name = context.TYPE().getText();
         validateConstName(name);
         var constExpression = expressionNoLet(context.expressionNoLet());
@@ -507,7 +508,7 @@ public class CapybaraParser {
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
-                context.VISIBILITY() != null ? dev.capylang.compiler.Visibility.LOCAL : null,
+                visibility,
                 position(context)
         );
     }
@@ -527,6 +528,7 @@ public class CapybaraParser {
     }
 
     private List<Definition> functionDeclaration(dev.capylang.parser.antlr.FunctionalParser.FunctionDeclarationContext functionDeclarationContext) {
+        var visibility = visibility(functionDeclarationContext.VISIBILITY());
         var functionNameDeclaration = functionDeclarationContext.functionNameDeclaration();
         var methodOwner = functionNameDeclaration.genericTypeDeclaration();
         var methodName = functionName(functionNameDeclaration);
@@ -563,17 +565,17 @@ public class CapybaraParser {
             if (localFunction != null) {
                 var localNameToken = localFunction.NAME().getSymbol();
                 var localName = localNameToken.getText();
-                if (!localName.startsWith("__")) {
-                    throw new IllegalStateException("Local function name has to start with `__`: " + localName);
-                }
                 var occurrences = localFunctionPositions.computeIfAbsent(localName, ignored -> new java.util.ArrayList<>());
                 occurrences.add(localNameToken);
                 if (localFunctionNameMap.containsKey(localName)) {
                     continue;
                 }
+                var normalizedLocalName = localName.startsWith("__")
+                        ? localName.substring(2)
+                        : localName;
                 localFunctionNameMap.put(
                         localName,
-                        localScopePrefix + "__local_fun_" + localFunctionIndex + "_" + localName.substring(2)
+                        localScopePrefix + "__local_fun_" + localFunctionIndex + "_" + normalizedLocalName
                 );
                 localFunctionIndex++;
             }
@@ -700,7 +702,7 @@ public class CapybaraParser {
                 functionDeclarationContext.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
-                functionDeclarationContext.VISIBILITY() != null ? dev.capylang.compiler.Visibility.LOCAL : null,
+                visibility,
                 position(functionDeclarationContext)
         );
         var allDefinitions = new java.util.ArrayList<Definition>(1 + extractedLocalDefinitions.size());
@@ -2794,6 +2796,17 @@ public class CapybaraParser {
         return context.getText();
     }
 
+    private static dev.capylang.compiler.Visibility visibility(TerminalNode visibility) {
+        if (visibility == null) {
+            return null;
+        }
+        return switch (visibility.getText()) {
+            case "local" -> dev.capylang.compiler.Visibility.LOCAL;
+            case "private" -> dev.capylang.compiler.Visibility.PRIVATE;
+            default -> throw new IllegalStateException("Unknown visibility: " + visibility.getText());
+        };
+    }
+
     private static String functionName(FunctionalParser.FunctionNameDeclarationContext context) {
         if (context.identifier() != null) {
             return identifier(context.identifier());
@@ -3238,11 +3251,5 @@ public class CapybaraParser {
     }
 
 }
-
-
-
-
-
-
 
 

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -161,7 +161,7 @@ public class JavaAstBuilder {
     private JavaConst buildStaticConst(CompiledFunction function) {
         return new JavaConst(
                 emittedFunctionName(function),
-                function.name().startsWith("_"),
+                function.name().startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 buildJavaType(function.returnType()),
                 function.expression(),
                 function.comments()
@@ -173,7 +173,7 @@ public class JavaAstBuilder {
         var expression = specializeReturnNewData(function.expression(), function.returnType());
         return new JavaMethod(
                 emittedFunctionName(function),
-                function.name().startsWith("_"),
+                function.name().startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 function.programMain(),
                 methodTypeParameters,
                 buildJavaReturnType(function),
@@ -865,7 +865,7 @@ public class JavaAstBuilder {
         var methodTypeParameters = methodTypeParameters(function, Set.copyOf(extractOwnerTypeParameters(function)));
         return new JavaMethod(
                 emittedFunctionName(function),
-                methodName.startsWith("_"),
+                methodName.startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 false,
                 methodTypeParameters,
                 buildJavaReturnType(function),
@@ -933,7 +933,7 @@ public class JavaAstBuilder {
                 : type.typeParameters();
         return new JavaRecord(
                 buildClassName(type.name()),
-                type.name().startsWith("_"),
+                type.name().startsWith("_") || type.visibility() == Visibility.PRIVATE,
                 type.comments(),
                 implementInterfaces,
                 fields,
@@ -955,7 +955,7 @@ public class JavaAstBuilder {
         var methodTypeParameters = methodTypeParameters(function, Set.copyOf(extractOwnerTypeParameters(function)));
         return new JavaMethod(
                 emittedFunctionName(function),
-                methodName.startsWith("_"),
+                methodName.startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 false,
                 methodTypeParameters,
                 buildJavaReturnType(function),


### PR DESCRIPTION
### Motivation
- Replace the forced underscore-based private naming with an explicit `private` visibility so authors can declare private functions/consts with a keyword instead of relying on leading `_` and `__` conventions.
- Keep backward compatibility with existing underscore-named symbols in generated code while making local names easier to author and inspect.

### Description
- Grammar: extended `VISIBILITY` to accept `'private'` in `compiler/src/main/antlr/Functional.g4` so `private` may prefix `fun|type|data|const` declarations.
- Compiler model: added `Visibility.PRIVATE` and a `visibility(...)` helper in `CapybaraParser` to map `local`/`private`, and threaded visibility through parsed `Function`, `Type`, `Data`, and `Const` declarations.
- Local names and diagnostics: removed the hard requirement that local functions start with `__` and normalize existing `__`-prefixed local names; kept strict validation for local const names (`__...`), and updated the compiler display/restoration logic to show user-friendly local names again.
- Java generation & visibility mapping: updated `JavaAstBuilder` so generated Java members are considered private when either the legacy underscore-naming is present or the declaration has `Visibility.PRIVATE`.
- Tooling and tests: updated IntelliJ syntax files to highlight the `private` keyword variants and updated integration/e2e `.cfun` sources and a compilation-error test expectation to the new `private` style.

### Testing
- Ran compiler unit tests with `./gradlew :compiler:test` and they passed.
- Ran integration/e2e tests with `./gradlew :capy:e2eTests` and they passed.
- Changes touched modules: `compiler` (grammar, parser, visibility model, diagnostics, Java AST generation), `capy` (e2e samples and test fixtures), and `Intellij` (syntax highlighting).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75a571580832087266be65f856e92)