### PR TITLE
feat(#94): add numeric comparison assertions for int/long/float/double

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -99,6 +99,43 @@ fun IntAssert.is_equal_to(other: int): IntAssert =
         assertions: this.assertions + () => assertion
     }
 
+fun IntAssert.is_greater_than(other: int): IntAssert =
+    let assertion = Assertion {
+        result: this.value > other,
+        message: "Expected int:\n" + this.value + "\nto be greater than:\n" + other,
+        type: 'IntAssert.is_greater_than'
+    }
+    IntAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun IntAssert.is_less_than(other: int): IntAssert =
+    let assertion = Assertion {
+        result: this.value < other,
+        message: "Expected int:\n" + this.value + "\nto be less than:\n" + other,
+        type: 'IntAssert.is_less_than'
+    }
+    IntAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun IntAssert.is_greater_or_equals_than(other: int): IntAssert =
+    let assertion = Assertion {
+        result: this.value >= other,
+        message: "Expected int:\n" + this.value + "\nto be greater than or equal to:\n" + other,
+        type: 'IntAssert.is_greater_or_equals_than'
+    }
+    IntAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun IntAssert.is_less_or_equals_than(other: int): IntAssert =
+    let assertion = Assertion {
+        result: this.value <= other,
+        message: "Expected int:\n" + this.value + "\nto be less than or equal to:\n" + other,
+        type: 'IntAssert.is_less_or_equals_than'
+    }
+    IntAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun IntAssert.is_zero(): IntAssert = this.is_equal_to(0)
+fun IntAssert.is_one(): IntAssert = this.is_equal_to(1)
+fun IntAssert.is_between(start: int, end: int): IntAssert =
+    this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
+
 fun LongAssert.is_equal_to(other: long): LongAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -109,6 +146,43 @@ fun LongAssert.is_equal_to(other: long): LongAssert =
         value: this.value,
         assertions: this.assertions + () => assertion
     }
+
+fun LongAssert.is_greater_than(other: long): LongAssert =
+    let assertion = Assertion {
+        result: this.value > other,
+        message: "Expected long:\n" + this.value + "\nto be greater than:\n" + other,
+        type: 'LongAssert.is_greater_than'
+    }
+    LongAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun LongAssert.is_less_than(other: long): LongAssert =
+    let assertion = Assertion {
+        result: this.value < other,
+        message: "Expected long:\n" + this.value + "\nto be less than:\n" + other,
+        type: 'LongAssert.is_less_than'
+    }
+    LongAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun LongAssert.is_greater_or_equals_than(other: long): LongAssert =
+    let assertion = Assertion {
+        result: this.value >= other,
+        message: "Expected long:\n" + this.value + "\nto be greater than or equal to:\n" + other,
+        type: 'LongAssert.is_greater_or_equals_than'
+    }
+    LongAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun LongAssert.is_less_or_equals_than(other: long): LongAssert =
+    let assertion = Assertion {
+        result: this.value <= other,
+        message: "Expected long:\n" + this.value + "\nto be less than or equal to:\n" + other,
+        type: 'LongAssert.is_less_or_equals_than'
+    }
+    LongAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun LongAssert.is_zero(): LongAssert = this.is_equal_to(0L)
+fun LongAssert.is_one(): LongAssert = this.is_equal_to(1L)
+fun LongAssert.is_between(start: long, end: long): LongAssert =
+    this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
 fun DoubleAssert.is_equal_to(other: double): DoubleAssert =
     let assertion = Assertion {
@@ -121,6 +195,43 @@ fun DoubleAssert.is_equal_to(other: double): DoubleAssert =
         assertions: this.assertions + () => assertion
     }
 
+fun DoubleAssert.is_greater_than(other: double): DoubleAssert =
+    let assertion = Assertion {
+        result: this.value > other,
+        message: "Expected double:\n" + this.value + "\nto be greater than:\n" + other,
+        type: 'DoubleAssert.is_greater_than'
+    }
+    DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun DoubleAssert.is_less_than(other: double): DoubleAssert =
+    let assertion = Assertion {
+        result: this.value < other,
+        message: "Expected double:\n" + this.value + "\nto be less than:\n" + other,
+        type: 'DoubleAssert.is_less_than'
+    }
+    DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun DoubleAssert.is_greater_or_equals_than(other: double): DoubleAssert =
+    let assertion = Assertion {
+        result: this.value >= other,
+        message: "Expected double:\n" + this.value + "\nto be greater than or equal to:\n" + other,
+        type: 'DoubleAssert.is_greater_or_equals_than'
+    }
+    DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun DoubleAssert.is_less_or_equals_than(other: double): DoubleAssert =
+    let assertion = Assertion {
+        result: this.value <= other,
+        message: "Expected double:\n" + this.value + "\nto be less than or equal to:\n" + other,
+        type: 'DoubleAssert.is_less_or_equals_than'
+    }
+    DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun DoubleAssert.is_zero(): DoubleAssert = this.is_equal_to(0.0)
+fun DoubleAssert.is_one(): DoubleAssert = this.is_equal_to(1.0)
+fun DoubleAssert.is_between(start: double, end: double): DoubleAssert =
+    this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
+
 fun FloatAssert.is_equal_to(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -131,6 +242,56 @@ fun FloatAssert.is_equal_to(other: float): FloatAssert =
         value: this.value,
         assertions: this.assertions + () => assertion
     }
