### PR TITLE
Add DateTimeUtil conversions for Capy types and unit tests

### DIFF
--- a/lib/capybara-lib/build.gradle
+++ b/lib/capybara-lib/build.gradle
@@ -36,6 +36,10 @@ plugins {
     id 'buildlogic.java-library-conventions'
 }
 
+dependencies {
+    testImplementation 'org.assertj:assertj-core:3.27.6'
+}
+
 class CapyRuntimeBridge implements Closeable {
     private final URLClassLoader classLoader
     private final def readLinkedProgramMethod

--- a/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
@@ -11,6 +11,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 public final class DateTimeUtil {
@@ -36,8 +37,14 @@ public final class DateTimeUtil {
         return LocalTime.of(time.hour(), time.minute(), time.second());
     }
 
+    /**
+     * Converts Java {@link LocalTime} to Capy {@link Time}.
+     * <p>
+     * Capy time precision is whole seconds, so sub-second nanos are explicitly truncated.
+     */
     public static Time fromJavaLocalTime(LocalTime time) {
-        return new Time(time.getHour(), time.getMinute(), time.getSecond(), Optional.empty());
+        var truncated = time.truncatedTo(ChronoUnit.SECONDS);
+        return new Time(truncated.getHour(), truncated.getMinute(), truncated.getSecond(), Optional.empty());
     }
 
     public static OffsetTime toJavaOffsetTime(Time time) {
@@ -47,6 +54,11 @@ public final class DateTimeUtil {
         return OffsetTime.of(toJavaLocalTime(time), offset);
     }
 
+    /**
+     * Converts Java {@link OffsetTime} to Capy {@link Time}.
+     * <p>
+     * Capy time precision is whole seconds, so sub-second nanos are explicitly truncated.
+     */
     public static Time fromJavaOffsetTime(OffsetTime time) {
         var totalSeconds = time.getOffset().getTotalSeconds();
         if (Math.floorMod(totalSeconds, TimeModule.sECONDSINMINUTE) != 0) {
@@ -55,7 +67,8 @@ public final class DateTimeUtil {
             );
         }
         var offsetMinutes = Math.floorDiv(totalSeconds, TimeModule.sECONDSINMINUTE);
-        return new Time(time.getHour(), time.getMinute(), time.getSecond(), Optional.of(offsetMinutes));
+        var truncated = time.toLocalTime().truncatedTo(ChronoUnit.SECONDS);
+        return new Time(truncated.getHour(), truncated.getMinute(), truncated.getSecond(), Optional.of(offsetMinutes));
     }
 
     public static LocalDateTime toJavaLocalDateTime(DateTime dateTime) {

--- a/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
@@ -88,9 +88,7 @@ public final class DateTimeUtil {
     }
 
     private static Optional<Integer> offsetMinutes(Time time) {
-        if (time.offset_minutes().isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of((Integer) time.offset_minutes().orElseThrow());
+        return OptionUtil.toJavaOptional(OptionUtil.toCapyOption(time.offset_minutes()))
+                .map(Integer.class::cast);
     }
 }

--- a/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
@@ -14,6 +14,8 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 
 public final class DateTimeUtil {
+    private static final int JAVA_MAX_OFFSET_MINUTES = 18 * TimeModule.mINUTESINHOUR;
+
     private DateTimeUtil() {
     }
 
@@ -40,13 +42,19 @@ public final class DateTimeUtil {
 
     public static OffsetTime toJavaOffsetTime(Time time) {
         var offset = offsetMinutes(time)
-                .map(minutes -> ZoneOffset.ofTotalSeconds(Math.multiplyExact(minutes, TimeModule.sECONDSINMINUTE)))
+                .map(DateTimeUtil::toJavaZoneOffset)
                 .orElseGet(() -> ZoneOffset.UTC);
         return OffsetTime.of(toJavaLocalTime(time), offset);
     }
 
     public static Time fromJavaOffsetTime(OffsetTime time) {
-        var offsetMinutes = Math.floorDiv(time.getOffset().getTotalSeconds(), TimeModule.sECONDSINMINUTE);
+        var totalSeconds = time.getOffset().getTotalSeconds();
+        if (Math.floorMod(totalSeconds, TimeModule.sECONDSINMINUTE) != 0) {
+            throw new IllegalArgumentException(
+                    "Java offset with second precision is unsupported: " + time.getOffset()
+            );
+        }
+        var offsetMinutes = Math.floorDiv(totalSeconds, TimeModule.sECONDSINMINUTE);
         return new Time(time.getHour(), time.getMinute(), time.getSecond(), Optional.of(offsetMinutes));
     }
 
@@ -70,6 +78,13 @@ public final class DateTimeUtil {
                 fromJavaLocalDate(dateTime.toLocalDate()),
                 fromJavaOffsetTime(dateTime.toOffsetTime())
         );
+    }
+
+    private static ZoneOffset toJavaZoneOffset(int minutes) {
+        if (minutes < -JAVA_MAX_OFFSET_MINUTES || minutes > JAVA_MAX_OFFSET_MINUTES) {
+            throw new IllegalArgumentException("Capy offset out of Java ZoneOffset range: " + minutes + " minutes");
+        }
+        return ZoneOffset.ofTotalSeconds(Math.multiplyExact(minutes, TimeModule.sECONDSINMINUTE));
     }
 
     private static Optional<Integer> offsetMinutes(Time time) {

--- a/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
@@ -1,0 +1,81 @@
+package dev.capylang;
+
+import capy.dateTime.Date;
+import capy.dateTime.DateTime;
+import capy.dateTime.Time;
+import capy.dateTime.TimeModule;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+public final class DateTimeUtil {
+    private DateTimeUtil() {
+    }
+
+    public static LocalDate toJavaLocalDate(Date date) {
+        return LocalDate.of(date.year(), date.month(), date.day());
+    }
+
+    public static Date fromJavaLocalDate(LocalDate date) {
+        return new Date(date.getDayOfMonth(), date.getMonthValue(), date.getYear());
+    }
+
+    /**
+     * Converts Capy {@link Time} to Java {@link LocalTime}.
+     * <p>
+     * Note: this conversion intentionally drops Capy offset information.
+     */
+    public static LocalTime toJavaLocalTime(Time time) {
+        return LocalTime.of(time.hour(), time.minute(), time.second());
+    }
+
+    public static Time fromJavaLocalTime(LocalTime time) {
+        return new Time(time.getHour(), time.getMinute(), time.getSecond(), Optional.empty());
+    }
+
+    public static OffsetTime toJavaOffsetTime(Time time) {
+        var offset = offsetMinutes(time)
+                .map(minutes -> ZoneOffset.ofTotalSeconds(Math.multiplyExact(minutes, TimeModule.sECONDSINMINUTE)))
+                .orElseGet(() -> ZoneOffset.UTC);
+        return OffsetTime.of(toJavaLocalTime(time), offset);
+    }
+
+    public static Time fromJavaOffsetTime(OffsetTime time) {
+        var offsetMinutes = Math.floorDiv(time.getOffset().getTotalSeconds(), TimeModule.sECONDSINMINUTE);
+        return new Time(time.getHour(), time.getMinute(), time.getSecond(), Optional.of(offsetMinutes));
+    }
+
+    public static LocalDateTime toJavaLocalDateTime(DateTime dateTime) {
+        return LocalDateTime.of(toJavaLocalDate(dateTime.date()), toJavaLocalTime(dateTime.time()));
+    }
+
+    public static DateTime fromJavaLocalDateTime(LocalDateTime dateTime) {
+        return new DateTime(
+                fromJavaLocalDate(dateTime.toLocalDate()),
+                fromJavaLocalTime(dateTime.toLocalTime())
+        );
+    }
+
+    public static OffsetDateTime toJavaOffsetDateTime(DateTime dateTime) {
+        return OffsetDateTime.of(toJavaLocalDateTime(dateTime), toJavaOffsetTime(dateTime.time()).getOffset());
+    }
+
+    public static DateTime fromJavaOffsetDateTime(OffsetDateTime dateTime) {
+        return new DateTime(
+                fromJavaLocalDate(dateTime.toLocalDate()),
+                fromJavaOffsetTime(dateTime.toOffsetTime())
+        );
+    }
+
+    private static Optional<Integer> offsetMinutes(Time time) {
+        if (time.offset_minutes().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of((Integer) time.offset_minutes().orElseThrow());
+    }
+}

--- a/lib/capybara-lib/src/main/java/dev/capylang/OptionUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/OptionUtil.java
@@ -1,0 +1,26 @@
+package dev.capylang;
+
+import capy.lang.Option;
+
+import java.util.Optional;
+
+public final class OptionUtil {
+    private OptionUtil() {
+    }
+
+    public static <T> Option<T> toCapyOption(Optional<T> optional) {
+        return optional.<Option<T>>map(Option.Some::new).orElseGet(OptionUtil::none);
+    }
+
+    public static <T> Optional<T> toJavaOptional(Option<T> option) {
+        return switch (option) {
+            case Option.Some<T> some -> Optional.ofNullable(some.value());
+            case Option.None ignored -> Optional.empty();
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Option<T> none() {
+        return (Option<T>) Option.None.INSTANCE;
+    }
+}

--- a/lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java
@@ -1,0 +1,117 @@
+package dev.capylang;
+
+import capy.dateTime.Date;
+import capy.dateTime.DateTime;
+import capy.dateTime.Time;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateTimeUtilTest {
+    @ParameterizedTest
+    @MethodSource("dateCases")
+    void shouldConvertDateToAndFromJavaLocalDate(Date capyDate, LocalDate javaDate) {
+        assertThat(DateTimeUtil.toJavaLocalDate(capyDate)).isEqualTo(javaDate);
+        assertThat(DateTimeUtil.fromJavaLocalDate(javaDate)).isEqualTo(capyDate);
+    }
+
+    @ParameterizedTest
+    @MethodSource("localTimeCases")
+    void shouldConvertTimeToAndFromJavaLocalTime(Time capyTime, LocalTime javaTime) {
+        assertThat(DateTimeUtil.toJavaLocalTime(capyTime)).isEqualTo(javaTime);
+        assertThat(DateTimeUtil.fromJavaLocalTime(javaTime)).isEqualTo(capyTime);
+    }
+
+    @ParameterizedTest
+    @MethodSource("offsetTimeCases")
+    void shouldConvertTimeToAndFromJavaOffsetTime(Time capyTime, OffsetTime javaTime) {
+        assertThat(DateTimeUtil.toJavaOffsetTime(capyTime)).isEqualTo(javaTime);
+        assertThat(DateTimeUtil.fromJavaOffsetTime(javaTime)).isEqualTo(capyTime);
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateTimeCases")
+    void shouldConvertDateTimeToAndFromJavaLocalDateTime(DateTime capyDateTime, LocalDateTime javaDateTime) {
+        assertThat(DateTimeUtil.toJavaLocalDateTime(capyDateTime)).isEqualTo(javaDateTime);
+        assertThat(DateTimeUtil.fromJavaLocalDateTime(javaDateTime)).isEqualTo(capyDateTime);
+    }
+
+    @ParameterizedTest
+    @MethodSource("offsetDateTimeCases")
+    void shouldConvertDateTimeToAndFromJavaOffsetDateTime(DateTime capyDateTime, OffsetDateTime javaDateTime) {
+        assertThat(DateTimeUtil.toJavaOffsetDateTime(capyDateTime)).isEqualTo(javaDateTime);
+        assertThat(DateTimeUtil.fromJavaOffsetDateTime(javaDateTime)).isEqualTo(capyDateTime);
+    }
+
+    @ParameterizedTest
+    @MethodSource("localTimeCases")
+    void shouldUseUtcWhenConvertingTimeWithoutOffsetToJavaOffsetTime(Time capyTime, LocalTime ignored) {
+        var timeWithoutOffset = new Time(capyTime.hour(), capyTime.minute(), capyTime.second(), Optional.empty());
+
+        assertThat(DateTimeUtil.toJavaOffsetTime(timeWithoutOffset).getOffset()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    private static Stream<Arguments> dateCases() {
+        return Stream.of(
+                Arguments.of(new Date(21, 4, 2026), LocalDate.of(2026, 4, 21)),
+                Arguments.of(new Date(1, 1, 1970), LocalDate.of(1970, 1, 1))
+        );
+    }
+
+    private static Stream<Arguments> localTimeCases() {
+        return Stream.of(
+                Arguments.of(new Time(13, 15, 45, Optional.empty()), LocalTime.of(13, 15, 45)),
+                Arguments.of(new Time(0, 0, 0, Optional.empty()), LocalTime.MIDNIGHT)
+        );
+    }
+
+    private static Stream<Arguments> offsetTimeCases() {
+        return Stream.of(
+                Arguments.of(
+                        new Time(13, 15, 45, Optional.of(330)),
+                        OffsetTime.of(13, 15, 45, 0, ZoneOffset.ofHoursMinutes(5, 30))
+                ),
+                Arguments.of(
+                        new Time(8, 0, 1, Optional.of(-240)),
+                        OffsetTime.of(8, 0, 1, 0, ZoneOffset.ofHours(-4))
+                )
+        );
+    }
+
+    private static Stream<Arguments> dateTimeCases() {
+        return Stream.of(
+                Arguments.of(
+                        new DateTime(new Date(21, 4, 2026), new Time(13, 15, 45, Optional.empty())),
+                        LocalDateTime.of(2026, 4, 21, 13, 15, 45)
+                ),
+                Arguments.of(
+                        new DateTime(new Date(1, 1, 1970), new Time(0, 0, 0, Optional.empty())),
+                        LocalDateTime.of(1970, 1, 1, 0, 0, 0)
+                )
+        );
+    }
+
+    private static Stream<Arguments> offsetDateTimeCases() {
+        return Stream.of(
+                Arguments.of(
+                        new DateTime(new Date(21, 4, 2026), new Time(13, 15, 45, Optional.of(-240))),
+                        OffsetDateTime.of(2026, 4, 21, 13, 15, 45, 0, ZoneOffset.ofHours(-4))
+                ),
+                Arguments.of(
+                        new DateTime(new Date(21, 4, 2026), new Time(13, 15, 45, Optional.of(0))),
+                        OffsetDateTime.of(2026, 4, 21, 13, 15, 45, 0, ZoneOffset.UTC)
+                )
+        );
+    }
+}

--- a/lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DateTimeUtilTest {
     @ParameterizedTest
@@ -60,6 +61,37 @@ class DateTimeUtilTest {
         var timeWithoutOffset = new Time(capyTime.hour(), capyTime.minute(), capyTime.second(), Optional.empty());
 
         assertThat(DateTimeUtil.toJavaOffsetTime(timeWithoutOffset).getOffset()).isEqualTo(ZoneOffset.UTC);
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("capyOffsetsOutsideJavaRange")
+    void shouldFailWhenCapyOffsetIsOutsideJavaZoneOffsetRange(int offsetMinutes) {
+        var capyTime = new Time(10, 0, 0, Optional.of(offsetMinutes));
+
+        assertThatThrownBy(() -> DateTimeUtil.toJavaOffsetTime(capyTime))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("out of Java ZoneOffset range");
+
+        var capyDateTime = new DateTime(new Date(21, 4, 2026), capyTime);
+        assertThatThrownBy(() -> DateTimeUtil.toJavaOffsetDateTime(capyDateTime))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("out of Java ZoneOffset range");
+    }
+
+    @ParameterizedTest
+    @MethodSource("javaOffsetsWithSecondPrecision")
+    void shouldFailWhenJavaOffsetContainsSecondPrecision(ZoneOffset offset) {
+        var offsetTime = OffsetTime.of(13, 15, 45, 0, offset);
+
+        assertThatThrownBy(() -> DateTimeUtil.fromJavaOffsetTime(offsetTime))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("second precision");
+
+        var offsetDateTime = OffsetDateTime.of(2026, 4, 21, 13, 15, 45, 0, offset);
+        assertThatThrownBy(() -> DateTimeUtil.fromJavaOffsetDateTime(offsetDateTime))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("second precision");
     }
 
     private static Stream<Arguments> dateCases() {
@@ -114,4 +146,20 @@ class DateTimeUtilTest {
                 )
         );
     }
+
+
+    private static Stream<Arguments> capyOffsetsOutsideJavaRange() {
+        return Stream.of(
+                Arguments.of(18 * 60 + 1),
+                Arguments.of(-(18 * 60 + 1))
+        );
+    }
+
+    private static Stream<Arguments> javaOffsetsWithSecondPrecision() {
+        return Stream.of(
+                Arguments.of(ZoneOffset.ofHoursMinutesSeconds(5, 30, 45)),
+                Arguments.of(ZoneOffset.ofHoursMinutesSeconds(-3, -15, -30))
+        );
+    }
+
 }

--- a/lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java
@@ -34,6 +34,25 @@ class DateTimeUtilTest {
         assertThat(DateTimeUtil.fromJavaLocalTime(javaTime)).isEqualTo(capyTime);
     }
 
+
+    @ParameterizedTest
+    @MethodSource("fractionalLocalTimes")
+    void shouldTruncateSubSecondPrecisionWhenConvertingFromJavaLocalTime(LocalTime javaTime, Time expected) {
+        assertThat(DateTimeUtil.fromJavaLocalTime(javaTime)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fractionalOffsetTimes")
+    void shouldTruncateSubSecondPrecisionWhenConvertingFromJavaOffsetTime(OffsetTime javaTime, Time expected) {
+        assertThat(DateTimeUtil.fromJavaOffsetTime(javaTime)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fractionalLocalDateTimes")
+    void shouldTruncateSubSecondPrecisionWhenConvertingFromJavaLocalDateTime(LocalDateTime javaDateTime, DateTime expected) {
+        assertThat(DateTimeUtil.fromJavaLocalDateTime(javaDateTime)).isEqualTo(expected);
+    }
+
     @ParameterizedTest
     @MethodSource("offsetTimeCases")
     void shouldConvertTimeToAndFromJavaOffsetTime(Time capyTime, OffsetTime javaTime) {
@@ -159,6 +178,43 @@ class DateTimeUtilTest {
         return Stream.of(
                 Arguments.of(ZoneOffset.ofHoursMinutesSeconds(5, 30, 45)),
                 Arguments.of(ZoneOffset.ofHoursMinutesSeconds(-3, -15, -30))
+        );
+    }
+
+
+
+    private static Stream<Arguments> fractionalLocalTimes() {
+        return Stream.of(
+                Arguments.of(
+                        LocalTime.of(13, 15, 45, 123_456_789),
+                        new Time(13, 15, 45, Optional.empty())
+                ),
+                Arguments.of(
+                        LocalTime.of(13, 15, 45, 999_999_999),
+                        new Time(13, 15, 45, Optional.empty())
+                )
+        );
+    }
+
+    private static Stream<Arguments> fractionalOffsetTimes() {
+        return Stream.of(
+                Arguments.of(
+                        OffsetTime.of(13, 15, 45, 500_000_000, ZoneOffset.ofHoursMinutes(5, 30)),
+                        new Time(13, 15, 45, Optional.of(330))
+                ),
+                Arguments.of(
+                        OffsetTime.of(8, 0, 1, 1, ZoneOffset.ofHours(-4)),
+                        new Time(8, 0, 1, Optional.of(-240))
+                )
+        );
+    }
+
+    private static Stream<Arguments> fractionalLocalDateTimes() {
+        return Stream.of(
+                Arguments.of(
+                        LocalDateTime.of(2026, 4, 21, 13, 15, 45, 700_000_000),
+                        new DateTime(new Date(21, 4, 2026), new Time(13, 15, 45, Optional.empty()))
+                )
         );
     }
 

--- a/lib/capybara-lib/src/test/java/dev/capylang/OptionUtilTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/OptionUtilTest.java
@@ -1,0 +1,43 @@
+package dev.capylang;
+
+import capy.lang.Option;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OptionUtilTest {
+    @Test
+    void shouldConvertJavaOptionalPresentToCapySome() {
+        var capyOption = OptionUtil.toCapyOption(Optional.of("capy"));
+
+        assertThat(capyOption).isEqualTo(new Option.Some<>("capy"));
+    }
+
+    @Test
+    void shouldConvertJavaOptionalEmptyToCapyNone() {
+        var capyOption = OptionUtil.toCapyOption(Optional.empty());
+
+        assertThat(capyOption).isEqualTo(none());
+    }
+
+    @Test
+    void shouldConvertCapySomeToJavaOptionalPresent() {
+        var javaOptional = OptionUtil.toJavaOptional(new Option.Some<>(42));
+
+        assertThat(javaOptional).hasValue(42);
+    }
+
+    @Test
+    void shouldConvertCapyNoneToJavaOptionalEmpty() {
+        var javaOptional = OptionUtil.toJavaOptional(none());
+
+        assertThat(javaOptional).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Option<T> none() {
+        return (Option<T>) Option.None.INSTANCE;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide deterministic conversions between project `capy.dateTime` types and Java `java.time` types to improve interoperability.
- Ensure offset handling is explicit and that times without offsets default to UTC when converted to offset-aware types.

### Description

- Added `lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java` implementing conversions such as `toJavaLocalDate`, `fromJavaLocalDate`, `toJavaLocalTime`, `fromJavaLocalTime`, `toJavaOffsetTime`, `fromJavaOffsetTime`, `toJavaLocalDateTime`, `fromJavaLocalDateTime`, `toJavaOffsetDateTime`, and `fromJavaOffsetDateTime` with proper offset handling via `TimeModule.sECONDSINMINUTE`. 
- Added `lib/capybara-lib/src/test/java/dev/capylang/DateTimeUtilTest.java` containing JUnit 5 parameterized tests that validate round-trip conversions and the UTC fallback for times without offsets. 
- Added `org.assertj:assertj-core:3.27.6` as a `testImplementation` dependency in `lib/capybara-lib/build.gradle` to support fluent assertions in the tests.

### Testing

- Ran the module unit tests with `./gradlew :lib:capybara-lib:test`, and all new and existing tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75a44f7108320922998876fd90f99)