### PR TITLE
Add capy.lang.Random PRNG and map `Random.seed` to System::nanoTime

### DIFF
--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -821,6 +821,9 @@ public final class JavaGenerator implements Generator {
         if (isCapyLangSystemNanoTimeMethod(ownerPackage, ownerName, method)) {
             return mapCapyLangSystemNanoTimeMethod(method, visibility, methodTypeParameters);
         }
+        if (isCapyLangRandomSeedMethod(ownerPackage, ownerName, method)) {
+            return mapCapyLangRandomSeedMethod(method, visibility, methodTypeParameters);
+        }
         if (isCapyTestCurrentLogTypeMethod(ownerPackage, ownerName, method)) {
             return mapCapyTestCurrentLogTypeMethod(method, visibility, methodTypeParameters);
         }
@@ -875,6 +878,21 @@ public final class JavaGenerator implements Generator {
     }
 
     private String mapCapyLangSystemNanoTimeMethod(JavaMethod method, String visibility, String methodTypeParameters) {
+        return mapJavaDoc(method.comments())
+               + visibility + "static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "() {\n"
+               + "return capy.lang.Effect.delay(java.lang.System::nanoTime);\n"
+               + "}\n";
+    }
+
+    private boolean isCapyLangRandomSeedMethod(String ownerPackage, String ownerName, JavaMethod method) {
+        return "capy.lang".equals(ownerPackage)
+               && "Random".equals(ownerName)
+               && "seed".equals(mapMethodName(method.name()))
+               && method.parameters().isEmpty()
+               && isEffectTypeReference(method.returnType().toString());
+    }
+
+    private String mapCapyLangRandomSeedMethod(JavaMethod method, String visibility, String methodTypeParameters) {
         return mapJavaDoc(method.comments())
                + visibility + "static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "() {\n"
                + "return capy.lang.Effect.delay(java.lang.System::nanoTime);\n"

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Random.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Random.cfun
@@ -1,0 +1,66 @@
+from /capy/lang/Effect import { * }
+from /capy/lang/Seq import { * }
+from /capy/lang/Primitives import { clamp_long_to_int }
+
+data Random { seed: long }
+
+/// Returns an impure seed based on the current JVM nano time.
+fun seed(): Effect[long] = <native>
+
+/// Returns a new random state seeded from current JVM nano time.
+fun random(): Effect[Random] = seed().map(value => Random { value })
+
+private const MULTIPLIER: long = 6364136223846793005L
+private const INCREMENT: long = 1442695040888963407L
+
+private fun _next_seed(seed: long): long = seed * MULTIPLIER + INCREMENT
+
+fun Random.long(): tuple[long, Random] =
+    let next = _next_seed(this.seed)
+    (next, Random { next })
+
+fun Random.int(): tuple[int, Random] =
+    let result = this.long()
+    (clamp_long_to_int(result[0]), result[1])
+
+fun Random.bool(): tuple[bool, Random] =
+    let result = this.long()
+    (result[0] % 2L == 0L, result[1])
+
+fun Random.float(): tuple[float, Random] =
+    let result = this.int()
+    let value = result[0]
+    // Normalize negative values to positive before scaling into [0, 1].
+    let positive = if value < 0 then 0 - value else value
+    (positive / 2147483647.0f, result[1])
+
+fun Random.double(): tuple[double, Random] =
+    let result = this.int()
+    let value = result[0]
+    // Normalize negative values to positive before scaling into [0, 1].
+    let positive = if value < 0 then 0 - value else value
+    (positive / 2147483647.0, result[1])
+
+fun Random.long_seq(): Seq[long] =
+    fun __next(random: Random): Seq[long] =
+        let value = random.long()
+        Cons { value[0], () => __next(value[1]) }
+    ---
+    __next(this)
+
+fun Random.int_seq(): Seq[int] =
+    fun __next(random: Random): Seq[int] =
+        let value = random.int()
+        Cons { value[0], () => __next(value[1]) }
+    ---
+    __next(this)
+
+fun Random.bool_seq(): Seq[bool] = this.long_seq().map(v => v % 2L == 0L)
+
+fun Random.float_seq(): Seq[float] =
+    // Normalize negatives to keep values within the expected [0, 1] range.
+    this.int_seq().map(v => (if v < 0 then 0 - v else v) / 2147483647.0f)
+
+fun Random.double_seq(): Seq[double] =
+    // Normalize negatives to keep values within the expected [0, 1] range.
+    this.int_seq().map(v => (if v < 0 then 0 - v else v) / 2147483647.0)

--- a/lib/capybara-lib/src/test/capybara/capy/lang/RandomTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/RandomTest.cfun
@@ -1,0 +1,41 @@
+from /capy/test/Assert import { * }
+from /capy/lang/Effect import { * }
+from /capy/lang/Random import { * }
+from /capy/lang/Seq import { * }
+from /capy/test/CapyTest import { * }
+
+fun tests(): Effect[TestFile] =
+    test_file("/capy/lang/RandomTest", [
+        test("should generate deterministic values", () => should_generate_deterministic_values()),
+        test("should advance random state", () => should_advance_random_state()),
+        test("should generate infinite random sequences", () => should_generate_infinite_random_sequences()),
+    ])
+
+fun should_generate_deterministic_values(): Assert =
+    let random = Random { 123L }
+    let r1 = random.long()
+    let r2 = random.long()
+    assert_all([
+        assert_that(r1[0]).is_equal_to(r2[0]),
+        assert_that(r1[1].seed).is_equal_to(r2[1].seed),
+    ])
+
+fun should_advance_random_state(): Assert =
+    let random = Random { 42L }
+    let b = random.bool()
+    let f = random.float()
+    let d = random.double()
+    assert_all([
+        assert_that(b[1].seed != random.seed).is_equal_to(true),
+        assert_that(f[1].seed != random.seed).is_equal_to(true),
+        assert_that(d[1].seed != random.seed).is_equal_to(true),
+    ])
+
+fun should_generate_infinite_random_sequences(): Assert =
+    let random = Random { 1L }
+    let ints = random.int_seq().take(5)
+    let doubles = random.double_seq().take(5)
+    assert_all([
+        assert_that(ints.size).is_equal_to(5),
+        assert_that(doubles.size).is_equal_to(5),
+    ])


### PR DESCRIPTION
### Motivation

- Provide a deterministic PRNG in the standard library with convenience functions and infinite sequences.
- Ensure the impure `seed()` effect for `capy.lang.Random` is implemented on the JVM by mapping it to a reliable time source.

### Description

- Add a new standard library implementation at `lib/capybara-lib/src/main/capybara/capy/lang/Random.cfun` that defines `data Random { seed: long }`, an LCG PRNG, helper methods (`long`, `int`, `bool`, `float`, `double`) and infinite sequence generators (`long_seq`, `int_seq`, `bool_seq`, `float_seq`, `double_seq`).
- Add `lib/capybara-lib/src/test/capybara/capy/lang/RandomTest.cfun` with unit tests for deterministic output, state advancement, and infinite sequence generation.
- Update the Java code generator in `compiler/src/main/java/dev/capylang/generator/JavaGenerator.java` to recognize `capy.lang.Random.seed` and map it to an effect that uses `java.lang.System::nanoTime`.

### Testing

- Added unit tests in `lib/capybara-lib/src/test/capybara/capy/lang/RandomTest.cfun` covering determinism, state advancement, and sequence generation; these tests were executed as part of the capybara-lib test suite and passed.
- Executed the repository test suite after the changes and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3390b240c832084e5483bf72b1cec)