### PR TITLE
feat(#92): allow underscores in int and long literals

### DIFF
--- a/capy/src/e2e-tests/capybara/dev/capylang/test/Consts.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/Consts.cfun
@@ -49,3 +49,10 @@ fun animal_type_text(): string =
     match ANIMAL_TYPE with
     case Dog { name } -> "dog:" + name
     case Cat { age } -> "cat:" + age
+
+
+fun underscored_int_literal(): int = 100_000
+
+fun underscored_long_literal(): long = 9_738_771_718_7L
+
+fun underscored_literals_sum(): long = underscored_int_literal() + underscored_long_literal()

--- a/capy/src/e2e-tests/java/dev/capylang/test/ConstsTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/ConstsTest.java
@@ -45,4 +45,11 @@ class ConstsTest {
         assertThat(Consts.dogDataName()).isEqualTo("Rex");
         assertThat(Consts.animalTypeText()).isEqualTo("cat:7");
     }
+    @Test
+    void underscoredNumericLiterals() {
+        assertThat(Consts.underscoredIntLiteral()).isEqualTo(100_000);
+        assertThat(Consts.underscoredLongLiteral()).isEqualTo(97_387_717_187L);
+        assertThat(Consts.underscoredLiteralsSum()).isEqualTo(97_387_817_187L);
+    }
+
 }

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -161,11 +161,12 @@ methodArgument: namedMethodArgument | expression;
 namedMethodArgument: identifier COLON expression;
 literal: BYTE_LITERAL | LONG_LITERAL | DOUBLE_LITERAL | INT_LITERAL | BOOL_LITERAL | STRING_LITERAL | FLOAT_LITERAL | NOTHING_LITERAL | REGEX_LITERAL;
 BYTE_LITERAL: '0' [xX] [0-9a-fA-F]+;
-LONG_LITERAL: [0-9]+ [lL];
+LONG_LITERAL: DECIMAL_DIGITS [lL];
 DOUBLE_LITERAL: ([0-9]+ '.' [0-9]* EXPONENT? | [0-9]+ EXPONENT) [dD]?;
 FLOAT_LITERAL: ([0-9]+ '.' [0-9]* EXPONENT? | [0-9]+ EXPONENT) [fF];
-INT_LITERAL: [0-9]+;
-fragment EXPONENT: [eE] [+\-]? [0-9]+;
+INT_LITERAL: DECIMAL_DIGITS;
+fragment EXPONENT: [eE] [+\-]? DECIMAL_DIGITS;
+fragment DECIMAL_DIGITS: [0-9] ([0-9_]* [0-9])?;
 STRING_LITERAL
     : '"' (~["\\\r\n] | '\\' .)* '"'
     | '\'' (~['\\\r\n] | '\\' .)* '\''

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -165,7 +165,7 @@ LONG_LITERAL: DECIMAL_DIGITS [lL];
 DOUBLE_LITERAL: ([0-9]+ '.' [0-9]* EXPONENT? | [0-9]+ EXPONENT) [dD]?;
 FLOAT_LITERAL: ([0-9]+ '.' [0-9]* EXPONENT? | [0-9]+ EXPONENT) [fF];
 INT_LITERAL: DECIMAL_DIGITS;
-fragment EXPONENT: [eE] [+\-]? DECIMAL_DIGITS;
+fragment EXPONENT: [eE] [+\-]? [0-9]+;
 fragment DECIMAL_DIGITS: [0-9] ([0-9_]* [0-9])?;
 STRING_LITERAL
     : '"' (~["\\\r\n] | '\\' .)* '"'

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -4733,7 +4733,8 @@ public class CapybaraExpressionCompiler {
 
     private Result<CompiledExpression> linkIntValue(IntValue intValue, Scope scope) {
         try {
-            var parsed = new BigInteger(intValue.intValue(), 10);
+            var normalized = intValue.intValue().replace("_", "");
+            var parsed = new BigInteger(normalized, 10);
             if (parsed.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0
                 || parsed.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0) {
                 return withPosition(Result.error("Int literal out of range: `" + intValue.intValue() + "`"), intValue.position());
@@ -4750,6 +4751,7 @@ public class CapybaraExpressionCompiler {
             var normalized = raw.endsWith("l") || raw.endsWith("L")
                     ? raw.substring(0, raw.length() - 1)
                     : raw;
+            normalized = normalized.replace("_", "");
             var parsed = new BigInteger(normalized, 10);
             if (parsed.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0
                 || parsed.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) {

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -284,6 +284,24 @@ class CapybaraParserTest {
         assertThat(function.expression()).isInstanceOf(FloatValue.class);
     }
 
+
+    @Test
+    @DisplayName("should parse underscored int and long literals")
+    void parseUnderscoredIntAndLongLiterals() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun i(): int = 100_000
+                fun l(): long = 9_738_771_718_7L
+                """));
+
+        var intFunction = findFunction("i", module.functional());
+        assertThat(intFunction.expression()).isInstanceOf(IntValue.class);
+        assertThat(((IntValue) intFunction.expression()).intValue()).isEqualTo("100_000");
+
+        var longFunction = findFunction("l", module.functional());
+        assertThat(longFunction.expression()).isInstanceOf(LongValue.class);
+        assertThat(((LongValue) longFunction.expression()).longValue()).isEqualTo("9_738_771_718_7L");
+    }
+
     @Test
     @DisplayName("should parse regex literal into runtime factory call")
     void parseRegexLiteral() {


### PR DESCRIPTION
### Motivation
- Improve readability of large numeric literals by allowing underscore (`_`) separators in `int` and `long` literals (e.g. `100_000`, `9_738_771_718_7L`).

### Description
- Updated lexer in `compiler/src/main/antlr/Functional.g4` to introduce `DECIMAL_DIGITS` and make `INT_LITERAL` and `LONG_LITERAL` accept grouped digits with optional underscores. 
- Normalization added to `compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java` to strip underscores before `BigInteger` parsing for range and validity checks while preserving the original literal text for codegen and diagnostics. 
- Added parser test `parseUnderscoredIntAndLongLiterals` in `compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java` to assert underscored `int` and `long` literals are parsed and retained as literal text. 
- Impacted module: `compiler` (grammar, literal linking/validation, parser tests). 

### Testing
- Ran parser and expression-compiler unit tests with `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest --tests dev.capylang.compiler.expression.CapybaraExpressionCompilerTest`, which completed successfully. 
- Ran parser-only tests with `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest`, which completed successfully. 
- The new parser test `parseUnderscoredIntAndLongLiterals` passed as part of the above runs. 

Sample .cfun snippet
```
fun i(): int = 100_000
fun l(): long = 9_738_771_718_7L
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2048363588320a10352c8b59e33e4)