### PR TITLE
feat(#100): support cfun rec tail recursion

### DIFF
--- a/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
+++ b/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
@@ -60,7 +60,7 @@
         <dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict>
       </array>
     </dict>
-    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|def|type|enum|data|single|const|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
+    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|type|enum|data|single|const|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
     <dict><key>name</key><string>keyword.operator.constructor.capybara</string><key>match</key><string>(?&lt;=\bconstructor\s*\{[^\n]*)\*(?=\s*\{)</string></dict>
     <dict><key>name</key><string>keyword.other.capybara</string><key>match</key><string>\\b(is_empty|size|to_int|to_long|to_double|to_float|to_bool)\\b</string></dict>
     <dict><key>name</key><string>support.type.primitive.capybara</string><key>match</key><string>\b(byte|int|long|float|double|bool|string|any|data|void|list|set|dict|tuple)(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
@@ -71,7 +71,7 @@
     <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)(__[A-Za-z0-9_]+)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)(__[A-Za-z0-9_]+)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -81,7 +81,7 @@
     </dict>
     <dict>
       <key>name</key><string>meta.function.documented.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -102,10 +102,10 @@
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
     <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(type|enum|data|single|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b(class|trait|interface)\s+(_*[A-Z][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun\s+(__[A-Za-z0-9_]+)</string></dict>
-    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+(__[A-Za-z0-9_]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:(__[A-Za-z0-9_]+)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(__[A-Za-z0-9_]+)\s*(?=\()</string></dict>

--- a/Intellij/syntaxes/Capybara.tmLanguage
+++ b/Intellij/syntaxes/Capybara.tmLanguage
@@ -60,7 +60,7 @@
         <dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict>
       </array>
     </dict>
-    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|def|type|enum|data|single|const|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
+    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|type|enum|data|single|const|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
     <dict><key>name</key><string>keyword.operator.constructor.capybara</string><key>match</key><string>(?&lt;=\bconstructor\s*\{[^\n]*)\*(?=\s*\{)</string></dict>
     <dict><key>name</key><string>keyword.other.capybara</string><key>match</key><string>\\b(is_empty|size|to_int|to_long|to_double|to_float|to_bool)\\b</string></dict>
     <dict><key>name</key><string>support.type.primitive.capybara</string><key>match</key><string>\b(byte|int|long|float|double|bool|string|any|data|void|list|set|dict|tuple)(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
@@ -71,7 +71,7 @@
     <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)(__[A-Za-z0-9_]+)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)(__[A-Za-z0-9_]+)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -81,7 +81,7 @@
     </dict>
     <dict>
       <key>name</key><string>meta.function.documented.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -102,10 +102,10 @@
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
     <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(type|enum|data|single|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b(class|trait|interface)\s+(_*[A-Z][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun\s+(__[A-Za-z0-9_]+)</string></dict>
-    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+(__[A-Za-z0-9_]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:(__[A-Za-z0-9_]+)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(__[A-Za-z0-9_]+)\s*(?=\()</string></dict>

--- a/Intellij/syntaxes/capybara.tmLanguage.json
+++ b/Intellij/syntaxes/capybara.tmLanguage.json
@@ -130,7 +130,7 @@
       "patterns": [
         {
           "name": "keyword.control.capybara",
-          "match": "\\b(fun|def|type|enum|data|single|const|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\\b"
+          "match": "\\b(fun|rec|def|type|enum|data|single|const|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\\b"
         },
         {
           "name": "keyword.operator.constructor.capybara",
@@ -166,7 +166,7 @@
       "patterns": [
         {
           "name": "meta.function.documented.private.capybara",
-          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun|def))(\\s+)(__[A-Za-z0-9_]+)",
+          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun(?:\\s+rec)?|def))(\\s+)(__[A-Za-z0-9_]+)",
           "captures": {
             "1": {
               "name": "comment.block.documentation.capybara"
@@ -181,7 +181,7 @@
         },
         {
           "name": "meta.function.documented.capybara",
-          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun|def))(\\s+)([A-Za-z_][A-Za-z0-9_]*)",
+          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun(?:\\s+rec)?|def))(\\s+)([A-Za-z_][A-Za-z0-9_]*)",
           "captures": {
             "1": {
               "name": "comment.block.documentation.capybara"
@@ -224,19 +224,19 @@
         },
         {
           "name": "entity.name.function.private.capybara",
-          "match": "\\bfun\\s+(__[A-Za-z0-9_]+)"
+          "match": "\\bfun(?:\\s+rec)?\\s+(__[A-Za-z0-9_]+)"
         },
         {
           "name": "entity.name.function.capybara",
-          "match": "\\bfun\\s+([A-Za-z_][A-Za-z0-9_]*)"
+          "match": "\\bfun(?:\\s+rec)?\\s+([A-Za-z_][A-Za-z0-9_]*)"
         },
         {
           "name": "meta.function.owner-generic.capybara",
-          "match": "\\b(fun)\\s+(_*[A-Z][A-Za-z0-9_]*\\[[^\\]]+\\])\\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)"
+          "match": "\\b(fun(?:\\s+rec)?)\\s+(_*[A-Z][A-Za-z0-9_]*\\[[^\\]]+\\])\\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)"
         },
         {
           "name": "meta.function.owner-infix.capybara",
-          "match": "\\b(fun)\\s+(_*[A-Z][A-Za-z0-9_]*)\\.([^]+)"
+          "match": "\\b(fun(?:\\s+rec)?)\\s+(_*[A-Z][A-Za-z0-9_]*)\\.([^]+)"
         },
         {
           "name": "entity.name.function.private.capybara",

--- a/adr/ADR-2026-04-29-cfun-rec-tail-recursion.md
+++ b/adr/ADR-2026-04-29-cfun-rec-tail-recursion.md
@@ -1,0 +1,28 @@
+# ADR-2026-04-29: `.cfun` `fun rec` Tail-Recursion Contract
+
+- Status: accepted
+- Deciders: Codex, repository maintainers
+- Date: 2026-04-29
+
+## Context
+
+Issue #100 introduces `.cfun` `fun rec` as an explicit recursion form with compiler checks and backend consequences.
+
+Without a dedicated marker, recursive intent and optimization expectations are implicit. That makes it hard to guarantee predictable lowering and diagnostics for recursion-heavy code.
+
+## Decision
+
+Capybara treats `fun rec` as a compiler-verified direct tail-recursion contract.
+
+- `rec` is declaration-local and only meaningful with `fun`.
+- The compiler validates direct tail-recursive shape for the declared function body.
+- Violations are rejected at compile time instead of silently compiling as ordinary recursion.
+- Java lowering for valid `fun rec` functions uses loop-style code generation rather than stack-growing self-calls.
+
+## Consequences
+
+Recursive performance intent is explicit in source, and invalid non-tail forms fail early.
+
+Java backend behavior becomes more predictable for approved tail-recursive declarations, with stack usage aligned to loop lowering.
+
+This ADR does not broaden recursion semantics beyond direct tail recursion and does not change non-`rec` function behavior.

--- a/adr/ADR-2026-04-29-cfun-rec-tail-recursion.md
+++ b/adr/ADR-2026-04-29-cfun-rec-tail-recursion.md
@@ -12,17 +12,19 @@ Without a dedicated marker, recursive intent and optimization expectations are i
 
 ## Decision
 
-Capybara treats `fun rec` as a compiler-verified direct tail-recursion contract.
+Capybara detects direct self-recursion for every function. It treats `fun rec` as a compiler-verified direct tail-recursion contract.
 
 - `rec` is declaration-local and only meaningful with `fun`.
-- The compiler validates direct tail-recursive shape for the declared function body.
-- Violations are rejected at compile time instead of silently compiling as ordinary recursion.
-- Java lowering for valid `fun rec` functions uses loop-style code generation rather than stack-growing self-calls.
+- The compiler records whether each function is directly recursive.
+- Functions whose direct self-recursive calls are all in tail position may use loop-style Java lowering, even without the `rec` marker.
+- `fun rec` validates direct tail-recursive shape for the declared function body.
+- `fun rec` violations are rejected at compile time instead of silently compiling as ordinary recursion.
+- Non-tail recursive functions without `rec` remain valid recursive functions and keep ordinary call-style Java lowering.
 
 ## Consequences
 
 Recursive performance intent is explicit in source, and invalid non-tail forms fail early.
 
-Java backend behavior becomes more predictable for approved tail-recursive declarations, with stack usage aligned to loop lowering.
+Java backend behavior becomes more predictable for tail-recursive functions, with stack usage aligned to loop lowering when the compiler can prove the direct self-recursive shape.
 
-This ADR does not broaden recursion semantics beyond direct tail recursion and does not change non-`rec` function behavior.
+This ADR does not broaden recursion semantics beyond direct self-recursion. The `rec` keyword remains the source-level assertion that recursion must be tail-recursive.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,3 +1,4 @@
 # Architecture Decision Records
 
 - [ADR-2026-04-14: Capybara OO v1 Frontend Boundary](ADR-2026-04-14-capybara-oo-v1.md)
+- [ADR-2026-04-29: `.cfun` `fun rec` Tail-Recursion Contract](ADR-2026-04-29-cfun-rec-tail-recursion.md)

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/ObjectOrientedFpInterop.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/ObjectOrientedFpInterop.cfun
@@ -1,6 +1,7 @@
 type InteropPet = InteropDog | InteropCat
 data InteropDog { name: string }
 data InteropCat { age: int }
+data RecInteropValue { value: int }
 
 fun make_dog(name: string): InteropDog = InteropDog { name: name }
 
@@ -8,3 +9,8 @@ fun pet_text(pet: InteropPet): string =
     match pet with
     case InteropDog { name } -> "dog:" + name
     case InteropCat { age } -> "cat:" + age
+
+fun RecInteropValue.step(delta: int): int = this.value + delta
+
+fun rec step(n: int, value: RecInteropValue, acc: int): int =
+    if n <= 0 then acc else step(n - 1, value, acc + value.step(n))

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/ObjectOrientedFpInterop.coo
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/ObjectOrientedFpInterop.coo
@@ -1,4 +1,4 @@
-from ObjectOrientedFpInterop import { InteropPet, InteropDog, InteropCat }
+from ObjectOrientedFpInterop import { InteropPet, InteropDog, InteropCat, RecInteropValue }
 
 class PetInteractor {
     def invoke_fp_function(name: string): string =
@@ -12,5 +12,10 @@ class PetInteractor {
         return match pet with
         case InteropDog { name } -> ("dog:" + name)
         case InteropCat { age } -> ("cat:" + age)
+    }
+
+    def invoke_rec_function(seed: int): int {
+        let value: RecInteropValue = RecInteropValue { value: seed }
+        return ObjectOrientedFpInterop.step(3, value, 0)
     }
 }

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/RecFunctions.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/RecFunctions.cfun
@@ -1,0 +1,43 @@
+from /capy/lang/Result import { Result, Success, Error }
+
+fun rec sum(n: int, acc: int): int =
+    if n <= 0 then acc else sum(n - 1, acc + n)
+
+fun sum_inner(n: int): int =
+    fun rec __sum(n: int, acc: int): int =
+        if n <= 0 then acc else __sum(n - 1, acc + n)
+    ---
+    __sum(n, 0)
+
+fun rec sum_with_let(n: int, acc: int): int =
+    let next_n = n - 1
+    let next_acc = acc + n
+    if n <= 0 then acc else sum_with_let(next_n, next_acc)
+
+fun rec sum_with_match(n: int, acc: int): int =
+    match n <= 0 with
+    case true -> acc
+    case false -> sum_with_match(n - 1, acc + n)
+
+fun rec count_down_large(n: int, acc: int): int =
+    if n <= 0 then acc else count_down_large(n - 1, acc + 1)
+
+fun rec sum_present_values(values: list[int], acc: int): int =
+    match values[0] with
+    case Some { value } -> sum_present_values(values[1:], acc + value)
+    case None -> acc
+
+private fun parse_length(value: string): Result[int] =
+    if value == "bad"
+    then Error { message: "bad length" }
+    else Success { value: value.size }
+
+fun rec sum_lengths_until_error(values: list[string], acc: int): string =
+    match values[0] with
+    case Some { value } ->
+        {
+            match parse_length(value) with
+            case Success { length } -> sum_lengths_until_error(values[1:], acc + length)
+            case Error { message } -> "error:" + message + ":" + acc
+        }
+    case None -> "ok:" + acc

--- a/capy/src/e2e-tests/capybara/dev/capylang/test/RecFunctions.cfun
+++ b/capy/src/e2e-tests/capybara/dev/capylang/test/RecFunctions.cfun
@@ -19,8 +19,29 @@ fun rec sum_with_match(n: int, acc: int): int =
     case true -> acc
     case false -> sum_with_match(n - 1, acc + n)
 
-fun rec count_down_large(n: int, acc: int): int =
-    if n <= 0 then acc else count_down_large(n - 1, acc + 1)
+fun rec factorial_large(n: int, acc: int): int =
+    if n <= 1 then acc else factorial_large(n - 1, acc * n)
+
+fun unmarked_tail_sum(n: int, acc: int): int =
+    if n <= 0 then acc else unmarked_tail_sum(n - 1, acc + n)
+
+fun unmarked_tail_factorial_large(n: int, acc: int): int =
+    if n <= 1 then acc else unmarked_tail_factorial_large(n - 1, acc * n)
+
+fun unmarked_local_tail_sum(n: int): int =
+    fun __sum(n: int, acc: int): int =
+        if n <= 0 then acc else __sum(n - 1, acc + n)
+    ---
+    __sum(n, 0)
+
+fun unmarked_local_tail_factorial_large(n: int): int =
+    fun __factorial(n: int, acc: int): int =
+        if n <= 1 then acc else __factorial(n - 1, acc * n)
+    ---
+    __factorial(n, 1)
+
+fun unmarked_non_tail_sum(n: int): int =
+    if n <= 0 then 0 else n + unmarked_non_tail_sum(n - 1)
 
 fun rec sum_present_values(values: list[int], acc: int): int =
     match values[0] with

--- a/capy/src/e2e-tests/java/dev/capylang/test/ObjectOrientedFpInteropTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/ObjectOrientedFpInteropTest.java
@@ -13,5 +13,6 @@ class ObjectOrientedFpInteropTest {
         assertThat(interactor.create_fp_data("Bara")).isInstanceOf(ObjectOrientedFpInterop.InteropDog.class);
         assertThat(((ObjectOrientedFpInterop.InteropDog) interactor.create_fp_data("Bara")).name()).isEqualTo("Bara");
         assertThat(interactor.match_fp_type("Mochi")).isEqualTo("dog:Mochi");
+        assertThat(interactor.invoke_rec_function(10)).isEqualTo(36);
     }
 }

--- a/capy/src/e2e-tests/java/dev/capylang/test/RecFunctionsTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/RecFunctionsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class RecFunctionsTest {
     @Test
@@ -25,7 +26,19 @@ class RecFunctionsTest {
 
     @Test
     void tailRecursiveFunctionIsLoweredWithoutJavaStackGrowth() {
-        assertThat(RecFunctions.countDownLarge(50_000, 0)).isEqualTo(50_000);
+        assertThat(RecFunctions.factorialLarge(5, 1)).isEqualTo(120);
+        assertThatCode(() -> RecFunctions.factorialLarge(50_000, 1)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void unmarkedRecursiveFunctionsStillCompileAndRun() {
+        assertThat(RecFunctions.unmarkedTailSum(5, 0)).isEqualTo(15);
+        assertThat(RecFunctions.unmarkedTailFactorialLarge(5, 1)).isEqualTo(120);
+        assertThatCode(() -> RecFunctions.unmarkedTailFactorialLarge(50_000, 1)).doesNotThrowAnyException();
+        assertThat(RecFunctions.unmarkedLocalTailSum(5)).isEqualTo(15);
+        assertThat(RecFunctions.unmarkedLocalTailFactorialLarge(5)).isEqualTo(120);
+        assertThatCode(() -> RecFunctions.unmarkedLocalTailFactorialLarge(50_000)).doesNotThrowAnyException();
+        assertThat(RecFunctions.unmarkedNonTailSum(5)).isEqualTo(15);
     }
 
     @Test

--- a/capy/src/e2e-tests/java/dev/capylang/test/RecFunctionsTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/RecFunctionsTest.java
@@ -1,0 +1,38 @@
+package dev.capylang.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecFunctionsTest {
+    @Test
+    void tailRecursiveTopLevelFunctionWorks() {
+        assertThat(RecFunctions.sum(5, 0)).isEqualTo(15);
+    }
+
+    @Test
+    void tailRecursiveLocalFunctionWorks() {
+        assertThat(RecFunctions.sumInner(5)).isEqualTo(15);
+    }
+
+    @Test
+    void tailRecursiveFunctionSupportsLetAndMatchTailPositions() {
+        assertThat(RecFunctions.sumWithLet(5, 0)).isEqualTo(15);
+        assertThat(RecFunctions.sumWithMatch(5, 0)).isEqualTo(15);
+    }
+
+    @Test
+    void tailRecursiveFunctionIsLoweredWithoutJavaStackGrowth() {
+        assertThat(RecFunctions.countDownLarge(50_000, 0)).isEqualTo(50_000);
+    }
+
+    @Test
+    void tailRecursiveMatchPreservesOptionAndResultBindings() {
+        assertThat(RecFunctions.sumPresentValues(List.of(1, 2, 3), 0)).isEqualTo(6);
+        assertThat(RecFunctions.sumLengthsUntilError(List.of("a", "bb", "bad", "cccc"), 0))
+                .isEqualTo("error:bad length:3");
+        assertThat(RecFunctions.sumLengthsUntilError(List.of("a", "bb", "ccc"), 0)).isEqualTo("ok:6");
+    }
+}

--- a/capy/src/e2e-tests/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-tests/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -208,6 +208,62 @@ public class CompilationErrorTest {
     }
 
     @Test
+    void shouldRejectRecFunctionWithNonTailRecursiveCall() {
+        var errors = compileProgram("""
+                        fun rec sum(n: int): int = n + sum(n - 1)
+                        """,
+                "rec_function_non_tail_call");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Recursive call to `sum` is not in tail position");
+    }
+
+    @Test
+    void shouldRejectRecFunctionWithoutSelfCall() {
+        var errors = compileProgram("""
+                        fun rec sum(n: int): int = n - 1
+                        """,
+                "rec_function_without_self_call");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("`fun rec` function `sum` must call itself in tail position");
+    }
+
+    @Test
+    void shouldRejectRecLocalFunctionWithNonTailRecursiveCall() {
+        var errors = compileProgram("""
+                        fun sum(n: int): int =
+                            fun rec __sum(n: int): int = n + __sum(n - 1)
+                            ---
+                            __sum(n)
+                        """,
+                "rec_local_function_non_tail_call");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Recursive call to `sum` is not in tail position")
+                .doesNotContain("__local_fun_");
+    }
+
+    @Test
+    void shouldRejectRecLocalFunctionWithoutSelfCall() {
+        var errors = compileProgram("""
+                        fun sum(n: int): int =
+                            fun rec __sum(n: int): int = n - 1
+                            ---
+                            __sum(n)
+                        """,
+                "rec_local_function_without_self_call");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("`fun rec` function `sum` must call itself in tail position")
+                .doesNotContain("__local_fun_");
+    }
+
+    @Test
     void shouldRejectLongReturnedWhereIntIsExpected() {
         var errors = compileProgram("""
                         fun broken(): int = 1L

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -14,14 +14,18 @@ definition:
     | singleDeclaration
     | constDeclaration;
 
-functionDeclaration: docComment* VISIBILITY? 'fun' functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody;
+functionDeclaration: docComment* VISIBILITY? 'fun' recFunctionMarker functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody
+                   | docComment* VISIBILITY? 'fun' functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody;
+recFunctionMarker: REC;
 functionBody: expression
             | localDefinition+ '---' expression;
 localDefinition: localFunctionDeclaration
                | localTypeDeclaration
                | localDataDeclaration
                | localConstDeclaration;
-localFunctionDeclaration: docComment* 'fun' NAME '(' parameters? ')' functionType? '=' expression;
+localFunctionDeclaration: docComment* 'fun' recFunctionMarker localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression
+                        | docComment* 'fun' localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression;
+localFunctionNameDeclaration: NAME | REC;
 localTypeDeclaration: 'type' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*
                     | 'type' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*;
 localDataDeclaration: 'data' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause?
@@ -49,8 +53,9 @@ genericTypeDeclaration: TYPE ('[' TYPE (',' TYPE)* ']')?;
 VISIBILITY: 'local' | 'private';
 BOOL_LITERAL: 'true' | 'false';
 COLLECTION: 'list' | 'set' | 'dict';
+REC: 'rec';
 NAME : [_]* [a-z] [a-zA-Z0-9_]*;
-identifier: NAME | COLLECTION | 'fun' | 'type' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'string' | 'float' | 'nothing' | 'any';
+identifier: NAME | REC | COLLECTION | 'fun' | 'type' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'string' | 'float' | 'nothing' | 'any';
 parameters: parameter (',' parameter)*;
 parameter: identifier ':' type;
 functionType: ':' type;
@@ -142,6 +147,7 @@ tupleLiteral: LPAREN expression (COMMA expression)+ RPAREN;
 ifExpression: 'if' expression 'then' expression 'else' expression;
 functionReference: COLON identifier;
 functionCall: NAME '(' argumentList? ')'
+            | REC '(' argumentList? ')'
             | COLLECTION '(' argumentList? ')'
             | 'fun' '(' argumentList? ')'
             | 'byte' '(' argumentList? ')'

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -2107,21 +2107,22 @@ public class CapybaraCompiler {
                                 .map(type -> linkType(type, dataTypes, functionGenericTypeNames, compileCache))
                                 .orElseGet(() -> Result.success(validatedExpression.type()))
                                 .flatMap(rtype -> validateFunctionReturnType(function, validatedExpression, rtype, dataTypes, moduleSourceFile)
-                                        .flatMap(finalExpression -> validateTailRecursiveFunction(
+                                        .flatMap(finalExpression -> classifyRecursion(
                                                 function,
-                                                finalExpression,
                                                 parameters,
+                                                finalExpression,
                                                 tailRecursiveSelfCallNames(function.name(), moduleSourceFile, moduleClassNameByModuleName),
                                                 moduleSourceFile
-                                        ).map(tailValidatedExpression -> new CompiledFunction(
+                                        ).map(recursion -> new CompiledFunction(
                                                 function.name(),
                                                 rtype,
                                                 parameters,
-                                                enrichNothing(tailValidatedExpression, function.name(), moduleSourceFile),
+                                                enrichNothing(finalExpression, function.name(), moduleSourceFile),
                                                 function.comments(),
                                                 function.visibility(),
                                                 isProgramMain(function.name(), rtype, parameters),
-                                                function.tailRecursive()
+                                                recursion.recursive(),
+                                                recursion.tailRecursive()
                                         )))))));
         linked = normalizeInfixOperatorErrors(linked, function, moduleSourceFile);
         linked = normalizeMatchExhaustivenessErrors(linked, function, moduleSourceFile);
@@ -2133,46 +2134,55 @@ public class CapybaraCompiler {
         return normalizeReadableFunctionErrors(linked, function, moduleSourceFile);
     }
 
-    private Result<CompiledExpression> validateTailRecursiveFunction(
+    private Result<RecursionClassification> classifyRecursion(
             Function function,
-            CompiledExpression expression,
             List<CompiledFunctionParameter> parameters,
+            CompiledExpression expression,
             Set<String> selfCallNames,
             String moduleSourceFile
     ) {
-        if (!function.tailRecursive()) {
-            return Result.success(expression);
-        }
+        var analysis = analyzeTailRecursion(selfCallNames, parameters, expression, true);
         if (methodOwnerType(function.name()).isPresent()) {
-            return tailRecursiveFunctionError(
-                    function,
-                    function.position(),
-                    moduleSourceFile,
-                    "`fun rec` is supported for functions, not type methods"
-            );
+            if (function.tailRecursive()) {
+                return tailRecursiveFunctionError(
+                        function,
+                        function.position(),
+                        moduleSourceFile,
+                        "`fun rec` is supported for functions, not type methods"
+                );
+            }
+            return Result.success(new RecursionClassification(analysis.hasSelfCall(), false));
         }
 
-        var analysis = analyzeTailRecursion(selfCallNames, parameters, expression, true);
         if (analysis.firstNonTailCall().isPresent()) {
-            return tailRecursiveFunctionError(
-                    function,
-                    function.position(),
-                    moduleSourceFile,
-                    "Recursive call to `" + displayFunctionName(function.name()) + "` is not in tail position"
-            );
+            if (function.tailRecursive()) {
+                return tailRecursiveFunctionError(
+                        function,
+                        function.position(),
+                        moduleSourceFile,
+                        "Recursive call to `" + displayFunctionName(function.name()) + "` is not in tail position"
+                );
+            }
+            return Result.success(new RecursionClassification(true, false));
         }
         if (!analysis.hasSelfCall()) {
-            return tailRecursiveFunctionError(
-                    function,
-                    function.position(),
-                    moduleSourceFile,
-                    "`fun rec` function `" + displayFunctionName(function.name()) + "` must call itself in tail position"
-            );
+            if (function.tailRecursive()) {
+                return tailRecursiveFunctionError(
+                        function,
+                        function.position(),
+                        moduleSourceFile,
+                        "`fun rec` function `" + displayFunctionName(function.name()) + "` must call itself in tail position"
+                );
+            }
+            return Result.success(new RecursionClassification(false, false));
         }
-        return Result.success(expression);
+        return Result.success(new RecursionClassification(true, true));
     }
 
-    private Result<CompiledExpression> tailRecursiveFunctionError(
+    private record RecursionClassification(boolean recursive, boolean tailRecursive) {
+    }
+
+    private <T> Result<T> tailRecursiveFunctionError(
             Function function,
             Optional<SourcePosition> position,
             String moduleSourceFile,

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import dev.capylang.compiler.CompiledFunction.CompiledFunctionParameter;
 import dev.capylang.compiler.expression.CapybaraExpressionCompiler;
+import dev.capylang.compiler.expression.*;
 import dev.capylang.compiler.parser.*;
 import dev.capylang.compiler.parser.Module;
 
@@ -2106,15 +2107,22 @@ public class CapybaraCompiler {
                                 .map(type -> linkType(type, dataTypes, functionGenericTypeNames, compileCache))
                                 .orElseGet(() -> Result.success(validatedExpression.type()))
                                 .flatMap(rtype -> validateFunctionReturnType(function, validatedExpression, rtype, dataTypes, moduleSourceFile)
-                                        .map(finalExpression -> new CompiledFunction(
+                                        .flatMap(finalExpression -> validateTailRecursiveFunction(
+                                                function,
+                                                finalExpression,
+                                                parameters,
+                                                tailRecursiveSelfCallNames(function.name(), moduleSourceFile, moduleClassNameByModuleName),
+                                                moduleSourceFile
+                                        ).map(tailValidatedExpression -> new CompiledFunction(
                                                 function.name(),
                                                 rtype,
                                                 parameters,
-                                                enrichNothing(finalExpression, function.name(), moduleSourceFile),
+                                                enrichNothing(tailValidatedExpression, function.name(), moduleSourceFile),
                                                 function.comments(),
                                                 function.visibility(),
-                                                isProgramMain(function.name(), rtype, parameters)
-                                        ))))));
+                                                isProgramMain(function.name(), rtype, parameters),
+                                                function.tailRecursive()
+                                        )))))));
         linked = normalizeInfixOperatorErrors(linked, function, moduleSourceFile);
         linked = normalizeMatchExhaustivenessErrors(linked, function, moduleSourceFile);
         linked = normalizeIntLiteralErrors(linked, function, moduleSourceFile);
@@ -2123,6 +2131,265 @@ public class CapybaraCompiler {
         var fallbackPosition = returnExpressionPosition(function.expression()).or(() -> function.position());
         linked = withPosition(linked, fallbackPosition, normalizedFile);
         return normalizeReadableFunctionErrors(linked, function, moduleSourceFile);
+    }
+
+    private Result<CompiledExpression> validateTailRecursiveFunction(
+            Function function,
+            CompiledExpression expression,
+            List<CompiledFunctionParameter> parameters,
+            Set<String> selfCallNames,
+            String moduleSourceFile
+    ) {
+        if (!function.tailRecursive()) {
+            return Result.success(expression);
+        }
+        if (methodOwnerType(function.name()).isPresent()) {
+            return tailRecursiveFunctionError(
+                    function,
+                    function.position(),
+                    moduleSourceFile,
+                    "`fun rec` is supported for functions, not type methods"
+            );
+        }
+
+        var analysis = analyzeTailRecursion(selfCallNames, parameters, expression, true);
+        if (analysis.firstNonTailCall().isPresent()) {
+            return tailRecursiveFunctionError(
+                    function,
+                    function.position(),
+                    moduleSourceFile,
+                    "Recursive call to `" + displayFunctionName(function.name()) + "` is not in tail position"
+            );
+        }
+        if (!analysis.hasSelfCall()) {
+            return tailRecursiveFunctionError(
+                    function,
+                    function.position(),
+                    moduleSourceFile,
+                    "`fun rec` function `" + displayFunctionName(function.name()) + "` must call itself in tail position"
+            );
+        }
+        return Result.success(expression);
+    }
+
+    private Result<CompiledExpression> tailRecursiveFunctionError(
+            Function function,
+            Optional<SourcePosition> position,
+            String moduleSourceFile,
+            String details
+    ) {
+        var sourcePosition = position.or(() -> function.position()).orElse(SourcePosition.EMPTY);
+        var line = Math.max(sourcePosition.line(), 1);
+        var column = Math.max(sourcePosition.column(), 0);
+        var file = normalizeFile(moduleSourceFile);
+        var functionLine = function.position().map(SourcePosition::line).orElse(line);
+        var functionPreview = functionLine == line
+                ? formatFunctionHeaderAndExpression(function, formatExpressionPreviewWithSpaces(function.expression()))
+                : formatFunctionPreviewUpToLine(function, line);
+        var message = "error: mismatched types\n"
+                      + " --> " + file + ":" + line + ":" + column + "\n"
+                      + functionPreview + "\n"
+                      + " ".repeat(Math.max(column, 0)) + "^ " + details + "\n";
+        var error = new Result.Error.SingleError(line, column, file, message);
+        return new Result.Error<>(List.of(error));
+    }
+
+    private TailRecursionAnalysis analyzeTailRecursion(
+            Set<String> selfCallNames,
+            List<CompiledFunctionParameter> parameters,
+            CompiledExpression expression,
+            boolean tailPosition
+    ) {
+        return switch (expression) {
+            case CompiledFunctionCall functionCall -> {
+                var result = TailRecursionAnalysis.empty();
+                var selfCall = isDirectSelfCall(selfCallNames, parameters, functionCall);
+                if (selfCall) {
+                    result = tailPosition
+                            ? TailRecursionAnalysis.tailCall()
+                            : TailRecursionAnalysis.nonTailCall(functionCall);
+                }
+                yield merge(result, analyzeAll(selfCallNames, parameters, functionCall.arguments(), false));
+            }
+            case CompiledIfExpression ifExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, ifExpression.condition(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, ifExpression.thenBranch(), tailPosition),
+                    analyzeTailRecursion(selfCallNames, parameters, ifExpression.elseBranch(), tailPosition)
+            );
+            case CompiledLetExpression letExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, letExpression.value(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, letExpression.rest(), tailPosition)
+            );
+            case CompiledMatchExpression matchExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, matchExpression.matchWith(), false),
+                    merge(matchExpression.cases().stream()
+                            .map(matchCase -> merge(
+                                    matchCase.guard()
+                                            .map(guard -> analyzeTailRecursion(selfCallNames, parameters, guard, false))
+                                            .orElseGet(TailRecursionAnalysis::empty),
+                                    analyzeTailRecursion(selfCallNames, parameters, matchCase.expression(), tailPosition)
+                            ))
+                            .toList())
+            );
+            case CompiledFunctionInvoke functionInvoke -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, functionInvoke.function(), false),
+                    analyzeAll(selfCallNames, parameters, functionInvoke.arguments(), false)
+            );
+            case CompiledInfixExpression infixExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, infixExpression.left(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, infixExpression.right(), false)
+            );
+            case CompiledFieldAccess fieldAccess ->
+                    analyzeTailRecursion(selfCallNames, parameters, fieldAccess.source(), false);
+            case CompiledIndexExpression indexExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, indexExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, indexExpression.index(), false)
+            );
+            case CompiledSliceExpression sliceExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, sliceExpression.source(), false),
+                    sliceExpression.start()
+                            .map(start -> analyzeTailRecursion(selfCallNames, parameters, start, false))
+                            .orElseGet(TailRecursionAnalysis::empty),
+                    sliceExpression.end()
+                            .map(end -> analyzeTailRecursion(selfCallNames, parameters, end, false))
+                            .orElseGet(TailRecursionAnalysis::empty)
+            );
+            case CompiledLambdaExpression lambdaExpression ->
+                    analyzeTailRecursion(selfCallNames, parameters, lambdaExpression.expression(), false);
+            case CompiledEffectExpression effectExpression ->
+                    analyzeTailRecursion(selfCallNames, parameters, effectExpression.body(), false);
+            case CompiledEffectBindExpression effectBindExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, effectBindExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, effectBindExpression.rest(), false)
+            );
+            case CompiledPipeExpression pipeExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, pipeExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeExpression.mapper(), false)
+            );
+            case CompiledPipeFlatMapExpression pipeFlatMapExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, pipeFlatMapExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeFlatMapExpression.mapper(), false)
+            );
+            case CompiledPipeFilterOutExpression pipeFilterOutExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, pipeFilterOutExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeFilterOutExpression.predicate(), false)
+            );
+            case CompiledPipeAllExpression pipeAllExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, pipeAllExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeAllExpression.predicate(), false)
+            );
+            case CompiledPipeAnyExpression pipeAnyExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, pipeAnyExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeAnyExpression.predicate(), false)
+            );
+            case CompiledPipeReduceExpression pipeReduceExpression -> merge(
+                    analyzeTailRecursion(selfCallNames, parameters, pipeReduceExpression.source(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeReduceExpression.initialValue(), false),
+                    analyzeTailRecursion(selfCallNames, parameters, pipeReduceExpression.reducerExpression(), false)
+            );
+            case CompiledNumericWidening numericWidening ->
+                    analyzeTailRecursion(selfCallNames, parameters, numericWidening.expression(), false);
+            case CompiledNewData newData -> analyzeAll(
+                    selfCallNames,
+                    parameters,
+                    newData.assignments().stream().map(CompiledNewData.FieldAssignment::value).toList(),
+                    false
+            );
+            case CompiledNewList newList -> analyzeAll(selfCallNames, parameters, newList.values(), false);
+            case CompiledNewSet newSet -> analyzeAll(selfCallNames, parameters, newSet.values(), false);
+            case CompiledNewDict newDict -> merge(newDict.entries().stream()
+                    .map(entry -> merge(
+                            analyzeTailRecursion(selfCallNames, parameters, entry.key(), false),
+                            analyzeTailRecursion(selfCallNames, parameters, entry.value(), false)
+                    ))
+                    .toList());
+            case CompiledTupleExpression tupleExpression ->
+                    analyzeAll(selfCallNames, parameters, tupleExpression.values(), false);
+            case CompiledBooleanValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledByteValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledDoubleValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledFloatValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledIntValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledLongValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledNothingValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledStringValue ignored -> TailRecursionAnalysis.empty();
+            case CompiledVariable ignored -> TailRecursionAnalysis.empty();
+        };
+    }
+
+    private TailRecursionAnalysis analyzeAll(
+            Set<String> selfCallNames,
+            List<CompiledFunctionParameter> parameters,
+            List<CompiledExpression> expressions,
+            boolean tailPosition
+    ) {
+        return merge(expressions.stream()
+                .map(expression -> analyzeTailRecursion(selfCallNames, parameters, expression, tailPosition))
+                .toList());
+    }
+
+    private boolean isDirectSelfCall(
+            Set<String> selfCallNames,
+            List<CompiledFunctionParameter> parameters,
+            CompiledFunctionCall functionCall
+    ) {
+        if (!selfCallNames.contains(functionCall.name()) || functionCall.arguments().size() != parameters.size()) {
+            return false;
+        }
+        for (int i = 0; i < parameters.size(); i++) {
+            if (!functionCall.arguments().get(i).type().equals(parameters.get(i).type())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Set<String> tailRecursiveSelfCallNames(
+            String functionName,
+            String moduleSourceFile,
+            Map<String, String> moduleClassNameByModuleName
+    ) {
+        var names = new LinkedHashSet<String>();
+        names.add(functionName);
+        var qualifiedModuleName = qualifiedModuleNameFromSourceFile(moduleSourceFile);
+        if (qualifiedModuleName.startsWith("/")) {
+            qualifiedModuleName = qualifiedModuleName.substring(1);
+        }
+        var className = moduleClassNameByModuleName.get(qualifiedModuleName);
+        if (className != null) {
+            names.add(className + "." + functionName);
+        }
+        return Set.copyOf(names);
+    }
+
+    private TailRecursionAnalysis merge(TailRecursionAnalysis... analyses) {
+        return merge(List.of(analyses));
+    }
+
+    private TailRecursionAnalysis merge(List<TailRecursionAnalysis> analyses) {
+        var hasSelfCall = false;
+        Optional<CompiledFunctionCall> firstNonTailCall = Optional.empty();
+        for (var analysis : analyses) {
+            hasSelfCall = hasSelfCall || analysis.hasSelfCall();
+            if (firstNonTailCall.isEmpty()) {
+                firstNonTailCall = analysis.firstNonTailCall();
+            }
+        }
+        return new TailRecursionAnalysis(hasSelfCall, firstNonTailCall);
+    }
+
+    private record TailRecursionAnalysis(boolean hasSelfCall, Optional<CompiledFunctionCall> firstNonTailCall) {
+        private static TailRecursionAnalysis empty() {
+            return new TailRecursionAnalysis(false, Optional.empty());
+        }
+
+        private static TailRecursionAnalysis tailCall() {
+            return new TailRecursionAnalysis(true, Optional.empty());
+        }
+
+        private static TailRecursionAnalysis nonTailCall(CompiledFunctionCall call) {
+            return new TailRecursionAnalysis(true, Optional.of(call));
+        }
     }
 
     private Result<dev.capylang.compiler.expression.CompiledExpression> validateConstructorReturnType(
@@ -2546,7 +2813,7 @@ public class CapybaraCompiler {
         if (function.expression() instanceof LetExpression && expressionPosition.line() != position.line()) {
             return formatMultilineFunctionPreview(function, declaredReturnType);
         }
-        return "fun " + displayFunctionName(function.name())
+        return functionKeyword(function) + " " + displayFunctionName(function.name())
                + "(" + function.parameters().stream()
                        .map(parameter -> parameter.name() + ": " + formatParserTypeInHeader(parameter.type()))
                        .collect(java.util.stream.Collectors.joining(", "))
@@ -2566,7 +2833,8 @@ public class CapybaraCompiler {
         var methodHeaderName = methodDeclaration
                 .map(this::formatMethodDeclarationName)
                 .orElse(displayFunctionName(function.name()));
-        var header = new StringBuilder("fun ")
+        var header = new StringBuilder(functionKeyword(function))
+                .append(" ")
                 .append(methodHeaderName)
                 .append("(")
                 .append(methodParameters.stream()
@@ -2575,6 +2843,10 @@ public class CapybaraCompiler {
                 .append(")");
         function.returnType().ifPresent(type -> header.append(": ").append(formatParserTypeInHeader(type)));
         return header.toString();
+    }
+
+    private String functionKeyword(Function function) {
+        return function.tailRecursive() ? "fun rec" : "fun";
     }
 
     private int methodDeclarationErrorLine(Function function) {
@@ -2669,7 +2941,9 @@ public class CapybaraCompiler {
 
     private String formatMultilineFunctionPreview(Function function, CompiledType declaredReturnType) {
         var builder = new StringBuilder();
-        builder.append("  fun ")
+        builder.append("  ")
+                .append(functionKeyword(function))
+                .append(" ")
                 .append(displayFunctionName(function.name()))
                 .append("(")
                 .append(function.parameters().stream()
@@ -4111,7 +4385,8 @@ public class CapybaraCompiler {
     }
 
     private String formatFunctionHeaderWithRestoredPrivateTypes(Function function) {
-        var header = new StringBuilder("fun ")
+        var header = new StringBuilder(functionKeyword(function))
+                .append(" ")
                 .append(displayFunctionName(function.name()))
                 .append("(")
                 .append(function.parameters().stream()

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledFunction.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledFunction.java
@@ -12,13 +12,14 @@ public record CompiledFunction(String name,
                              List<String> comments,
                              Visibility visibility,
                              boolean programMain,
+                             boolean recursive,
                              boolean tailRecursive) implements Comparable<CompiledFunction> {
     public CompiledFunction(String name,
                           CompiledType returnType,
                           List<CompiledFunctionParameter> parameters,
                           CompiledExpression expression,
                           List<String> comments) {
-        this(name, returnType, parameters, expression, comments, null, false, false);
+        this(name, returnType, parameters, expression, comments, null, false, false, false);
     }
 
     public CompiledFunction(String name,
@@ -27,7 +28,7 @@ public record CompiledFunction(String name,
                             CompiledExpression expression,
                             List<String> comments,
                             boolean programMain) {
-        this(name, returnType, parameters, expression, comments, null, programMain, false);
+        this(name, returnType, parameters, expression, comments, null, programMain, false, false);
     }
 
     public record CompiledFunctionParameter(String name, CompiledType type) {

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledFunction.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledFunction.java
@@ -11,13 +11,14 @@ public record CompiledFunction(String name,
                              CompiledExpression expression,
                              List<String> comments,
                              Visibility visibility,
-                             boolean programMain) implements Comparable<CompiledFunction> {
+                             boolean programMain,
+                             boolean tailRecursive) implements Comparable<CompiledFunction> {
     public CompiledFunction(String name,
                           CompiledType returnType,
                           List<CompiledFunctionParameter> parameters,
                           CompiledExpression expression,
                           List<String> comments) {
-        this(name, returnType, parameters, expression, comments, null, false);
+        this(name, returnType, parameters, expression, comments, null, false, false);
     }
 
     public CompiledFunction(String name,
@@ -26,7 +27,7 @@ public record CompiledFunction(String name,
                             CompiledExpression expression,
                             List<String> comments,
                             boolean programMain) {
-        this(name, returnType, parameters, expression, comments, null, programMain);
+        this(name, returnType, parameters, expression, comments, null, programMain, false);
     }
 
     public record CompiledFunctionParameter(String name, CompiledType type) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -375,7 +375,7 @@ public class CapybaraParser {
 
     private List<SourcePosition> findLocalFunctionLocations(String source, String localName) {
         var locations = new ArrayList<SourcePosition>();
-        var pattern = Pattern.compile("(^|\\R)([ \\t]*)fun\\s+" + Pattern.quote(localName) + "\\s*\\(");
+        var pattern = Pattern.compile("(^|\\R)([ \\t]*)fun\\s+(?:rec\\s+)?" + Pattern.quote(localName) + "\\s*\\(");
         var matcher = pattern.matcher(source);
         while (matcher.find()) {
             var prefix = source.substring(0, matcher.start(2));
@@ -559,7 +559,7 @@ public class CapybaraParser {
         for (var localDefinition : localDefinitions) {
             var localFunction = localDefinition.localFunctionDeclaration();
             if (localFunction != null) {
-                var localNameToken = localFunction.NAME().getSymbol();
+                var localNameToken = localFunction.localFunctionNameDeclaration().start;
                 var localName = localNameToken.getText();
                 var occurrences = localFunctionPositions.computeIfAbsent(localName, ignored -> new java.util.ArrayList<>());
                 occurrences.add(localNameToken);
@@ -699,7 +699,8 @@ public class CapybaraParser {
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
                 visibility,
-                position(functionDeclarationContext)
+                position(functionDeclarationContext),
+                functionDeclarationContext.recFunctionMarker() != null
         );
         var allDefinitions = new java.util.ArrayList<Definition>(1 + extractedLocalDefinitions.size());
         allDefinitions.add(topLevelFunction);
@@ -713,7 +714,7 @@ public class CapybaraParser {
             java.util.Map<String, String> localTypeNameMap,
             java.util.Map<String, String> localConstNameMap
     ) {
-        var localName = context.NAME().getText();
+        var localName = context.localFunctionNameDeclaration().getText();
         var mappedName = localFunctionNameMap.get(localName);
         if (mappedName == null) {
             throw new IllegalStateException("Unknown local function mapping for: " + localName);
@@ -738,7 +739,9 @@ public class CapybaraParser {
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
-                position(context)
+                null,
+                position(context),
+                context.recFunctionMarker() != null
         );
     }
 
@@ -2224,9 +2227,11 @@ public class CapybaraParser {
                 ? identifier(context.identifier())
                 : context.NAME() != null
                         ? context.NAME().getText()
-                        : context.COLLECTION() != null
-                                ? context.COLLECTION().getText()
-                                : context.getChild(0).getText();
+                        : context.REC() != null
+                                ? context.REC().getText()
+                                : context.COLLECTION() != null
+                                        ? context.COLLECTION().getText()
+                                        : context.getChild(0).getText();
         return new FunctionCall(moduleName, functionName, arguments, position(context));
     }
 

--- a/compiler/src/main/java/dev/capylang/compiler/parser/Function.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/Function.java
@@ -9,11 +9,20 @@ public record Function(String name, List<Parameter> parameters, Optional<Type> r
                        Expression expression,
                        List<String> comments,
                        Visibility visibility,
-                       Optional<SourcePosition> position) implements Definition {
+                       Optional<SourcePosition> position,
+                       boolean tailRecursive) implements Definition {
+    public Function(String name, List<Parameter> parameters, Optional<Type> returnType,
+                    Expression expression,
+                    List<String> comments,
+                    Visibility visibility,
+                    Optional<SourcePosition> position) {
+        this(name, parameters, returnType, expression, comments, visibility, position, false);
+    }
+
     public Function(String name, List<Parameter> parameters, Optional<Type> returnType,
                     Expression expression,
                     List<String> comments,
                     Optional<SourcePosition> position) {
-        this(name, parameters, returnType, expression, comments, null, position);
+        this(name, parameters, returnType, expression, comments, null, position, false);
     }
 }

--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -1004,6 +1004,7 @@ public final class JavaGenerator implements Generator {
                 method.expression(),
                 method.parameters(),
                 method.selfCallNames(),
+                method.sourceReturnType(),
                 method.sourceParameterTypes(),
                 moduleHelperClass
         );

--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import static java.lang.String.join;
 import static java.util.stream.Collectors.joining;
 import static dev.capylang.generator.java.JavaExpressionEvaluator.evaluateExpression;
+import static dev.capylang.generator.java.JavaExpressionEvaluator.evaluateTailRecursiveExpression;
 
 public final class JavaGenerator implements Generator {
     private static final Logger log = Logger.getLogger(JavaGenerator.class.getName());
@@ -798,7 +799,7 @@ public final class JavaGenerator implements Generator {
                 : method.typeParameters().stream().collect(joining(", ", "<", ">")) + " ";
         return mapJavaDoc(method.comments())
                + prefix + " " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
-               + evaluateExpression(method.expression(), method.parameters(), helperCallOwnerName)
+               + evaluateMethodBody(method, helperCallOwnerName)
                + "\n}\n";
     }
 
@@ -832,7 +833,7 @@ public final class JavaGenerator implements Generator {
         }
         return mapJavaDoc(method.comments())
                + visibility + "static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
-               + evaluateExpression(method.expression(), method.parameters())
+               + evaluateMethodBody(method, null)
                + "\n}\n";
     }
 
@@ -956,7 +957,7 @@ public final class JavaGenerator implements Generator {
                 : method.typeParameters().stream().collect(joining(", ", "<", ">")) + " ";
         return mapJavaDoc(method.comments())
                + (method.isPrivate() ? "private" : "public") + " " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
-               + evaluateExpression(method.expression(), method.parameters(), helperCallOwnerName)
+               + evaluateMethodBody(method, helperCallOwnerName)
                + "\n}\n";
     }
 
@@ -966,7 +967,7 @@ public final class JavaGenerator implements Generator {
                 : method.typeParameters().stream().collect(joining(", ", "<", ">")) + " ";
         var capybaraMainMethod = mapJavaDoc(method.comments())
                + "public static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
-               + evaluateExpression(method.expression(), method.parameters())
+               + evaluateMethodBody(method, null)
                + "\n}\n";
         var returnsEffectProgram = isEffectProgramType(method.returnType().toString());
         var programType = returnsEffectProgram
@@ -993,6 +994,19 @@ public final class JavaGenerator implements Generator {
                + "default -> throw new java.lang.IllegalStateException(\"Unexpected value: \" + program);\n"
                + "}\n"
                + "}\n";
+    }
+
+    private String evaluateMethodBody(JavaMethod method, String moduleHelperClass) {
+        if (!method.tailRecursive()) {
+            return evaluateExpression(method.expression(), method.parameters(), moduleHelperClass);
+        }
+        return evaluateTailRecursiveExpression(
+                method.expression(),
+                method.parameters(),
+                method.selfCallNames(),
+                method.sourceParameterTypes(),
+                moduleHelperClass
+        );
     }
 
     private String normalizeProgramTypeReference(String typeName) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -51,9 +51,8 @@ public class JavaAstBuilder {
         var functionsByOwnerPrefix = indexFunctionsByOwnerPrefix(module.functions());
         var javaPackageName = buildJavaPackageName(module.path());
         var javaClassName = buildClassName(module.name());
-        var qualifiedJavaClassName = javaPackageName.isBlank()
-                ? javaClassName.toString()
-                : javaPackageName + "." + javaClassName;
+        var staticMethodsClassName = staticMethodsClassName(module, javaClassName.toString());
+        var staticMethodsSelfCallClassNames = staticMethodsSelfCallClassNames(module, javaPackageName, staticMethodsClassName);
         var interfaces = buildInterfaces(typeIndex.dataParentTypes().stream()
                 .filter(parentType -> !parentType.enumType())
                 .collect(toCollection(TreeSet::new)), functionsByOwnerPrefix);
@@ -66,10 +65,36 @@ public class JavaAstBuilder {
                         .map(staticImport -> normalizeJavaClassReference(staticImport.className()) + "." + buildJavaStaticImportMember(staticImport.memberName()))
                         .collect(toCollection(TreeSet::new)),
                 buildStaticConsts(module.functions()),
-                buildStaticMethods(module.functions(), qualifiedJavaClassName),
+                buildStaticMethods(module.functions(), staticMethodsSelfCallClassNames),
                 interfaces,
                 buildRecords(typeIndex.dataTypes(), subClassToInterface, functionsByOwnerPrefix),
                 buildEnums(typeIndex, subClassToInterface));
+    }
+
+    private String staticMethodsClassName(CompiledModule module, String javaClassName) {
+        var ownerType = module.types().get(module.name());
+        if (ownerType == null || ownerType instanceof CompiledDataParentType) {
+            return javaClassName;
+        }
+        return javaClassName + "Module";
+    }
+
+    private List<String> staticMethodsSelfCallClassNames(CompiledModule module, String javaPackageName, String staticMethodsClassName) {
+        var generatedClassName = javaPackageName.isBlank()
+                ? staticMethodsClassName
+                : javaPackageName + "." + staticMethodsClassName;
+        return Stream.of(generatedClassName, linkedStaticMethodsClassName(module))
+                .distinct()
+                .toList();
+    }
+
+    private String linkedStaticMethodsClassName(CompiledModule module) {
+        var className = module.path().replace('/', '.').replace('\\', '.') + "." + module.name();
+        var ownerType = module.types().get(module.name());
+        if (ownerType == null || ownerType instanceof CompiledDataParentType) {
+            return className;
+        }
+        return className + "Module";
     }
 
     private ModuleTypeIndex indexTypes(SortedMap<String, GenericDataType> types) {
@@ -136,11 +161,11 @@ public class JavaAstBuilder {
         return new JavaType(normalizeJavaTypeIdentifier(name));
     }
 
-    private SortedSet<JavaMethod> buildStaticMethods(Set<CompiledFunction> functions, String qualifiedJavaClassName) {
+    private SortedSet<JavaMethod> buildStaticMethods(Set<CompiledFunction> functions, List<String> qualifiedJavaClassNames) {
         return functions.stream()
                 .filter(function -> !function.name().startsWith(METHOD_DECL_PREFIX))
                 .filter(function -> !isConstFunction(function))
-                .map(function -> buildStaticMethod(function, qualifiedJavaClassName))
+                .map(function -> buildStaticMethod(function, qualifiedJavaClassNames))
                 .collect(toCollection(TreeSet::new));
     }
 
@@ -173,7 +198,7 @@ public class JavaAstBuilder {
         );
     }
 
-    private JavaMethod buildStaticMethod(CompiledFunction function, String qualifiedJavaClassName) {
+    private JavaMethod buildStaticMethod(CompiledFunction function, List<String> qualifiedJavaClassNames) {
         var methodTypeParameters = methodTypeParameters(function, Set.of());
         var expression = specializeReturnNewData(function.expression(), function.returnType());
         return new JavaMethod(
@@ -182,7 +207,7 @@ public class JavaAstBuilder {
                 function.name().startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 function.programMain(),
                 function.tailRecursive(),
-                selfCallNames(function, qualifiedJavaClassName),
+                selfCallNames(function, qualifiedJavaClassNames),
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(function.parameters()),
@@ -229,11 +254,13 @@ public class JavaAstBuilder {
         return functionNameOverrides.getOrDefault(signatureKey(function.name(), function.parameters().stream().map(CompiledFunction.CompiledFunctionParameter::type).toList()), buildMethodName(baseMethodName(function.name())));
     }
 
-    private List<String> selfCallNames(CompiledFunction function, String qualifiedJavaClassName) {
-        return Stream.of(
-                        function.name(),
-                        qualifiedJavaClassName + "." + function.name(),
-                        qualifiedJavaClassName + "." + emittedFunctionName(function)
+    private List<String> selfCallNames(CompiledFunction function, List<String> qualifiedJavaClassNames) {
+        return Stream.concat(
+                        Stream.of(function.name()),
+                        qualifiedJavaClassNames.stream().flatMap(className -> Stream.of(
+                                className + "." + function.name(),
+                                className + "." + emittedFunctionName(function)
+                        ))
                 )
                 .distinct()
                 .toList();

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -49,19 +49,24 @@ public class JavaAstBuilder {
     public JavaClass build(CompiledModule module) {
         var typeIndex = indexTypes(module.types());
         var functionsByOwnerPrefix = indexFunctionsByOwnerPrefix(module.functions());
+        var javaPackageName = buildJavaPackageName(module.path());
+        var javaClassName = buildClassName(module.name());
+        var qualifiedJavaClassName = javaPackageName.isBlank()
+                ? javaClassName.toString()
+                : javaPackageName + "." + javaClassName;
         var interfaces = buildInterfaces(typeIndex.dataParentTypes().stream()
                 .filter(parentType -> !parentType.enumType())
                 .collect(toCollection(TreeSet::new)), functionsByOwnerPrefix);
         var subClassToInterface = findSubClassToInterface(typeIndex.dataParentTypes(), interfaces);
         return new JavaClass(
                 sortedSetOf(generatedAnnotation()),
-                buildClassName(module.name()),
-                new JavaPackage(buildJavaPackageName(module.path())),
+                javaClassName,
+                new JavaPackage(javaPackageName),
                 module.staticImports().stream()
                         .map(staticImport -> normalizeJavaClassReference(staticImport.className()) + "." + buildJavaStaticImportMember(staticImport.memberName()))
                         .collect(toCollection(TreeSet::new)),
                 buildStaticConsts(module.functions()),
-                buildStaticMethods(module.functions()),
+                buildStaticMethods(module.functions(), qualifiedJavaClassName),
                 interfaces,
                 buildRecords(typeIndex.dataTypes(), subClassToInterface, functionsByOwnerPrefix),
                 buildEnums(typeIndex, subClassToInterface));
@@ -131,11 +136,11 @@ public class JavaAstBuilder {
         return new JavaType(normalizeJavaTypeIdentifier(name));
     }
 
-    private SortedSet<JavaMethod> buildStaticMethods(Set<CompiledFunction> functions) {
+    private SortedSet<JavaMethod> buildStaticMethods(Set<CompiledFunction> functions, String qualifiedJavaClassName) {
         return functions.stream()
                 .filter(function -> !function.name().startsWith(METHOD_DECL_PREFIX))
                 .filter(function -> !isConstFunction(function))
-                .map(this::buildStaticMethod)
+                .map(function -> buildStaticMethod(function, qualifiedJavaClassName))
                 .collect(toCollection(TreeSet::new));
     }
 
@@ -168,16 +173,22 @@ public class JavaAstBuilder {
         );
     }
 
-    private JavaMethod buildStaticMethod(CompiledFunction function) {
+    private JavaMethod buildStaticMethod(CompiledFunction function, String qualifiedJavaClassName) {
         var methodTypeParameters = methodTypeParameters(function, Set.of());
         var expression = specializeReturnNewData(function.expression(), function.returnType());
         return new JavaMethod(
                 emittedFunctionName(function),
+                function.name(),
                 function.name().startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 function.programMain(),
+                function.tailRecursive(),
+                selfCallNames(function, qualifiedJavaClassName),
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(function.parameters()),
+                function.parameters().stream()
+                        .map(CompiledFunction.CompiledFunctionParameter::type)
+                        .toList(),
                 expression,
                 function.comments()
         );
@@ -215,6 +226,16 @@ public class JavaAstBuilder {
 
     private String emittedFunctionName(CompiledFunction function) {
         return functionNameOverrides.getOrDefault(signatureKey(function.name(), function.parameters().stream().map(CompiledFunction.CompiledFunctionParameter::type).toList()), buildMethodName(baseMethodName(function.name())));
+    }
+
+    private List<String> selfCallNames(CompiledFunction function, String qualifiedJavaClassName) {
+        return Stream.of(
+                        function.name(),
+                        qualifiedJavaClassName + "." + function.name(),
+                        qualifiedJavaClassName + "." + emittedFunctionName(function)
+                )
+                .distinct()
+                .toList();
     }
 
     private String baseMethodName(String name) {
@@ -881,11 +902,17 @@ public class JavaAstBuilder {
         var methodTypeParameters = methodTypeParameters(function, Set.copyOf(extractOwnerTypeParameters(function)));
         return new JavaMethod(
                 emittedFunctionName(function),
+                function.name(),
                 methodName.startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 false,
+                function.tailRecursive(),
+                List.of(function.name()),
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(parameters),
+                parameters.stream()
+                        .map(CompiledFunction.CompiledFunctionParameter::type)
+                        .toList(),
                 function.expression(),
                 function.comments()
         );
@@ -971,11 +998,17 @@ public class JavaAstBuilder {
         var methodTypeParameters = methodTypeParameters(function, Set.copyOf(extractOwnerTypeParameters(function)));
         return new JavaMethod(
                 emittedFunctionName(function),
+                function.name(),
                 methodName.startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 false,
+                function.tailRecursive(),
+                List.of(function.name()),
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(parameters),
+                parameters.stream()
+                        .map(CompiledFunction.CompiledFunctionParameter::type)
+                        .toList(),
                 function.expression(),
                 function.comments()
         );

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -186,6 +186,7 @@ public class JavaAstBuilder {
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(function.parameters()),
+                function.returnType(),
                 function.parameters().stream()
                         .map(CompiledFunction.CompiledFunctionParameter::type)
                         .toList(),
@@ -910,6 +911,7 @@ public class JavaAstBuilder {
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(parameters),
+                function.returnType(),
                 parameters.stream()
                         .map(CompiledFunction.CompiledFunctionParameter::type)
                         .toList(),
@@ -1006,6 +1008,7 @@ public class JavaAstBuilder {
                 methodTypeParameters,
                 buildJavaReturnType(function),
                 buildJavaFunctionParameters(parameters),
+                function.returnType(),
                 parameters.stream()
                         .map(CompiledFunction.CompiledFunctionParameter::type)
                         .toList(),

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -2,6 +2,7 @@ package dev.capylang.generator.java;
 
 import dev.capylang.compiler.CompiledDataParentType;
 import dev.capylang.compiler.CompiledDataType;
+import dev.capylang.compiler.CompiledType;
 import dev.capylang.compiler.expression.*;
 import dev.capylang.compiler.parser.InfixOperator;
 
@@ -31,6 +32,8 @@ public class JavaExpressionEvaluator {
     private static final java.util.concurrent.atomic.AtomicLong STRING_PARSE_VAR_COUNTER =
             new java.util.concurrent.atomic.AtomicLong();
     private static final java.util.concurrent.atomic.AtomicLong TUPLE_LET_VAR_COUNTER =
+            new java.util.concurrent.atomic.AtomicLong();
+    private static final java.util.concurrent.atomic.AtomicLong TAIL_ARGUMENT_COUNTER =
             new java.util.concurrent.atomic.AtomicLong();
     private static final Logger log = Logger.getLogger(JavaExpressionEvaluator.class.getName());
     private static final ConcurrentMap<String, String> JAVA_CAST_TYPE_CACHE = new ConcurrentHashMap<>();
@@ -67,13 +70,33 @@ public class JavaExpressionEvaluator {
             String moduleHelperClass
     ) {
         log.fine(() -> "evaluateExpression: " + expression.getClass().getSimpleName() + " -> " + expression);
+        var scope = initialScope(parameters, moduleHelperClass);
+        var evaluatedScope = evaluateExpression(expression, scope);
+        return expressionToJava(evaluatedScope);
+    }
+
+    public static String evaluateTailRecursiveExpression(
+            CompiledExpression expression,
+            List<JavaMethod.JavaFunctionParameter> parameters,
+            List<String> selfCallNames,
+            List<CompiledType> sourceParameterTypes,
+            String moduleHelperClass
+    ) {
+        log.fine(() -> "evaluateTailRecursiveExpression: " + expression.getClass().getSimpleName() + " -> " + expression);
+        var context = new TailRecursiveContext(selfCallNames, parameters, sourceParameterTypes);
+        var code = new StringBuilder("while (true) {\n");
+        appendTailRecursiveStatement(code, expression, initialScope(parameters, moduleHelperClass), context);
+        code.append("}");
+        return code.toString();
+    }
+
+    private static Scope initialScope(List<JavaMethod.JavaFunctionParameter> parameters, String moduleHelperClass) {
         var scope = moduleHelperClass == null ? Scope.EMPTY : Scope.EMPTY.withModuleHelperClass(moduleHelperClass);
         for (var parameter : parameters) {
             scope = scope.addLocalValue(parameter.sourceName())
                     .addValueOverride(parameter.sourceName(), parameter.generatedName());
         }
-        var evaluatedScope = evaluateExpression(expression, scope);
-        return expressionToJava(evaluatedScope);
+        return scope;
     }
 
     private static String expressionToJava(Scope scope) {
@@ -84,6 +107,183 @@ public class JavaExpressionEvaluator {
         }
         sb.append("return ").append(scope.getExpression()).append(';');
         return sb.toString();
+    }
+
+    private static void appendTailRecursiveStatement(
+            StringBuilder code,
+            CompiledExpression expression,
+            Scope scope,
+            TailRecursiveContext context
+    ) {
+        if (expression instanceof CompiledFunctionCall functionCall && isTailRecursiveSelfCall(functionCall, context)) {
+            appendTailRecursiveSelfCall(code, functionCall, scope, context);
+            return;
+        }
+        if (expression instanceof CompiledIfExpression ifExpression) {
+            appendTailRecursiveIf(code, ifExpression, scope, context);
+            return;
+        }
+        if (expression instanceof CompiledLetExpression letExpression) {
+            appendTailRecursiveLet(code, letExpression, scope, context);
+            return;
+        }
+        if (expression instanceof CompiledMatchExpression matchExpression) {
+            appendTailRecursiveMatch(code, matchExpression, scope, context);
+            return;
+        }
+
+        var evaluated = evaluateExpression(expression, scope).popExpression();
+        appendStatements(code, newStatements(scope, evaluated.scope()));
+        code.append("return ").append(evaluated.expression()).append(";\n");
+    }
+
+    private static void appendTailRecursiveSelfCall(
+            StringBuilder code,
+            CompiledFunctionCall functionCall,
+            Scope scope,
+            TailRecursiveContext context
+    ) {
+        var current = scope;
+        var arguments = new ArrayList<String>(functionCall.arguments().size());
+        for (var argument : functionCall.arguments()) {
+            var evaluatedArgument = evaluateExpression(argument, current).popExpression();
+            appendStatements(code, newStatements(current, evaluatedArgument.scope()));
+            current = evaluatedArgument.scope();
+            arguments.add(evaluatedArgument.expression());
+        }
+
+        var temporaryNames = new ArrayList<String>(arguments.size());
+        for (int i = 0; i < arguments.size(); i++) {
+            var temporaryName = "__capybaraTailArg" + TAIL_ARGUMENT_COUNTER.incrementAndGet();
+            temporaryNames.add(temporaryName);
+            var parameterType = context.parameterTypes().get(i);
+            var argument = functionCall.arguments().get(i);
+            code.append(javaCastType(parameterType))
+                    .append(" ")
+                    .append(temporaryName)
+                    .append(" = ")
+                    .append(coerceExpressionForExpectedType(parameterType, argument.type(), arguments.get(i)))
+                    .append(";\n");
+        }
+
+        for (int i = 0; i < temporaryNames.size(); i++) {
+            code.append(context.parameters().get(i).generatedName())
+                    .append(" = ")
+                    .append(temporaryNames.get(i))
+                    .append(";\n");
+        }
+        code.append("continue;\n");
+    }
+
+    private static void appendTailRecursiveIf(
+            StringBuilder code,
+            CompiledIfExpression expression,
+            Scope scope,
+            TailRecursiveContext context
+    ) {
+        var condition = evaluateExpression(expression.condition(), scope).popExpression();
+        appendStatements(code, newStatements(scope, condition.scope()));
+        code.append("if (")
+                .append(toBooleanExpression(condition.expression(), expression.condition().type()))
+                .append(") {\n");
+        appendTailRecursiveStatement(code, expression.thenBranch(), condition.scope(), context);
+        code.append("} else {\n");
+        appendTailRecursiveStatement(code, expression.elseBranch(), condition.scope(), context);
+        code.append("}\n");
+    }
+
+    private static void appendTailRecursiveLet(
+            StringBuilder code,
+            CompiledLetExpression let,
+            Scope scope,
+            TailRecursiveContext context
+    ) {
+        var value = evaluateExpression(let.value(), scope).popExpression();
+        appendStatements(code, newStatements(scope, value.scope()));
+        var letDeclarationType = let.declaredType().orElse(let.value().type());
+        var coercedValueExpression = coerceExpressionForExpectedType(letDeclarationType, let.value().type(), value.expression());
+        var scopeExpression = shouldUseTypedLetDeclaration(let.value(), let.declaredType().isPresent())
+                ? value.scope().declareTypedValue(let.name(), javaCastType(letDeclarationType), coercedValueExpression, let.rest())
+                : value.scope().declareValue(let.name(), coercedValueExpression, let.rest());
+        appendStatements(code, newStatements(value.scope(), scopeExpression.scope()));
+        appendTailRecursiveStatement(code, scopeExpression.expression(), scopeExpression.scope(), context);
+    }
+
+    private static void appendTailRecursiveMatch(
+            StringBuilder code,
+            CompiledMatchExpression matchExpression,
+            Scope scope,
+            TailRecursiveContext context
+    ) {
+        var matchSelectorName = "__matchValue" + MATCH_SELECTOR_COUNTER.incrementAndGet();
+        var optionMatch = isOptionType(matchExpression.matchWith().type());
+        var matchWithExSc = evaluateExpression(matchExpression.matchWith(), scope).popExpression();
+        appendStatements(code, newStatements(scope, matchWithExSc.scope()));
+        var selectorExpression = castMatchSelectorExpression(matchWithExSc.expression(), matchExpression.matchWith().type(), optionMatch);
+        var declaredValue = matchWithExSc.scope().declareValue(
+                matchSelectorName,
+                selectorExpression,
+                new CompiledVariable(matchSelectorName, matchExpression.matchWith().type())
+        );
+        appendStatements(code, newStatements(matchWithExSc.scope(), declaredValue.scope()));
+        var current = declaredValue.scope();
+        var switchTarget = current.findValueOverride(matchSelectorName).orElse(matchSelectorName);
+
+        code.append("switch (").append(switchTarget).append(") {\n");
+        for (var matchCase : matchExpression.cases()) {
+            var preparedCase = prepareMatchCase(matchExpression, matchCase, current, switchTarget, optionMatch);
+            code.append(preparedCase.casePattern()).append(" -> {\n");
+            appendTailRecursiveStatement(code, matchCase.expression(), preparedCase.branchScope(), context);
+            code.append("}\n");
+        }
+        var hasWildcard = matchExpression.cases().stream()
+                .map(CompiledMatchExpression.MatchCase::pattern)
+                .anyMatch(pattern ->
+                        pattern instanceof CompiledMatchExpression.WildcardPattern
+                        || pattern instanceof CompiledMatchExpression.WildcardBindingPattern);
+        if (optionMatch && !hasWildcard) {
+            code.append("case java.lang.Object __capybaraUnexpected -> throw new java.lang.IllegalStateException(\"Unexpected value: \" + ")
+                    .append(switchTarget)
+                    .append(");\n");
+        }
+        if (matchExpression.matchWith().type() == dev.capylang.compiler.PrimitiveLinkedType.BOOL && !hasWildcard) {
+            code.append("default -> throw new java.lang.IllegalStateException(\"Unexpected bool value: \" + ")
+                    .append(switchTarget)
+                    .append(");\n");
+        }
+        code.append("}\n");
+    }
+
+    private static boolean isTailRecursiveSelfCall(CompiledFunctionCall functionCall, TailRecursiveContext context) {
+        if (!context.selfCallNames().contains(functionCall.name())) {
+            return false;
+        }
+        if (functionCall.arguments().size() != context.parameterTypes().size()) {
+            return false;
+        }
+        for (int i = 0; i < functionCall.arguments().size(); i++) {
+            if (!functionCall.arguments().get(i).type().equals(context.parameterTypes().get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void appendStatements(StringBuilder code, List<String> statements) {
+        for (var statement : statements) {
+            code.append(statement).append(";\n");
+        }
+    }
+
+    private static List<String> newStatements(Scope before, Scope after) {
+        return after.getStatements().subList(before.getStatements().size(), after.getStatements().size());
+    }
+
+    private record TailRecursiveContext(
+            List<String> selfCallNames,
+            List<JavaMethod.JavaFunctionParameter> parameters,
+            List<CompiledType> parameterTypes
+    ) {
     }
 
     private static Scope evaluateExpression(CompiledExpression expression, Scope scope) {
@@ -1591,117 +1791,8 @@ public class JavaExpressionEvaluator {
 
         for (int caseIndex = 0; caseIndex < matchExpression.cases().size(); caseIndex++) {
             var matchCase = matchExpression.cases().get(caseIndex);
-            var branchScope = current;
-            var optionCaseVar = "__capybaraOptionCase" + OPTION_CASE_VAR_COUNTER.incrementAndGet();
-            var caseBindingNames = new java.util.HashMap<String, String>();
-            if (matchCase.pattern() instanceof CompiledMatchExpression.ConstructorPattern constructorPattern) {
-                var bindingNames = constructorPatternBindingNames(constructorPattern, caseBindingNames);
-                var bindingCastTypes = constructorBindingCastTypes(matchExpression.matchWith().type(), constructorPattern);
-                for (int i = 0; i < constructorPattern.fieldPatterns().size(); i++) {
-                    var fieldPattern = constructorPattern.fieldPatterns().get(i);
-                    var bindingName = bindingNames.get(i);
-                    if (fieldPattern instanceof CompiledMatchExpression.VariablePattern variablePattern) {
-                        branchScope = branchScope.addLocalValue(variablePattern.name());
-                        branchScope = branchScope.addValueOverride(variablePattern.name(), bindingName);
-                        var castType = bindingCastTypes.get(i);
-                        if (castType != null && !"java.lang.Object".equals(castType)) {
-                            branchScope = branchScope.addValueOverride(bindingName, "((" + castType + ") " + bindingName + ")");
-                            branchScope = branchScope.addValueOverride(variablePattern.name(), "((" + castType + ") " + bindingName + ")");
-                        }
-                    }
-                    if (fieldPattern instanceof CompiledMatchExpression.TypedPattern typedPattern) {
-                        branchScope = branchScope.addLocalValue(typedPattern.name());
-                        var typedValue = "((" + javaPatternType(typedPattern.type()) + ") " + bindingName + ")";
-                        branchScope = branchScope.addValueOverride(bindingName, typedValue);
-                        branchScope = branchScope.addValueOverride(
-                                typedPattern.name(),
-                                typedValue
-                        );
-                    }
-                }
-                if (optionMatch && isOptionSomePattern(constructorPattern.constructorName()) && constructorPattern.fieldPatterns().size() == 1) {
-                    var firstPattern = constructorPattern.fieldPatterns().getFirst();
-                    if (firstPattern instanceof CompiledMatchExpression.VariablePattern variablePattern) {
-                        var castType = optionPayloadCastType(matchExpression.matchWith().type());
-                        if (castType == null) {
-                            castType = bindingCastTypes.isEmpty() ? null : bindingCastTypes.getFirst();
-                        }
-                        var valueExpression = optionSomeBindingExpression(switchTarget + ".orElse(null)");
-                        if (castType != null && !"java.lang.Object".equals(castType)) {
-                            valueExpression = "((" + castType + ") " + valueExpression + ")";
-                        }
-                        branchScope = branchScope.addValueOverride(
-                                variablePattern.name(),
-                                valueExpression
-                        );
-                    }
-                    if (firstPattern instanceof CompiledMatchExpression.TypedPattern typedPattern) {
-                        var castType = optionPayloadCastType(matchExpression.matchWith().type());
-                        if (castType == null) {
-                            castType = javaPatternType(typedPattern.type());
-                        }
-                        branchScope = branchScope.addValueOverride(
-                                typedPattern.name(),
-                                "((" + castType + ") " + optionSomeBindingExpression(switchTarget + ".orElse(null)") + ")"
-                        );
-                    }
-                }
-                if (isResultErrorConstructor(matchExpression.matchWith().type(), constructorPattern)
-                    && constructorPattern.fieldPatterns().size() == 1
-                    && constructorPattern.fieldPatterns().getFirst() instanceof CompiledMatchExpression.VariablePattern variablePattern) {
-                    var valueName = variablePattern.name();
-                    var generatedName = caseBindingNames.getOrDefault(valueName, valueName);
-                    branchScope = branchScope.addValueOverride(valueName, "((" + generatedName + ") == null ? null : " + generatedName + ".getMessage())");
-                }
-            }
-            if (matchCase.pattern() instanceof CompiledMatchExpression.TypedPattern typedPattern) {
-                var generatedName = caseBindingNames.computeIfAbsent(
-                        typedPattern.name(),
-                        ignored -> "__capybaraMatchBinding" + MATCH_BINDING_COUNTER.incrementAndGet()
-                );
-                var typedPatternValue = generatedName;
-                if (optionMatch && isOptionSomePattern(typedPattern.type().name())) {
-                    var castType = optionPayloadCastType(matchExpression.matchWith().type());
-                    var payloadExpression = optionSomeBindingExpression(generatedName + ".orElse(null)");
-                    if (castType != null && !"java.lang.Object".equals(castType)) {
-                        payloadExpression = "((" + castType + ") " + payloadExpression + ")";
-                    }
-                    typedPatternValue = "new "
-                                        + normalizeJavaTypeReference(stripGenericSuffix(typedPattern.type().name()))
-                                        + "<>("
-                                        + payloadExpression
-                                        + ")";
-                } else if (optionMatch && isOptionNonePattern(typedPattern.type().name())) {
-                    typedPatternValue = normalizeJavaTypeReference(stripGenericSuffix(typedPattern.type().name())) + ".INSTANCE";
-                }
-                branchScope = branchScope
-                        .addLocalValue(typedPattern.name())
-                        .addValueOverride(typedPattern.name(), typedPatternValue);
-            }
-            if (matchCase.pattern() instanceof CompiledMatchExpression.TypedPattern typedPattern
-                && matchExpression.matchWith() instanceof CompiledVariable matchedVariable) {
-                var generatedName = caseBindingNames.getOrDefault(typedPattern.name(), typedPattern.name());
-                branchScope = branchScope
-                        .addValueOverride(matchedVariable.name(), generatedName);
-            }
-            if (matchCase.pattern() instanceof CompiledMatchExpression.WildcardBindingPattern wildcardBindingPattern) {
-                var generatedName = caseBindingNames.computeIfAbsent(
-                        wildcardBindingPattern.name(),
-                        ignored -> "__capybaraMatchBinding" + MATCH_BINDING_COUNTER.incrementAndGet()
-                );
-                branchScope = branchScope
-                        .addLocalValue(wildcardBindingPattern.name())
-                        .addValueOverride(wildcardBindingPattern.name(), generatedName);
-            }
-            var casePattern = matchCasePattern(matchCase.pattern(), matchExpression.matchWith().type(), optionCaseVar, caseBindingNames);
-            if (matchCase.guard().isPresent()) {
-                var guardScope = evaluateExpression(matchCase.guard().orElseThrow(), branchScope).popExpression();
-                var guardStatements = guardScope.scope().getStatements()
-                        .subList(branchScope.getStatements().size(), guardScope.scope().getStatements().size());
-                var guardExpression = wrapGuardExpression(guardStatements, guardScope.expression());
-                casePattern = appendCaseGuard(casePattern, guardExpression);
-            }
-            var expressionScope = evaluateExpression(matchCase.expression(), branchScope).popExpression();
+            var preparedCase = prepareMatchCase(matchExpression, matchCase, current, switchTarget, optionMatch);
+            var expressionScope = evaluateExpression(matchCase.expression(), preparedCase.branchScope()).popExpression();
             var caseExpression = expressionScope.expression();
             if (optionMatch) {
                 caseExpression = castMatchCaseExpression(caseExpression, matchExpression.type());
@@ -1716,13 +1807,13 @@ public class JavaExpressionEvaluator {
                 caseExpression = "((" + javaCastType(matchCase.expression().type()) + ") (" + caseExpression + "))";
             }
             var caseStatements = expressionScope.scope().getStatements()
-                    .subList(branchScope.getStatements().size(), expressionScope.scope().getStatements().size());
+                    .subList(preparedCase.branchScope().getStatements().size(), expressionScope.scope().getStatements().size());
             var caseStatementsCode = String.join(" ", caseStatements.stream()
                     .map(statement -> statement + ";")
                     .toList());
             var caseRule = caseStatements.isEmpty()
-                    ? casePattern + " -> (" + caseExpression + ");"
-                    : casePattern
+                    ? preparedCase.casePattern() + " -> (" + caseExpression + ");"
+                    : preparedCase.casePattern()
                       + " -> { " + caseStatementsCode + " yield (" + caseExpression + "); }";
             cases.add(caseRule);
         }
@@ -1743,6 +1834,122 @@ public class JavaExpressionEvaluator {
         }
 
         return current.addExpression("switch (" + switchTarget + ") { " + String.join(" ", cases) + " }");
+    }
+
+    private static PreparedMatchCase prepareMatchCase(
+            CompiledMatchExpression matchExpression,
+            CompiledMatchExpression.MatchCase matchCase,
+            Scope current,
+            String switchTarget,
+            boolean optionMatch
+    ) {
+        var branchScope = current;
+        var optionCaseVar = "__capybaraOptionCase" + OPTION_CASE_VAR_COUNTER.incrementAndGet();
+        var caseBindingNames = new java.util.HashMap<String, String>();
+        if (matchCase.pattern() instanceof CompiledMatchExpression.ConstructorPattern constructorPattern) {
+            var bindingNames = constructorPatternBindingNames(constructorPattern, caseBindingNames);
+            var bindingCastTypes = constructorBindingCastTypes(matchExpression.matchWith().type(), constructorPattern);
+            for (int i = 0; i < constructorPattern.fieldPatterns().size(); i++) {
+                var fieldPattern = constructorPattern.fieldPatterns().get(i);
+                var bindingName = bindingNames.get(i);
+                if (fieldPattern instanceof CompiledMatchExpression.VariablePattern variablePattern) {
+                    branchScope = branchScope.addLocalValue(variablePattern.name());
+                    branchScope = branchScope.addValueOverride(variablePattern.name(), bindingName);
+                    var castType = bindingCastTypes.get(i);
+                    if (castType != null && !"java.lang.Object".equals(castType)) {
+                        branchScope = branchScope.addValueOverride(bindingName, "((" + castType + ") " + bindingName + ")");
+                        branchScope = branchScope.addValueOverride(variablePattern.name(), "((" + castType + ") " + bindingName + ")");
+                    }
+                }
+                if (fieldPattern instanceof CompiledMatchExpression.TypedPattern typedPattern) {
+                    branchScope = branchScope.addLocalValue(typedPattern.name());
+                    var typedValue = "((" + javaPatternType(typedPattern.type()) + ") " + bindingName + ")";
+                    branchScope = branchScope.addValueOverride(bindingName, typedValue);
+                    branchScope = branchScope.addValueOverride(typedPattern.name(), typedValue);
+                }
+            }
+            if (optionMatch && isOptionSomePattern(constructorPattern.constructorName()) && constructorPattern.fieldPatterns().size() == 1) {
+                var firstPattern = constructorPattern.fieldPatterns().getFirst();
+                if (firstPattern instanceof CompiledMatchExpression.VariablePattern variablePattern) {
+                    var castType = optionPayloadCastType(matchExpression.matchWith().type());
+                    if (castType == null) {
+                        castType = bindingCastTypes.isEmpty() ? null : bindingCastTypes.getFirst();
+                    }
+                    var valueExpression = optionSomeBindingExpression(switchTarget + ".orElse(null)");
+                    if (castType != null && !"java.lang.Object".equals(castType)) {
+                        valueExpression = "((" + castType + ") " + valueExpression + ")";
+                    }
+                    branchScope = branchScope.addValueOverride(variablePattern.name(), valueExpression);
+                }
+                if (firstPattern instanceof CompiledMatchExpression.TypedPattern typedPattern) {
+                    var castType = optionPayloadCastType(matchExpression.matchWith().type());
+                    if (castType == null) {
+                        castType = javaPatternType(typedPattern.type());
+                    }
+                    branchScope = branchScope.addValueOverride(
+                            typedPattern.name(),
+                            "((" + castType + ") " + optionSomeBindingExpression(switchTarget + ".orElse(null)") + ")"
+                    );
+                }
+            }
+            if (isResultErrorConstructor(matchExpression.matchWith().type(), constructorPattern)
+                && constructorPattern.fieldPatterns().size() == 1
+                && constructorPattern.fieldPatterns().getFirst() instanceof CompiledMatchExpression.VariablePattern variablePattern) {
+                var valueName = variablePattern.name();
+                var generatedName = caseBindingNames.getOrDefault(valueName, valueName);
+                branchScope = branchScope.addValueOverride(valueName, "((" + generatedName + ") == null ? null : " + generatedName + ".getMessage())");
+            }
+        }
+        if (matchCase.pattern() instanceof CompiledMatchExpression.TypedPattern typedPattern) {
+            var generatedName = caseBindingNames.computeIfAbsent(
+                    typedPattern.name(),
+                    ignored -> "__capybaraMatchBinding" + MATCH_BINDING_COUNTER.incrementAndGet()
+            );
+            var typedPatternValue = generatedName;
+            if (optionMatch && isOptionSomePattern(typedPattern.type().name())) {
+                var castType = optionPayloadCastType(matchExpression.matchWith().type());
+                var payloadExpression = optionSomeBindingExpression(generatedName + ".orElse(null)");
+                if (castType != null && !"java.lang.Object".equals(castType)) {
+                    payloadExpression = "((" + castType + ") " + payloadExpression + ")";
+                }
+                typedPatternValue = "new "
+                                    + normalizeJavaTypeReference(stripGenericSuffix(typedPattern.type().name()))
+                                    + "<>("
+                                    + payloadExpression
+                                    + ")";
+            } else if (optionMatch && isOptionNonePattern(typedPattern.type().name())) {
+                typedPatternValue = normalizeJavaTypeReference(stripGenericSuffix(typedPattern.type().name())) + ".INSTANCE";
+            }
+            branchScope = branchScope
+                    .addLocalValue(typedPattern.name())
+                    .addValueOverride(typedPattern.name(), typedPatternValue);
+        }
+        if (matchCase.pattern() instanceof CompiledMatchExpression.TypedPattern typedPattern
+            && matchExpression.matchWith() instanceof CompiledVariable matchedVariable) {
+            var generatedName = caseBindingNames.getOrDefault(typedPattern.name(), typedPattern.name());
+            branchScope = branchScope.addValueOverride(matchedVariable.name(), generatedName);
+        }
+        if (matchCase.pattern() instanceof CompiledMatchExpression.WildcardBindingPattern wildcardBindingPattern) {
+            var generatedName = caseBindingNames.computeIfAbsent(
+                    wildcardBindingPattern.name(),
+                    ignored -> "__capybaraMatchBinding" + MATCH_BINDING_COUNTER.incrementAndGet()
+            );
+            branchScope = branchScope
+                    .addLocalValue(wildcardBindingPattern.name())
+                    .addValueOverride(wildcardBindingPattern.name(), generatedName);
+        }
+        var casePattern = matchCasePattern(matchCase.pattern(), matchExpression.matchWith().type(), optionCaseVar, caseBindingNames);
+        if (matchCase.guard().isPresent()) {
+            var guardScope = evaluateExpression(matchCase.guard().orElseThrow(), branchScope).popExpression();
+            var guardStatements = guardScope.scope().getStatements()
+                    .subList(branchScope.getStatements().size(), guardScope.scope().getStatements().size());
+            var guardExpression = wrapGuardExpression(guardStatements, guardScope.expression());
+            casePattern = appendCaseGuard(casePattern, guardExpression);
+        }
+        return new PreparedMatchCase(branchScope, casePattern);
+    }
+
+    private record PreparedMatchCase(Scope branchScope, String casePattern) {
     }
 
     private static String appendCaseGuard(String casePattern, String guardExpression) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -79,11 +79,12 @@ public class JavaExpressionEvaluator {
             CompiledExpression expression,
             List<JavaMethod.JavaFunctionParameter> parameters,
             List<String> selfCallNames,
+            CompiledType sourceReturnType,
             List<CompiledType> sourceParameterTypes,
             String moduleHelperClass
     ) {
         log.fine(() -> "evaluateTailRecursiveExpression: " + expression.getClass().getSimpleName() + " -> " + expression);
-        var context = new TailRecursiveContext(selfCallNames, parameters, sourceParameterTypes);
+        var context = new TailRecursiveContext(selfCallNames, parameters, sourceReturnType, sourceParameterTypes);
         var code = new StringBuilder("while (true) {\n");
         appendTailRecursiveStatement(code, expression, initialScope(parameters, moduleHelperClass), context);
         code.append("}");
@@ -134,7 +135,9 @@ public class JavaExpressionEvaluator {
 
         var evaluated = evaluateExpression(expression, scope).popExpression();
         appendStatements(code, newStatements(scope, evaluated.scope()));
-        code.append("return ").append(evaluated.expression()).append(";\n");
+        code.append("return ")
+                .append(coerceTailReturnExpression(context.returnType(), evaluated.expression()))
+                .append(";\n");
     }
 
     private static void appendTailRecursiveSelfCall(
@@ -282,6 +285,7 @@ public class JavaExpressionEvaluator {
     private record TailRecursiveContext(
             List<String> selfCallNames,
             List<JavaMethod.JavaFunctionParameter> parameters,
+            CompiledType returnType,
             List<CompiledType> parameterTypes
     ) {
     }
@@ -1743,6 +1747,26 @@ public class JavaExpressionEvaluator {
             return "((" + javaPrimitiveType(expectedPrimitive) + ") " + expression + ")";
         }
         return expression;
+    }
+
+    private static String coerceTailReturnExpression(dev.capylang.compiler.CompiledType expectedType, String expression) {
+        if (shouldCastTailReturnToExpectedType(expectedType)) {
+            return "((" + javaCastTypeForMatchCase(expectedType) + ") (" + expression + "))";
+        }
+        return expression;
+    }
+
+    private static boolean shouldCastTailReturnToExpectedType(dev.capylang.compiler.CompiledType expectedType) {
+        return switch (expectedType) {
+            case dev.capylang.compiler.CompiledDataType ignored -> true;
+            case dev.capylang.compiler.CompiledDataParentType ignored -> true;
+            case dev.capylang.compiler.CollectionLinkedType.CompiledList ignored -> true;
+            case dev.capylang.compiler.CollectionLinkedType.CompiledSet ignored -> true;
+            case dev.capylang.compiler.CollectionLinkedType.CompiledDict ignored -> true;
+            case dev.capylang.compiler.CompiledTupleType ignored -> true;
+            case dev.capylang.compiler.CompiledFunctionType ignored -> true;
+            default -> false;
+        };
     }
 
     private static boolean isImplicitNumericWidening(

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaMethod.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaMethod.java
@@ -15,6 +15,7 @@ public record JavaMethod(
         List<String> typeParameters,
         JavaType returnType,
         List<JavaFunctionParameter> parameters,
+        dev.capylang.compiler.CompiledType sourceReturnType,
         List<dev.capylang.compiler.CompiledType> sourceParameterTypes,
         CompiledExpression expression,
         List<String> comments) implements Comparable<JavaMethod> {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaMethod.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaMethod.java
@@ -7,11 +7,15 @@ import java.util.List;
 
 public record JavaMethod(
         String name,
+        String sourceName,
         boolean isPrivate,
         boolean programMain,
+        boolean tailRecursive,
+        List<String> selfCallNames,
         List<String> typeParameters,
         JavaType returnType,
         List<JavaFunctionParameter> parameters,
+        List<dev.capylang.compiler.CompiledType> sourceParameterTypes,
         CompiledExpression expression,
         List<String> comments) implements Comparable<JavaMethod> {
     @Override

--- a/compiler/src/test/java/dev/capylang/compiler/RecursionCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/RecursionCompilerTest.java
@@ -1,0 +1,77 @@
+package dev.capylang.compiler;
+
+import dev.capylang.compiler.parser.RawModule;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecursionCompilerTest {
+    @Test
+    void shouldClassifyUnmarkedRecursiveFunctions() {
+        var program = compileProgram("""
+                fun unmarked_tail_sum(n: int, acc: int): int =
+                    if n <= 0 then acc else unmarked_tail_sum(n - 1, acc + n)
+
+                fun unmarked_non_tail_sum(n: int): int =
+                    if n <= 0 then 0 else n + unmarked_non_tail_sum(n - 1)
+
+                fun plain(n: int): int = n + 1
+                """);
+
+        assertThat(function(program, "unmarked_tail_sum"))
+                .satisfies(function -> {
+                    assertThat(function.recursive()).isTrue();
+                    assertThat(function.tailRecursive()).isTrue();
+                });
+        assertThat(function(program, "unmarked_non_tail_sum"))
+                .satisfies(function -> {
+                    assertThat(function.recursive()).isTrue();
+                    assertThat(function.tailRecursive()).isFalse();
+                });
+        assertThat(function(program, "plain"))
+                .satisfies(function -> {
+                    assertThat(function.recursive()).isFalse();
+                    assertThat(function.tailRecursive()).isFalse();
+                });
+    }
+
+    @Test
+    void shouldClassifyUnmarkedLocalTailRecursiveFunctions() {
+        var program = compileProgram("""
+                fun unmarked_local_tail_sum(n: int): int =
+                    fun __sum(n: int, acc: int): int =
+                        if n <= 0 then acc else __sum(n - 1, acc + n)
+                    ---
+                    __sum(n, 0)
+                """);
+
+        assertThat(program.modules().first().functions())
+                .filteredOn(function -> function.name().contains("__local_fun_"))
+                .singleElement()
+                .satisfies(function -> {
+                    assertThat(function.recursive()).isTrue();
+                    assertThat(function.tailRecursive()).isTrue();
+                });
+    }
+
+    private static CompiledProgram compileProgram(String source) {
+        var result = CapybaraCompiler.INSTANCE.compile(
+                List.of(new RawModule("Recursion", "/foo/bar", source)),
+                new TreeSet<>()
+        );
+        if (result instanceof Result.Error<CompiledProgram> error) {
+            throw new AssertionError(error.errors().toString());
+        }
+        return ((Result.Success<CompiledProgram>) result).value();
+    }
+
+    private static CompiledFunction function(CompiledProgram program, String name) {
+        return program.modules().first().functions().stream()
+                .filter(function -> function.name().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -317,6 +317,26 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldRewriteQualifiedTailRecursiveCallWhenStaticMethodsUseModuleSuffix() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram("Counter", "/foo/bar", """
+                data Counter { value: int }
+
+                fun rec sum(n: int, acc: int): int =
+                    if n <= 0 then acc else Counter.sum(n - 1, acc + n)
+                """));
+
+        var generated = generatedProgram.modules().stream()
+                .filter(module -> module.relativePath().equals(Path.of("foo", "bar", "CounterModule.java")))
+                .findFirst()
+                .orElseThrow()
+                .code();
+
+        assertThat(generated).contains("while (true)");
+        assertThat(generated).contains("continue;");
+        assertThat(generated).doesNotContain("return foo.bar.CounterModule.sum(");
+    }
+
+    @Test
     void shouldNotGenerateDuplicateRecordToStringWhenCapybaraDefinesToString() {
         var program = compileProgram("Pretty", "/foo/bar", """
                 data Pretty { value: string }

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -475,9 +475,9 @@ class CapybaraParserTest {
         var parser = new CapybaraParser();
         Method method = CapybaraParser.class.getDeclaredMethod("formatParserError", RawModule.class, String.class, String.class);
         method.setAccessible(true);
-        var module = new RawModule("SemVer", "/capy/util", """
+                var module = new RawModule("SemVer", "/capy/util", """
                 fun parse(): int =
-                    fun __parse_positive_digit(value: int): int = value
+                    fun rec __parse_positive_digit(value: int): int = __parse_positive_digit(value)
                     fun __parse_positive_digit(value: int): int = value + 1
                     ---
                     0
@@ -509,6 +509,46 @@ class CapybaraParserTest {
 
         var localFunction = findFunction("__accumulate__scope_1_0__local_fun_0_accumulate", module.functional());
         assertThat(localFunction.comments()).containsExactly("Internal accumulate");
+    }
+
+    @Test
+    @DisplayName("should parse tail recursive function marker")
+    void parseTailRecursiveFunctionMarker() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun rec sum(n: int, acc: int): int =
+                    if n <= 0 then acc else sum(n - 1, acc + n)
+                """));
+
+        var function = findFunction("sum", module.functional());
+        assertThat(function.tailRecursive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should parse tail recursive local function marker")
+    void parseTailRecursiveLocalFunctionMarker() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun sum(n: int): int =
+                    fun rec __sum(n: int, acc: int): int =
+                        if n <= 0 then acc else __sum(n - 1, acc + n)
+                    ---
+                    __sum(n, 0)
+                """));
+
+        var localFunction = findFunction("__sum__scope_1_0__local_fun_0_sum", module.functional());
+        assertThat(localFunction.tailRecursive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should keep rec usable as a function name and call")
+    void parseRecFunctionNameAndCall() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun rec(x: int): int = x
+                fun call_rec(x: int): int = rec(x)
+                """));
+
+        assertThat(findFunction("rec", module.functional()).tailRecursive()).isFalse();
+        var call = (FunctionCall) findFunction("call_rec", module.functional()).expression();
+        assertThat(call.name()).isEqualTo("rec");
     }
 
     @Test

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -112,7 +112,7 @@ fun Date.add_years_months(years: int, months: int): Date =
 
 /// Formats this date as an ISO 8601 calendar date.
 fun Date.to_iso_8601(): string =
-    fun __pad_left(value: string, size: int): string =
+    fun rec __pad_left(value: string, size: int): string =
         if value.size >= size
         then value
         else __pad_left("0" + value, size)
@@ -140,7 +140,7 @@ fun from_iso_8601(iso: string): Result[Date] =
             match ("" + char).to_int() with
             case Success { digit } -> Success { __Parse { buffer: value[1:], value: digit } }
             case Error -> Error { __invalid("expected digit, got `" + char + "`") }
-    fun __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
+    fun rec __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
         if value.is_empty
         then Success { __Parse { buffer: value, value: parsed } }
         else
@@ -155,21 +155,21 @@ fun from_iso_8601(iso: string): Result[Date] =
         if parse.buffer.is_empty
         then Success { parse.value }
         else Error { __invalid("expected digits for " + label + ", got `" + value + "`") }
-    fun __drop_prefix(value: string, size: int): string =
+    fun rec __drop_prefix(value: string, size: int): string =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
             case Some { _ } -> __drop_prefix(value[1:], size - 1)
-    fun __take_prefix(value: string, size: int): string =
+    fun rec __take_prefix(value: string, size: int, acc: string): string =
         if size <= 0
-        then ""
+        then acc
         else
             match value[0] with
-            case None -> ""
-            case Some { char } -> ("" + char) + __take_prefix(value[1:], size - 1)
-    fun __slice(value: string, start: int, size: int): string = __take_prefix(__drop_prefix(value, start), size)
+            case None -> acc
+            case Some { char } -> __take_prefix(value[1:], size - 1, acc + char)
+    fun __slice(value: string, start: int, size: int): string = __take_prefix(__drop_prefix(value, start), size, "")
     fun __parse_year(value: string): Result[int] =
         if value.is_empty
         then Error { __invalid("expected year") }
@@ -212,7 +212,7 @@ fun from_iso_8601(iso: string): Result[Date] =
         & __slice(iso, extended_month_end, 1) == "-"
     let is_basic = iso.size >= 8
     if is_extended
-    then __parse_date(__take_prefix(iso, extended_year_end), __slice(iso, extended_month_start, 2), __slice(iso, extended_day_start, 2))
+    then __parse_date(__take_prefix(iso, extended_year_end, ""), __slice(iso, extended_month_start, 2), __slice(iso, extended_day_start, 2))
     else if is_basic
-        then __parse_date(__take_prefix(iso, basic_year_end), __slice(iso, basic_month_start, 2), __slice(iso, basic_day_start, 2))
+        then __parse_date(__take_prefix(iso, basic_year_end, ""), __slice(iso, basic_month_start, 2), __slice(iso, basic_day_start, 2))
         else Error { __invalid("expected date in `YYYY-MM-DD` or `YYYYMMDD` format, got `" + iso + "`") }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -131,7 +131,7 @@ fun from_iso_8601(iso: string): Result[DateTime] =
     data __Split { left: string, right: string }
     data __SplitScan { left: string, right: string, seen_separator: bool }
     fun __invalid(message: string): string = "Invalid ISO 8601 date-time format: " + message
-    fun __scan_split(value: string, scan: __SplitScan): Result[__Split] =
+    fun rec __scan_split(value: string, scan: __SplitScan): Result[__Split] =
         if value.is_empty
         then if !scan.seen_separator
             then Error { __invalid("expected `T` separator between date and time") }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -131,7 +131,7 @@ fun from_iso_8601(iso: string): Result[Duration] =
         case None -> Error { __invalid("unexpected end of string while parsing digits") }
         case Some { '0' } -> Success { __Parse { buffer: value[1:], value: 0 } }
         case Some -> __parse_positive_digit(value)
-    fun __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
+    fun rec __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
         match value[0] with
         case Some { char } ->
             if match char with
@@ -301,7 +301,7 @@ fun from_iso_8601(iso: string): Result[Duration] =
             has_component: true,
             has_time_component: parse.has_time_component | parse.in_time
         }}
-    fun __parse_designator_duration(parse: __DurationParse): Result[Duration] =
+    fun rec __parse_designator_duration(parse: __DurationParse): Result[Duration] =
         match parse.buffer[0] with
         case None ->
             if !parse.has_component

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -51,14 +51,14 @@ fun from_iso_8601(iso: string): Result[Interval] =
     data __Split { left: string, right: string }
     data __SplitScan { left: string, right: string, seen_separator: bool }
     fun __invalid(message: string): string = "Invalid ISO 8601 interval format: " + message
-    fun __drop_prefix(value: string, size: int): string =
+    fun rec __drop_prefix(value: string, size: int): string =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
             case Some { _ } -> __drop_prefix(value[1:], size - 1)
-    fun __scan_split(separator: string, value: string, scan: __SplitScan): Result[__Split] =
+    fun rec __scan_split(separator: string, value: string, scan: __SplitScan): Result[__Split] =
         if value.is_empty
         then if !scan.seen_separator
             then Error { __invalid("expected exactly one `" + separator + "` separator") }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
@@ -59,7 +59,7 @@ fun Time.add_hours(hours: int): Time = this.add_seconds(hours * SECONDS_IN_HOUR)
 
 /// Formats this time as an ISO 8601 extended time.
 fun Time.to_iso_8601(): string =
-    fun __pad_left(value: string, size: int): string =
+    fun rec __pad_left(value: string, size: int): string =
         if value.size >= size
         then value
         else __pad_left("0" + value, size)
@@ -89,21 +89,21 @@ fun from_iso_8601(iso: string): Result[Time] =
     data __Parse[T] { buffer: string, value: T }
     data __ZoneParse { buffer: string, offset_minutes: Option[int] }
     fun __invalid(message: string): string = "Invalid ISO 8601 time format: " + message
-    fun __drop_prefix(value: string, size: int): string =
+    fun rec __drop_prefix(value: string, size: int): string =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
             case Some { _ } -> __drop_prefix(value[1:], size - 1)
-    fun __take_prefix(value: string, size: int): string =
+    fun rec __take_prefix(value: string, size: int, acc: string): string =
         if size <= 0
-        then ""
+        then acc
         else
             match value[0] with
-            case None -> ""
-            case Some { char } -> ("" + char) + __take_prefix(value[1:], size - 1)
-    fun __slice(value: string, start: int, size: int): string = __take_prefix(__drop_prefix(value, start), size)
+            case None -> acc
+            case Some { char } -> __take_prefix(value[1:], size - 1, acc + char)
+    fun __slice(value: string, start: int, size: int): string = __take_prefix(__drop_prefix(value, start), size, "")
     fun __parse_single_digit(value: string): Result[__Parse[int]] =
         match value[0] with
         case None -> Error { __invalid("unexpected end of string while parsing digits") }
@@ -111,7 +111,7 @@ fun from_iso_8601(iso: string): Result[Time] =
             match ("" + char).to_int() with
             case Success { digit } -> Success { __Parse { buffer: value[1:], value: digit } }
             case Error -> Error { __invalid("expected digit, got `" + char + "`") }
-    fun __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
+    fun rec __parse_rest_digits(value: string, parsed: int): Result[__Parse[int]] =
         if value.is_empty
         then Success { __Parse { buffer: value, value: parsed } }
         else
@@ -144,25 +144,25 @@ fun from_iso_8601(iso: string): Result[Time] =
         if value.is_empty
         then Error { __invalid("time must not be empty") }
         else if __slice(value, value.size - 1, 1) == "Z"
-            then Success { __ZoneParse { buffer: __take_prefix(value, value.size - 1), offset_minutes: Some { 0 } } }
+            then Success { __ZoneParse { buffer: __take_prefix(value, value.size - 1, ""), offset_minutes: Some { 0 } } }
             else if value.size >= 6
                 & (__slice(value, value.size - 6, 1) == "+" | __slice(value, value.size - 6, 1) == "-")
                 & __slice(value, value.size - 3, 1) == ":"
                 then {
                     let offset_minutes <- __parse_offset(__slice(value, value.size - 6, 1), __slice(value, value.size - 5, 2), __slice(value, value.size - 2, 2))
-                    Success { __ZoneParse { buffer: __take_prefix(value, value.size - 6), offset_minutes: Some { offset_minutes } } }
+                    Success { __ZoneParse { buffer: __take_prefix(value, value.size - 6, ""), offset_minutes: Some { offset_minutes } } }
                 }
                 else if value.size >= 5
                     & (__slice(value, value.size - 5, 1) == "+" | __slice(value, value.size - 5, 1) == "-")
                     then {
                         let offset_minutes <- __parse_offset(__slice(value, value.size - 5, 1), __slice(value, value.size - 4, 2), __slice(value, value.size - 2, 2))
-                        Success { __ZoneParse { buffer: __take_prefix(value, value.size - 5), offset_minutes: Some { offset_minutes } } }
+                        Success { __ZoneParse { buffer: __take_prefix(value, value.size - 5, ""), offset_minutes: Some { offset_minutes } } }
                     }
                     else if value.size >= 3
                         & (__slice(value, value.size - 3, 1) == "+" | __slice(value, value.size - 3, 1) == "-")
                         then {
                             let offset_minutes <- __parse_offset(__slice(value, value.size - 3, 1), __slice(value, value.size - 2, 2), "00")
-                            Success { __ZoneParse { buffer: __take_prefix(value, value.size - 3), offset_minutes: Some { offset_minutes } } }
+                            Success { __ZoneParse { buffer: __take_prefix(value, value.size - 3, ""), offset_minutes: Some { offset_minutes } } }
                         }
                         else Success { __ZoneParse { buffer: value, offset_minutes: None {} } }
     fun __parse_parts(hour_part: string, minute_part: string, second_part: string, offset_minutes: Option[int]): Result[Time] = {

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -9,7 +9,7 @@ data Path {
 }
 
 fun from_string(string: string): Path =
-    fun __segments(value: string, current: string, acc: list[string]): list[string] =
+    fun rec __segments(value: string, current: string, acc: list[string]): list[string] =
         match value[0] with
         case None ->
             if current == ""
@@ -85,7 +85,7 @@ fun Path.is_absolute(): bool =
 fun Path.is_root(): bool = this.segments.size == 0
 
 fun Path.normalize(): Path =
-    fun __normalize_path(root: PathRoot, segments: list[string], acc: list[string]): list[string] =
+    fun rec __normalize_path(root: PathRoot, segments: list[string], acc: list[string]): list[string] =
         match segments[0] with
         case None -> acc
         case Some { seg } ->
@@ -108,7 +108,6 @@ fun Path.normalize(): Path =
         prefix: this.prefix,
         segments: __normalize_path(this.root, this.segments, [])
     }
-
 
 
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -1,7 +1,7 @@
 from /capy/lang/Option import { * }
 
 fun digits(number: int): int =
-    fun __digits(number: int, acc: int): int =
+    fun rec __digits(number: int, acc: int): int =
         if number < 10
         then acc
         else __digits(number / 10, acc + 1)
@@ -60,7 +60,7 @@ fun min(a: int, b: int): int = if a < b then a else b
 ///
 /// Returns `None` when the list is empty.
 fun min(values: list[int]): Option[int] =
-    fun __min(min: int, values: list[int]): int =
+    fun rec __min(min: int, values: list[int]): int =
         match values[0] with
         case None -> min
         case Some { v } -> if min < v then __min(min, values[1:]) else __min(v, values[1:])
@@ -76,7 +76,7 @@ fun max(a: int, b: int): int = if a > b then a else b
 ///
 /// Returns `None` when the list is empty.
 fun max(values: list[int]): Option[int] =
-    fun __max(max: int, values: list[int]): int =
+    fun rec __max(max: int, values: list[int]): int =
         match values[0] with
         case None -> max
         case Some { v } -> if max < v then __max(v, values[1:]) else __max(max, values[1:])
@@ -92,7 +92,7 @@ fun min(a: long, b: long): long = if a < b then a else b
 ///
 /// Returns `None` when the list is empty.
 fun min(values: list[long]): Option[long] =
-    fun __min(min: long, values: list[long]): long =
+    fun rec __min(min: long, values: list[long]): long =
         match values[0] with
         case None -> min
         case Some { v } -> if min < v then __min(min, values[1:]) else __min(v, values[1:])
@@ -108,7 +108,7 @@ fun max(a: long, b: long): long = if a > b then a else b
 ///
 /// Returns `None` when the list is empty.
 fun max(values: list[long]): Option[long] =
-    fun __max(max: long, values: list[long]): long =
+    fun rec __max(max: long, values: list[long]): long =
         match values[0] with
         case None -> max
         case Some { v } -> if max < v then __max(v, values[1:]) else __max(max, values[1:])

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
@@ -7,34 +7,43 @@ data Match { group_value: string }
 fun from_literal(pattern: string, flags: string): Regex = Regex { pattern, flags }
 
 fun _drop_prefix(value: string, size: int): string =
-    if size <= 0
-    then value
-    else
-        match value[0] with
-        case None -> ""
-        case Some { _ } -> _drop_prefix(value[1:], size - 1)
+    fun rec __drop_prefix(value: string, size: int): string =
+        if size <= 0
+        then value
+        else
+            match value[0] with
+            case None -> ""
+            case Some { _ } -> __drop_prefix(value[1:], size - 1)
+    ---
+    __drop_prefix(value, size)
 
 fun _find_all(pattern: string, input: string, acc: list[Match]): list[Match] =
-    if pattern == ""
-    then acc
-    else
-        match input[0] with
-        case None -> acc
-        case Some { _ } ->
-            if input.starts_with(pattern)
-            then _find_all(pattern, _drop_prefix(input, pattern.size), acc + Match { group_value: pattern })
-            else _find_all(pattern, input[1:], acc)
+    fun rec __find_all(pattern: string, input: string, acc: list[Match]): list[Match] =
+        if pattern == ""
+        then acc
+        else
+            match input[0] with
+            case None -> acc
+            case Some { _ } ->
+                if input.starts_with(pattern)
+                then __find_all(pattern, _drop_prefix(input, pattern.size), acc + Match { group_value: pattern })
+                else __find_all(pattern, input[1:], acc)
+    ---
+    __find_all(pattern, input, acc)
 
 fun _split(pattern: string, input: string, current: string, acc: list[string]): list[string] =
-    if pattern == ""
-    then [input]
-    else
-        match input[0] with
-        case None -> acc + current
-        case Some { c } ->
-            if input.starts_with(pattern)
-            then _split(pattern, _drop_prefix(input, pattern.size), "", acc + current)
-            else _split(pattern, input[1:], current + c, acc)
+    fun rec __split(pattern: string, input: string, current: string, acc: list[string]): list[string] =
+        if pattern == ""
+        then [input]
+        else
+            match input[0] with
+            case None -> acc + current
+            case Some { c } ->
+                if input.starts_with(pattern)
+                then __split(pattern, _drop_prefix(input, pattern.size), "", acc + current)
+                else __split(pattern, input[1:], current + c, acc)
+    ---
+    __split(pattern, input, current, acc)
 
 fun Regex.matches(input: string): bool = input ? this.pattern
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -45,7 +45,7 @@ fun powers_of_2_seq() = powers_seq(2)
 ///
 /// This method is safe to use with infinite sequences.
 fun Seq[T].take(n: int): list[T] =
-    fun __take(seq: Seq[T], n: int, list: list[T]): list[T] =
+    fun rec __take(seq: Seq[T], n: int, list: list[T]): list[T] =
         if n <=0
         then list
         else
@@ -59,7 +59,7 @@ fun Seq[T].take(n: int): list[T] =
 ///
 /// Important: calling this on an infinite sequence does not terminate.
 fun Seq[T].as_list(): list[T] =
-    fun __as_list(seq: Seq[T], list: list[T]): list[T] =
+    fun rec __as_list(seq: Seq[T], list: list[T]): list[T] =
         match seq with
         case End -> list
         case Cons { value, rest } -> __as_list(rest(), list + value)
@@ -112,7 +112,7 @@ fun Seq[T].filter(pred: T => bool): Seq[T] =
 
 /// Skips the first `n` elements of the sequence.
 fun Seq[T].drop(n: int): Seq[T] =
-    fun __drop(seq: Seq[T], n: int) =
+    fun rec __drop(seq: Seq[T], n: int) =
         if n <= 0
         then seq
         else
@@ -130,7 +130,7 @@ fun Seq[T].drop(n: int): Seq[T] =
 ///
 /// The first element that satisfies `pred` is included in the result.
 fun Seq[T].drop_until(pred: T => bool): Seq[T] =
-    fun __drop_until(seq: Seq[T], pred: T => bool) =
+    fun rec __drop_until(seq: Seq[T], pred: T => bool) =
         match seq with
         case End -> End
         case Cons { value, rest } ->
@@ -201,7 +201,7 @@ fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
     __flat_map(this, map)
 
 fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
-    fun __reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
+    fun rec __reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
         match seq with
         case End -> acc
         case Cons { value, rest } -> __reduce(rest(), reducer(acc, value), reducer)

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -49,7 +49,7 @@ fun deserialize(json: string): Result[JsonObject] =
 data _Parse[T] { value: T, parsing_string: string }
 fun _Parse[T].pop(): tuple[Option[string], _Parse[T]] = (this.parsing_string[0], _Parse { this.value, this.parsing_string[1:] })
 
-fun _deserialize_json(json: string): Result[_Parse[Json]] =
+fun rec _deserialize_json(json: string): Result[_Parse[Json]] =
     match json[0] with
     case None -> Error { "Expected JSON, but got end of string" }
     case Some { first_char } when _is_white_space(first_char) -> _deserialize_json(_drop_white_space(json[1:]))
@@ -64,16 +64,17 @@ fun _deserialize_json(json: string): Result[_Parse[Json]] =
         case _ -> Error { "Do not know what to do with char `" + first_char + "`!" }
 
 fun _deserialize_json_array(json: string): Result[_Parse[JsonArray]] =
-    fun __deserialize_json_array(parse: _Parse[JsonArray]): Result[_Parse[JsonArray]] =
+    fun rec __deserialize_json_array(parse: _Parse[JsonArray]): Result[_Parse[JsonArray]] =
         match parse.parsing_string[0] with
         case None -> Error { "Expected `,` or `]`, but got end of string!" }
         case Some { ']' } -> Success { parse.pop()[1] }
-        case Some { ',' } ->
-            _deserialize_json(parse.parsing_string[1:])
-                | parse_json => __deserialize_json_array(_Parse {
-                    value: parse.value + parse_json.value,
-                    parsing_string: parse_json.parsing_string
-                })
+        case Some { ',' } -> {
+            let parse_json <- _deserialize_json(parse.parsing_string[1:])
+            __deserialize_json_array(_Parse {
+                value: parse.value + parse_json.value,
+                parsing_string: parse_json.parsing_string
+            })
+        }
         case Some { v } ->  Error { "Expected `,` or `]`, but got `" + v + "`!" }
     ---
     if json.starts_with('[]')
@@ -124,7 +125,7 @@ fun _deserialize_json_bool(json: string): Result[_Parse[JsonBool]] =
     }
 
 fun _deserialize_json_number(json: string): Result[_Parse[JsonNumber]] =
-    fun __parse_number(parse: _Parse[string]): Result[_Parse[string]] =
+    fun rec __parse_number(parse: _Parse[string]): Result[_Parse[string]] =
         match parse.parsing_string[0] with
         case None -> Error { 'Expected `-[0-9]`, but got empty string!' }
         case Some { first_char } ->
@@ -178,33 +179,29 @@ fun _deserialize_json_object(json: string): Result[_Parse[JsonObject]] =
     case Some { v } -> Error { message: "Expected `{`, but got `" + v + "`."}
 
 fun _deserialize_key_values(json: string): Result[_Parse[dict[Json]]] =
-    match json[0] with
-    case None -> Error { "Expected `,` or `}`, but got empty string!" }
-    case Some { "}" } -> {
-        let empty: dict[Json] = {:}
-        Success { _Parse { empty, json[1:] } }
-    }
-    case Some { _ } ->
-        match _deserialize_key_value(_drop_white_space(json)) with
-        case Error e -> e
-        case Success { parse_key_value } ->
-            match parse_key_value.parsing_string[0] with
-            case None -> Error { "Expected `,` or `}`, but got empty string!" }
-            case Some { "," } -> {
-                _deserialize_key_values(_drop_white_space(parse_key_value.parsing_string[1:]))
-                | rest =>
-                    Success { _Parse {
-                        { parse_key_value.value.key : parse_key_value.value.value } + rest.value,
-                        rest.parsing_string
-                    }}
-            }
-            case Some { "}" } -> Success {
-                _Parse {
-                    { parse_key_value.value.key : parse_key_value.value.value },
-                    _drop_white_space(parse_key_value.parsing_string[1:])
+    fun rec __deserialize_key_values(json: string, acc: dict[Json]): Result[_Parse[dict[Json]]] =
+        match json[0] with
+        case None -> Error { "Expected `,` or `}`, but got empty string!" }
+        case Some { "}" } -> Success { _Parse { acc, json[1:] } }
+        case Some { _ } ->
+            match _deserialize_key_value(_drop_white_space(json)) with
+            case Error e -> e
+            case Success { parse_key_value } -> {
+                let next = acc + { parse_key_value.value.key : parse_key_value.value.value }
+                match parse_key_value.parsing_string[0] with
+                case None -> Error { "Expected `,` or `}`, but got empty string!" }
+                case Some { "," } -> __deserialize_key_values(_drop_white_space(parse_key_value.parsing_string[1:]), next)
+                case Some { "}" } -> Success {
+                    _Parse {
+                        next,
+                        _drop_white_space(parse_key_value.parsing_string[1:])
+                    }
                 }
+                case Some { v } -> Error { "Expected `,` or `}`, but got `" + v + "`!" }
             }
-            case Some { v } -> Error { "Expected `,` or `}`, but got `" + v + "`!" }
+    ---
+    let empty: dict[Json] = {:}
+    __deserialize_key_values(json, empty)
 
 data _KeyValue { key: string, value: Json }
 
@@ -237,7 +234,7 @@ fun _parse_string(json: string): Result[_Parse[string]] =
     /// - `\r` - carriage return
     /// - `\t` - horizontal tab
     /// - `\\uXXXX` - 4 HEX digits
-    fun __parse_string_until_quotation(parse: _Parse[string], escape: bool): Result[_Parse[string]] =
+    fun rec __parse_string_until_quotation(parse: _Parse[string], escape: bool): Result[_Parse[string]] =
         if escape
         then
             match parse.parsing_string[0] with
@@ -267,18 +264,22 @@ fun _parse_string(json: string): Result[_Parse[string]] =
     case Some { v } -> Error { message: "parse_string: Expected `\"`, but got `" + v + "`." }
     case None -> Error { message: "parse_string: Expected JSON string, got end of string." }
 
-fun _drop_white_space(s: string): string =
+fun rec _drop_white_space(s: string): string =
     match s[0] with
     case Some { c } when _is_white_space(c) -> _drop_white_space(s[1:])
     case _ -> s
 
 fun _is_white_space(s: string): bool =
     const __white_spaces = { " ", "\r", "\n", "\t" }
+    fun rec __is_white_space(s: string, white_spaces: set[string]): bool =
+        match s[0] with
+        case None -> true
+        case Some { c } ->
+            if white_spaces ? c
+            then __is_white_space(s[1:], white_spaces)
+            else false
     ---
-    match s.size with
-    case 0 -> true
-    case 1 -> __white_spaces ? s
-    case _ -> (s |all? :_is_white_space)
+    __is_white_space(s, __white_spaces)
 
 fun deserialize(dict: dict[any]): Result[JsonObject] =
     data __Entry { key: string, value: Result[Json] }

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -312,15 +312,18 @@ private fun team_city_messages_case(test_case: TestCase): list[string] =
     ]
 
 fun team_city_escape(value: string): string =
-    match value[0] with
-    case None -> ''
-    case Some { '\'' } -> "|'" + team_city_escape(value[1:])
-    case Some { '\n' } -> '|n' + team_city_escape(value[1:])
-    case Some { '\r' } -> '|r' + team_city_escape(value[1:])
-    case Some { '|' } -> '||' + team_city_escape(value[1:])
-    case Some { '[' } -> '|[' + team_city_escape(value[1:])
-    case Some { ']' } -> '|]' + team_city_escape(value[1:])
-    case Some { c } -> c + team_city_escape(value[1:])
+    fun rec __team_city_escape(value: string, acc: string): string =
+        match value[0] with
+        case None -> acc
+        case Some { '\'' } -> __team_city_escape(value[1:], acc + "|'")
+        case Some { '\n' } -> __team_city_escape(value[1:], acc + '|n')
+        case Some { '\r' } -> __team_city_escape(value[1:], acc + '|r')
+        case Some { '|' } -> __team_city_escape(value[1:], acc + '||')
+        case Some { '[' } -> __team_city_escape(value[1:], acc + '|[')
+        case Some { ']' } -> __team_city_escape(value[1:], acc + '|]')
+        case Some { c } -> __team_city_escape(value[1:], acc + c)
+    ---
+    __team_city_escape(value, '')
 
 private fun test_suite_name(file_name: string): string = file_name
 
@@ -357,14 +360,16 @@ private fun stale_output_files(output_dir: Path, manifest_file: Path, expected_f
     )
 
 private fun stale_files(files: list[Path], expected_files: list[Path]): list[Path] =
-    match files[0] with
-    case None -> []
-    case Some { file } ->
-        let normalized = file.normalize()
-        let rest = stale_files(files[1:], expected_files)
-        if path_to_manifest_line(normalized) == OUTPUT_MANIFEST_FILE | path_list_contains(expected_files, normalized)
-        then rest
-        else [normalized] + rest
+    fun rec __stale_files(files: list[Path], expected_files: list[Path], acc: list[Path]): list[Path] =
+        match files[0] with
+        case None -> acc
+        case Some { file } ->
+            let normalized = file.normalize()
+            if path_to_manifest_line(normalized) == OUTPUT_MANIFEST_FILE | path_list_contains(expected_files, normalized)
+            then __stale_files(files[1:], expected_files, acc)
+            else __stale_files(files[1:], expected_files, acc + normalized)
+    ---
+    __stale_files(files, expected_files, [])
 
 private fun delete_stale_outputs(output_dir: Path, stale_files: list[Path]): Effect[Result[list[Path]]] =
     match stale_files[0] with
@@ -409,7 +414,7 @@ private fun manifest_content(paths: list[Path]): string =
     paths |> '', (acc, path) => acc + path_to_manifest_line(path.normalize()) + '\n'
 
 private fun manifest_paths(content: string): list[Path] =
-    fun lines(value: string, current: string, acc: list[string]): list[string] =
+    fun rec lines(value: string, current: string, acc: list[string]): list[string] =
         match value[0] with
         case None ->
             if current.is_empty
@@ -461,7 +466,7 @@ private fun list_regular_files_from_entries(entries: list[Path]): Effect[Result[
 private fun relative_to(base: Path, path: Path): Path =
     from_string(path_segments_to_string(drop_prefix_segments(base.normalize().segments, path.normalize().segments)))
 
-private fun drop_prefix_segments(prefix: list[string], segments: list[string]): list[string] =
+private fun rec drop_prefix_segments(prefix: list[string], segments: list[string]): list[string] =
     match prefix[0] with
     case None -> segments
     case Some { expected } ->
@@ -479,13 +484,14 @@ private fun path_to_manifest_line(path: Path): string =
     path_segments_to_string(path.normalize().segments)
 
 private fun path_segments_to_string(segments: list[string]): string =
-    match segments[0] with
-    case None -> ''
-    case Some { segment } ->
-        let rest = path_segments_to_string(segments[1:])
-        if rest.is_empty
-        then segment
-        else segment + '/' + rest
+    fun rec __path_segments_to_string(segments: list[string], acc: string): string =
+        match segments[0] with
+        case None -> acc
+        case Some { segment } ->
+            let next = if acc.is_empty then segment else acc + '/' + segment
+            __path_segments_to_string(segments[1:], next)
+    ---
+    __path_segments_to_string(segments, '')
 
 private fun has_failures(test_outputs: list[TestOutput]): bool = test_outputs |any? output => output.failed
 

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -1,6 +1,5 @@
 from /capy/lang/Option import { Option, Some, None }
 from /capy/lang/Result import {*}
-from /capy/lang/Math import { digits }
 
 /// Given a version number MAJOR.MINOR.PATCH, increment the:
 ///
@@ -111,15 +110,8 @@ fun parse_semver(version: string): Result[SemVer] =
         case None -> Error { 'Unexpected end of version string!' }
         case Some { '0' } -> Success { __Parse { version[1:], 0 } }
         case Some { value } ->
-            __parse_positive_digit(version)
-                | first_positive_digit_parse => {
-                    match __parse_digits(first_positive_digit_parse.buffer) with
-                    case Error -> Success { first_positive_digit_parse }
-                    case Success { parse_digits } -> Success { __Parse {
-                        buffer: parse_digits.buffer,
-                        value: first_positive_digit_parse.value * 10 ^ digits(parse_digits.value) + parse_digits.value
-                    }}
-                }
+            let first_positive_digit_parse <- __parse_positive_digit(version)
+            __parse_digits_rest(first_positive_digit_parse.buffer, first_positive_digit_parse.value)
 
         /// ```
         /// <pre-release> ::= <dot-separated pre-release identifiers>
@@ -130,19 +122,17 @@ fun parse_semver(version: string): Result[SemVer] =
         ///                                           | <pre-release identifier> "." <dot-separated pre-release identifiers>
         /// ```
         fun __parse_dot_separated_pre_release_identifiers(version: string): Result[__Parse[string]] =
-            __parse_pre_release_identifier(version)
-            | parse => {
-                match parse.buffer[0] with
-                case None -> Success { parse }
-                case Some { char } when char == '.' ->
-                    __parse_dot_separated_pre_release_identifiers(parse.buffer[1:])
-                    | parse_dot_separated => Success { __Parse {
-                        buffer: parse_dot_separated.buffer,
-                        value: parse.value + "." + parse_dot_separated.value
-                    }}
-                case Some { char } when char == '+' -> Success { parse }
-                case Some { char } -> Error { 'Expected end of version string or `.` for next pre-release identifier, but got `' + char + '`!' }
+            let parse <- __parse_pre_release_identifier(version)
+            __parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parse.value)
+        fun rec __parse_dot_separated_pre_release_identifiers_rest(version: string, parsed: string): Result[__Parse[string]] =
+            match version[0] with
+            case None -> Success { __Parse { buffer: version, value: parsed } }
+            case Some { char } when char == '.' -> {
+                let parse <- __parse_pre_release_identifier(version[1:])
+                __parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parsed + "." + parse.value)
             }
+            case Some { char } when char == '+' -> Success { __Parse { buffer: version, value: parsed } }
+            case Some { char } -> Error { 'Expected end of version string or `.` for next pre-release identifier, but got `' + char + '`!' }
         /// ```
         /// <pre-release identifier> ::= <alphanumeric identifier>
         ///                            | <numeric identifier>
@@ -164,20 +154,16 @@ fun parse_semver(version: string): Result[SemVer] =
         //                                     | <build identifier> "." <dot-separated build identifiers>
         /// ```
         fun __parse_dot_separated_build_identifiers(version: string): Result[__Parse[string]] =
-            __parse_dot_separated_build_identifier(version)
-            | parse_identifier => {
-                match parse_identifier.buffer[0] with
-                case None -> Success { parse_identifier }
-                case Some { char } when char == '.' -> {
-                    __parse_dot_separated_build_identifiers(parse_identifier.buffer[1:])
-                    | parse_dot_separated_build_identifiers =>
-                        Success { __Parse {
-                            buffer: parse_dot_separated_build_identifiers.buffer,
-                            value: parse_identifier.value + "." + parse_dot_separated_build_identifiers.value
-                        }}
-                    }
-                case Some { char } -> Error { 'Expected end of version string or `.` for next build identifier, but got `' + char + '`!' }
+            let parse_identifier <- __parse_dot_separated_build_identifier(version)
+            __parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parse_identifier.value)
+        fun rec __parse_dot_separated_build_identifiers_rest(version: string, parsed: string): Result[__Parse[string]] =
+            match version[0] with
+            case None -> Success { __Parse { buffer: version, value: parsed } }
+            case Some { char } when char == '.' -> {
+                let parse_identifier <- __parse_dot_separated_build_identifier(version[1:])
+                __parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parsed + "." + parse_identifier.value)
             }
+            case Some { char } -> Error { 'Expected end of version string or `.` for next build identifier, but got `' + char + '`!' }
         /// ```
         // <build identifier> ::= <alphanumeric identifier>
         //                      | <digits>
@@ -220,14 +206,12 @@ fun parse_semver(version: string): Result[SemVer] =
         //                           | <identifier character> <identifier characters>
         /// ```
         fun __parse_identifier_characters(version: string): Result[__Parse[string]] =
-            __parse_identifier_character(version)
-            | pic => {
-                match __parse_identifier_characters(pic.buffer) with
-                case Error -> Success { pic }
-                case Success { parse_identifier_characters } -> Success { __Parse {
-                    buffer: parse_identifier_characters.buffer,
-                    value: pic.value + parse_identifier_characters.value }}
-            }
+            let pic <- __parse_identifier_character(version)
+            __parse_identifier_characters_rest(pic.buffer, pic.value)
+        fun rec __parse_identifier_characters_rest(version: string, parsed: string): Result[__Parse[string]] =
+            match __parse_identifier_character(version) with
+            case Success { parse } -> __parse_identifier_characters_rest(parse.buffer, parsed + parse.value)
+            case Error -> Success { __Parse { buffer: version, value: parsed } }
         /// ```
         /// <identifier character> ::= <digit>
         ///                          | <non-digit>
@@ -252,24 +236,20 @@ fun parse_semver(version: string): Result[SemVer] =
         ///            | <digit> <digits>
         /// ```
         fun __parse_digits(version: string): Result[__Parse[int]] =
-            __parse_digit(version)
-            | parse =>
-                match __parse_digits(parse.buffer) with
-                case Error -> Success { parse }
-                case Success { parse_digits } -> Success { __Parse {
-                    buffer: parse_digits.buffer,
-                    value: parse.value * 10 ^ digits(parse_digits.value) + parse_digits.value
-                }}
+            let parse <- __parse_digit(version)
+            __parse_digits_rest(parse.buffer, parse.value)
+        fun rec __parse_digits_rest(version: string, parsed: int): Result[__Parse[int]] =
+            match __parse_digit(version) with
+            case Success { parse } -> __parse_digits_rest(parse.buffer, parsed * 10 + parse.value)
+            case Error -> Success { __Parse { buffer: version, value: parsed } }
         /// Same as `__parse_digits(version: string): Result[__Parse[int]]`, but returns string to prevent prefix zeroes from being stripped, which is important for build metadata identifiers
         fun __parse_digits_as_string(version: string): Result[__Parse[string]] =
-            __parse_digit_as_string(version)
-            | parse =>
-                match __parse_digits_as_string(parse.buffer) with
-                case Error -> Success { parse }
-                case Success { parse_digits } -> Success { __Parse {
-                    buffer: parse_digits.buffer,
-                    value: parse.value + parse_digits.value
-                }}
+            let parse <- __parse_digit_as_string(version)
+            __parse_digits_as_string_rest(parse.buffer, parse.value)
+        fun rec __parse_digits_as_string_rest(version: string, parsed: string): Result[__Parse[string]] =
+            match __parse_digit_as_string(version) with
+            case Success { parse } -> __parse_digits_as_string_rest(parse.buffer, parsed + parse.value)
+            case Error -> Success { __Parse { buffer: version, value: parsed } }
         /// ```
         /// <digit> ::= "0"
         ///           | <positive digit>

--- a/lib/capybara-lib/src/test/capybara/capy/util/SemVerTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/util/SemVerTest.cfun
@@ -8,6 +8,8 @@ fun tests(): Effect[TestFile] =
     let test_cases = {
         "1.2.3" : SemVer { 1, 2, 3, None {}, None {} },
         "0.0.0" : SemVer { 0, 0, 0, None {}, None {} },
+        "10.20.30" : SemVer { 10, 20, 30, None {}, None {} },
+        "100.200.300" : SemVer { 100, 200, 300, None {}, None {} },
         // pre-release
         "1.2.3-prerelease" : SemVer { 1, 2, 3, Some {'prerelease'}, None {} },
         "1.2.3-p.r.e.r.e.l.e.a.s.e" : SemVer { 1, 2, 3, Some {'p.r.e.r.e.l.e.a.s.e'}, None {} },


### PR DESCRIPTION
## Summary
- Add `fun rec` support for Capybara Functional functions, including local functions.
- Validate marked `rec` functions so missing recursion and non-tail recursion fail at compile time.
- Detect unmarked recursive functions, lower tail-recursive ones without requiring `rec`, and keep non-tail recursive functions callable.
- Add compiler and e2e coverage, including factorial stack-safety checks for marked and unmarked tail-recursive functions.
- Update the tail-recursion ADR with the final behavior.
- Mark/refactor eligible `lib/capybara-lib` helpers as tail-recursive, including accumulator rewrites for parsers/scanners where behavior stays equivalent.
- Add SemVer coverage for multi-digit core versions touched by the tail-recursive parser rewrite.

## Impacted Modules
- `compiler`: grammar, linker/validation, Java generation, diagnostics/tests.
- `capy`: e2e coverage for recursive Functional programs.
- `lib/capybara-lib`: Functional library helpers and SemVer tests.
- `docs`: ADR update for tail-recursion behavior.

## Sample
```cfun
fun rec sum(n: int, acc: int): int = if n <= 0 then acc else sum(n - 1, acc + n)
```

## Validation
- `env GRADLE_USER_HOME=/tmp/gradle-home-capybara-100 ./gradlew --project-cache-dir /tmp/gradle-project-cache-capybara-100 :compiler:test`
- `env GRADLE_USER_HOME=/tmp/gradle-home-capybara-100 ./gradlew --project-cache-dir /tmp/gradle-project-cache-capybara-100 :capy:e2eTests`
- `env GRADLE_USER_HOME=/tmp/gradle-home-capybara-100 ./gradlew --project-cache-dir /tmp/gradle-project-cache-capybara-100 :capy:e2eTests --tests dev.capylang.test.RecFunctionsTest`
- `env GRADLE_USER_HOME=/tmp/gradle-home-capybara-100 ./gradlew --no-daemon --no-configuration-cache --project-cache-dir /tmp/gradle-project-cache-capybara-100 :lib:capybara-lib:testCapybara`
- `git diff --check`

Closes #100