+
+fun FloatAssert.is_greater_than(other: float): FloatAssert =
+    let assertion = Assertion {
+        result: this.value > other,
+        message: "Expected float:\n" + this.value + "\nto be greater than:\n" + other,
+        type: 'FloatAssert.is_greater_than'
+    }
+    FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun FloatAssert.is_less_than(other: float): FloatAssert =
+    let assertion = Assertion {
+        result: this.value < other,
+        message: "Expected float:\n" + this.value + "\nto be less than:\n" + other,
+        type: 'FloatAssert.is_less_than'
+    }
+    FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun FloatAssert.is_greater_or_equals_than(other: float): FloatAssert =
+    let assertion = Assertion {
+        result: this.value >= other,
+        message: "Expected float:\n" + this.value + "\nto be greater than or equal to:\n" + other,
+        type: 'FloatAssert.is_greater_or_equals_than'
+    }
+    FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun FloatAssert.is_less_or_equals_than(other: float): FloatAssert =
+    let assertion = Assertion {
+        result: this.value <= other,
+        message: "Expected float:\n" + this.value + "\nto be less than or equal to:\n" + other,
+        type: 'FloatAssert.is_less_or_equals_than'
+    }
+    FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun FloatAssert.is_zero(): FloatAssert =
+    let assertion = Assertion {
+        result: this.value == 0,
+        message: "Expected float:\n" + this.value + "\nto be equal to:\n0",
+        type: 'FloatAssert.is_zero'
+    }
+    FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+
+fun FloatAssert.is_one(): FloatAssert =
+    let assertion = Assertion {
+        result: this.value == 1,
+        message: "Expected float:\n" + this.value + "\nto be equal to:\n1",
+        type: 'FloatAssert.is_one'
+    }
+    FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+fun FloatAssert.is_between(start: float, end: float): FloatAssert =
+    this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
 fun BoolAssert.is_equal_to(other: bool): BoolAssert =
     let assertion = Assertion {

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -195,6 +195,17 @@ fun DoubleAssert.is_equal_to(other: double): DoubleAssert =
         assertions: this.assertions + () => assertion
     }
 
+fun DoubleAssert.is_equal_to(other: double, epsilon: double): DoubleAssert =
+    let assertion = Assertion {
+        result: if this.value >= other - epsilon then this.value <= other + epsilon else false,
+        message: "Expected double:\n" + this.value + "\nto be equal to:\n" + other + "\nwithin epsilon:\n" + epsilon,
+        type: 'DoubleAssert.is_equal_to'
+    }
+    DoubleAssert {
+        value: this.value,
+        assertions: this.assertions + () => assertion
+    }
+
 fun DoubleAssert.is_greater_than(other: double): DoubleAssert =
     let assertion = Assertion {
         result: this.value > other,
@@ -236,6 +247,17 @@ fun FloatAssert.is_equal_to(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value == other,
         message: "Expected float:\n" + this.value + "\nto be equal to:\n" + other,
+        type: 'FloatAssert.is_equal_to'
+    }
+    FloatAssert {
+        value: this.value,
+        assertions: this.assertions + () => assertion
+    }
+
+fun FloatAssert.is_equal_to(other: float, epsilon: float): FloatAssert =
+    let assertion = Assertion {
+        result: if this.value >= other - epsilon then this.value <= other + epsilon else false,
+        message: "Expected float:\n" + this.value + "\nto be equal to:\n" + other + "\nwithin epsilon:\n" + epsilon,
         type: 'FloatAssert.is_equal_to'
     }
     FloatAssert {

--- a/lib/capybara-lib/src/test/capybara/capy/test/DecimalAssertTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/test/DecimalAssertTest.cfun
@@ -36,6 +36,7 @@ fun should_assert_double_decimals(): Assert =
         assert_that(10.5).is_less_than(11.5),
         assert_that(10.5).is_greater_or_equals_than(10.5),
         assert_that(10.5).is_less_or_equals_than(10.5),
+        assert_that(10.5).is_equal_to(10.51, 0.02),
         assert_that(0.0).is_zero(),
         assert_that(1.0).is_one(),
         assert_that(10.5).is_between(9.5, 11.5),

--- a/lib/capybara-lib/src/test/capybara/capy/test/DecimalAssertTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/test/DecimalAssertTest.cfun
@@ -1,0 +1,42 @@
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+
+fun tests(): TestFile =
+    test_file("/capy/test/DecimalAssertTest.cfun", [
+        test("should assert int decimals", should_assert_int_decimals()),
+        test("should assert long decimals", should_assert_long_decimals()),
+        test("should assert double decimals", should_assert_double_decimals()),
+    ])
+
+fun should_assert_int_decimals(): Assert =
+    assert_all([
+        assert_that(10).is_greater_than(9),
+        assert_that(10).is_less_than(11),
+        assert_that(10).is_greater_or_equals_than(10),
+        assert_that(10).is_less_or_equals_than(10),
+        assert_that(0).is_zero(),
+        assert_that(1).is_one(),
+        assert_that(10).is_between(9, 11),
+    ])
+
+fun should_assert_long_decimals(): Assert =
+    assert_all([
+        assert_that(10L).is_greater_than(9L),
+        assert_that(10L).is_less_than(11L),
+        assert_that(10L).is_greater_or_equals_than(10L),
+        assert_that(10L).is_less_or_equals_than(10L),
+        assert_that(0L).is_zero(),
+        assert_that(1L).is_one(),
+        assert_that(10L).is_between(9L, 11L),
+    ])
+
+fun should_assert_double_decimals(): Assert =
+    assert_all([
+        assert_that(10.5).is_greater_than(9.5),
+        assert_that(10.5).is_less_than(11.5),
+        assert_that(10.5).is_greater_or_equals_than(10.5),
+        assert_that(10.5).is_less_or_equals_than(10.5),
+        assert_that(0.0).is_zero(),
+        assert_that(1.0).is_one(),
+        assert_that(10.5).is_between(9.5, 11.5),
+    ])

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/FloatAssertTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/FloatAssertTest.java
@@ -1,0 +1,23 @@
+package dev.capylang.test;
+
+import capy.test.Assert;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class FloatAssertTest {
+    @Test
+    void shouldSupportNumericComparisonAssertionsForFloat() {
+        var assertResult = Assert.assertAll(java.util.List.of(
+                Assert.assertThat(10.5f).isGreaterThan(9.5f),
+                Assert.assertThat(10.5f).isLessThan(11.5f),
+                Assert.assertThat(10.5f).isGreaterOrEqualsThan(10.5f),
+                Assert.assertThat(10.5f).isLessOrEqualsThan(10.5f),
+                Assert.assertThat(0f).isZero(),
+                Assert.assertThat(1f).isOne(),
+                Assert.assertThat(10.5f).isBetween(9.5f, 11.5f)
+        ));
+
+        assertFalse(assertResult.failed());
+    }
+}

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/FloatAssertTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/FloatAssertTest.java
@@ -13,6 +13,7 @@ class FloatAssertTest {
                 Assert.assertThat(10.5f).isLessThan(11.5f),
                 Assert.assertThat(10.5f).isGreaterOrEqualsThan(10.5f),
                 Assert.assertThat(10.5f).isLessOrEqualsThan(10.5f),
+                Assert.assertThat(10.5f).isEqualTo(10.51f, 0.02f),
                 Assert.assertThat(0f).isZero(),
                 Assert.assertThat(1f).isOne(),
                 Assert.assertThat(10.5f).isBetween(9.5f, 11.5f)


### PR DESCRIPTION
### Motivation
- Provide convenient, fluent assertions for numeric/decimal types so tests can express ordering and boundary checks (greater/less, zero/one, between) directly on `IntAssert`, `LongAssert`, `DoubleAssert`, and `FloatAssert` values.

### Description
- Added comparison and boundary assertion functions to `lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun` for `IntAssert`, `LongAssert`, `DoubleAssert`, and `FloatAssert`: `is_greater_than`, `is_less_than`, `is_greater_or_equals_than`, `is_less_or_equals_than`, `is_zero`, `is_one`, and `is_between`.
- Implemented `is_zero`/`is_one` for floats and doubles with appropriately-typed comparisons to avoid type-mismatch issues.
- Added a new Capybara test file `lib/capybara-lib/src/test/capybara/capy/test/DecimalAssertTest.cfun` that exercises the new assertions for `int`, `long`, and `double`/`float` flows.
- Sample usage: `assert_that(10).is_greater_than(9)`, `assert_that(10L).is_between(9L, 11L)`, `assert_that(0.0).is_zero()`.

### Testing
- Ran the Capybara library test task with `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :lib:capybara-lib:testCapybara`, and the build and test run completed successfully (`BUILD SUCCESSFUL`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f209bd20908320a71d28f60fe56af6)