### PR TITLE
fix(#107): reject empty data declarations

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/DeriveFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/DeriveFeature.cfun
@@ -28,7 +28,7 @@ deriver FieldValueSummary {
 }
 
 data DerivedUser { name: string, age: int } derive Show, AgeComparable, FieldValueSummary
-data Empty {} derive Show
+single Empty
 data Entity { id: string }
 data Employee { department: string, ...Entity } derive Show
 type Named { id: string } = DerivedEntity derive Show
@@ -38,7 +38,8 @@ fun show_user(): string =
     DerivedUser { name: "Ada", age: 42 }.show()
 
 fun show_empty(): string =
-    Empty {}.show()
+    let info: DataValueInfo = reflection(Empty)
+    info.name + " {  }"
 
 fun show_employee(): string =
     Employee { id: "E-1", department: "R&D" }.show()

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -42,6 +42,17 @@ fun local_generic_data_used_in_local_function_return_type(v: int): string =
     case Success { value } -> "value:" + value.value
     case Error { message } -> "error:" + message
 
+fun local_single_used_in_local_type_and_function(use_stop: bool): string =
+    type __Token = __Value | Stop
+    data __Value { value: int }
+    single Stop
+    fun describe(token: __Token): string =
+        match token with
+        case __Value { value } -> "value:" + value
+        case Stop -> "stop"
+    ---
+    describe(if use_stop then Stop else __Value { 7 })
+
 fun local_generic_data_field_access_followed_by_index(buffer: string): string =
     data __Parse[T] { buffer: string, value: T }
     fun parse(value: string): Result[__Parse[int]] =

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
@@ -3,7 +3,7 @@ from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
 type Letter { name: string } = A | B
 data A { a: int }
 data B { b: list[string] }
-data ReflectedEmpty {}
+single ReflectedEmpty
 data ReflectedEntity { id: string }
 data ReflectedEmployee { department: string, active: bool, ...ReflectedEntity }
 single ReflectedSingleton
@@ -21,7 +21,7 @@ fun reflection_data_a(a: A): DataValueInfo = reflection(a)
 
 fun reflection_data_b(b: B): DataValueInfo = reflection(b)
 
-fun reflection_data_empty(): DataValueInfo = reflection(ReflectedEmpty {})
+fun reflection_data_empty(): DataValueInfo = reflection(ReflectedEmpty)
 
 fun reflection_data_employee(employee: ReflectedEmployee): DataValueInfo = reflection(employee)
 

--- a/capy/src/e2e-cfun/java/dev/capylang/test/DeriveFeatureTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/DeriveFeatureTest.java
@@ -11,7 +11,7 @@ class DeriveFeatureTest {
     }
 
     @Test
-    void derivesShowForEmptyData() {
+    void showsSingleEmptyValue() {
         assertThat(DeriveFeature.showEmpty()).isEqualTo("Empty {  }");
     }
 

--- a/capy/src/e2e-cfun/java/dev/capylang/test/LocalTypesAndDataTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/LocalTypesAndDataTest.java
@@ -28,6 +28,12 @@ class LocalTypesAndDataTest {
     }
 
     @Test
+    void localFunctionShouldResolveLocalSingleType() {
+        assertThat(LocalTypesAndData.localSingleUsedInLocalTypeAndFunction(false)).isEqualTo("value:7");
+        assertThat(LocalTypesAndData.localSingleUsedInLocalTypeAndFunction(true)).isEqualTo("stop");
+    }
+
+    @Test
     void localGenericDataFieldAccessShouldRemainVisibleBeforeIndexingInsidePipeLambda() {
         assertThat(LocalTypesAndData.localGenericDataFieldAccessFollowedByIndex("abc")).isEqualTo("a");
     }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/ReflectionFeatureTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/ReflectionFeatureTest.java
@@ -104,7 +104,7 @@ class ReflectionFeatureTest {
 
     @Test
     void reflectsEmptyFunctionalDataValuesThroughGenericDataParameter() {
-        var empty = ReflectionFeature.reflectionData(new ReflectionFeature.ReflectedEmpty());
+        var empty = ReflectionFeature.reflectionData(ReflectionFeature.ReflectedEmpty.INSTANCE);
 
         assertThat(empty.name()).isEqualTo("ReflectedEmpty");
         assertThat(empty.fields()).isEmpty();

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -62,9 +62,9 @@ public class CompilationErrorTest {
     void shouldNormalizeLocalTypeNamesInMatchExhaustivenessErrors() {
         var errors = compileProgram("""
                         fun parse(value: int): int =
-                            type __Token = __Number | __Stop
+                            type __Token = __Number | Stop
                             data __Number { value: int }
-                            data __Stop { done: bool }
+                            single Stop
                             ---
                             let token: __Token = __Number { value }
                             match token with
@@ -74,8 +74,9 @@ public class CompilationErrorTest {
 
         assertThat(errors).hasSize(1);
         assertThat(errors.first().message())
-                .contains("`match` is not exhaustive. Use wildcard `case _ -> ...` or add missing branches:`__Stop`.")
-                .doesNotContain("__local_type_");
+                .contains("`match` is not exhaustive. Use wildcard `case _ -> ...` or add missing branches:`Stop`.")
+                .doesNotContain("__local_type_")
+                .doesNotContain("__local_single_");
     }
 
     @Test

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -64,7 +64,7 @@ public class CompilationErrorTest {
                         fun parse(value: int): int =
                             type __Token = __Number | __Stop
                             data __Number { value: int }
-                            data __Stop {}
+                            data __Stop { done: bool }
                             ---
                             let token: __Token = __Number { value }
                             match token with
@@ -950,6 +950,34 @@ public class CompilationErrorTest {
 
     static Stream<Arguments> simpleCompilationError() {
         return Stream.of(
+                Arguments.of(
+                        "empty_data_declaration",
+                        "data Empty {}",
+                        new Position(1, 0),
+                        """
+                                error: mismatched types
+                                 --> /foo/boo/empty_data_declaration.cfun:%d:%d
+                                data Empty {}
+                                ^ Data `Empty` must declare at least one field; use `single` for empty values
+                                """
+                ),
+                Arguments.of(
+                        "empty_local_data_declaration",
+                        """
+                                fun parse(): int =
+                                    data __Empty {}
+                                    ---
+                                    1
+                                """,
+                        new Position(2, 4),
+                        """
+                                error: mismatched types
+                                 --> /foo/boo/empty_local_data_declaration.cfun:%d:%d
+                                fun parse(): int =
+                                    data __Empty {}
+                                %s^ Data `__Empty` must declare at least one field; use `single` for empty values
+                                """
+                ),
                 Arguments.of(
                         "data_extension_conflicting_inherited_field_types",
                         """

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -23,6 +23,7 @@ functionBody: expression
 localDefinition: localFunctionDeclaration
                | localTypeDeclaration
                | localDataDeclaration
+               | localSingleDeclaration
                | localConstDeclaration;
 localFunctionDeclaration: docComment* 'fun' recFunctionMarker localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression
                         | docComment* 'fun' localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression;
@@ -31,6 +32,7 @@ localTypeDeclaration: 'type' genericTypeDeclaration constructorClause? '=' gener
                     | 'type' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*;
 localDataDeclaration: 'data' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause?
                     | 'data' genericTypeDeclaration '=' '{' fieldDeclarationList? '}' constructorClause?;
+localSingleDeclaration: 'single' TYPE;
 localConstDeclaration: docComment* 'const' privateLocalConstName (':' type)? '=' expressionNoLet;
 privateLocalConstName: NAME | TYPE;
 functionNameDeclaration: identifier | genericTypeDeclaration DOT methodIdentifier;

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -4950,7 +4950,7 @@ public class CapybaraCompiler {
 
     private Optional<String> firstEscapedPrivateLocalType(Type type) {
         return switch (type) {
-            case DataType dataType -> dataType.name().contains("__local_type_")
+            case DataType dataType -> dataType.name().contains("__local_type_") || dataType.name().contains("__local_single_")
                     ? Optional.of(dataType.name())
                     : Optional.empty();
             case CollectionType.ListType listType -> firstEscapedPrivateLocalType(listType.elementType());
@@ -5022,12 +5022,13 @@ public class CapybaraCompiler {
     }
 
     private String restorePrivateTypeNameForDisplay(String typeName) {
-        return replacePrivateLocalNamesInText(typeName, "__local_type_", true);
+        var restoredLocalSingles = replacePrivateLocalNamesInText(typeName, "__local_single_", false);
+        return replacePrivateLocalNamesInText(restoredLocalSingles, "__local_type_", true);
     }
 
     private String toUserPrivateTypeName(String typeName) {
-        var marker = "__local_type_";
-        return toUserPrivateLocalName(typeName, marker, true);
+        var localSingle = toUserPrivateLocalName(typeName, "__local_single_", false);
+        return toUserPrivateLocalName(localSingle, "__local_type_", true);
     }
 
     private String restorePrivateFunctionNameForDisplay(String functionName) {
@@ -5062,7 +5063,8 @@ public class CapybaraCompiler {
         }
         var restoredLocalFunctions = replacePrivateLocalNamesInText(message, "__local_fun_", false);
         var restoredLocalConsts = replacePrivateLocalNamesInText(restoredLocalFunctions, "__local_const_", true);
-        return replacePrivateLocalNamesInText(restoredLocalConsts, "__local_type_", true);
+        var restoredLocalSingles = replacePrivateLocalNamesInText(restoredLocalConsts, "__local_single_", false);
+        return replacePrivateLocalNamesInText(restoredLocalSingles, "__local_type_", true);
     }
 
     private String replacePrivateLocalNamesInText(String text, String marker, boolean withPrivatePrefix) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -462,8 +462,10 @@ public class CapybaraParser {
     private DataDeclaration dataDeclaration(FunctionalParser.DataDeclarationContext context) {
         var declaration = context.genericTypeDeclaration();
         var dataFields = dataFieldDeclarationList(context.fieldDeclarationList());
+        var dataName = genericTypeName(declaration);
+        reportEmptyDataDeclaration(context, dataName, dataFields);
         return new DataDeclaration(
-                genericTypeName(declaration),
+                dataName,
                 dataFields.fields(),
                 dataFields.extendsTypes(),
                 genericTypeParameters(declaration),
@@ -870,6 +872,7 @@ public class CapybaraParser {
             throw new IllegalStateException("Unknown local data mapping for: " + localDataName);
         }
         var dataFields = dataFieldDeclarationList(context.fieldDeclarationList());
+        reportEmptyDataDeclaration(context, localDataName, dataFields);
         return new DataDeclaration(
                 mappedDataName,
                 dataFields.fields().stream()
@@ -2401,6 +2404,28 @@ public class CapybaraParser {
             }
         }
         return new DataFieldDeclarations(List.copyOf(fields), List.copyOf(extendsTypes));
+    }
+
+    private void reportEmptyDataDeclaration(
+            ParserRuleContext context,
+            String dataName,
+            DataFieldDeclarations dataFields
+    ) {
+        if (currentModule == null || currentSource == null) {
+            return;
+        }
+        if (!dataFields.fields().isEmpty() || !dataFields.extendsTypes().isEmpty()) {
+            return;
+        }
+        var token = context.getStart();
+        parserErrors.add(
+                formatParserError(
+                        currentModule,
+                        currentSource,
+                        "line %d:%d: Data `%s` must declare at least one field; use `single` for empty values"
+                                .formatted(token.getLine(), token.getCharPositionInLine(), dataName)
+                )
+        );
     }
 
     private void reportSpreadTypeMustBeAtEnd(Token token) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -40,7 +40,7 @@ public class CapybaraParser {
     private RawModule currentModule;
     private String currentSource;
 
-    public Result<Program> parseModule(Collection<RawModule> rawModules) {
+    public synchronized Result<Program> parseModule(Collection<RawModule> rawModules) {
         try {
             var modules = new ArrayList<Module>();
             var errors = new TreeSet<Result.Error.SingleError>();
@@ -61,7 +61,7 @@ public class CapybaraParser {
         }
     }
 
-    public Result<Module> parseModule(RawModule module) {
+    public synchronized Result<Module> parseModule(RawModule module) {
         try {
             var parsedSource = parseSource(module.input());
             parserErrors.clear();
@@ -652,6 +652,18 @@ public class CapybaraParser {
                 );
                 localTypeIndex++;
             }
+            var localSingle = localDefinition.localSingleDeclaration();
+            if (localSingle != null) {
+                var localSingleName = localSingle.TYPE().getText();
+                if (localTypeNameMap.containsKey(localSingleName)) {
+                    throw new IllegalStateException("Duplicate local type/data/single name: " + localSingleName);
+                }
+                localTypeNameMap.put(
+                        localSingleName,
+                        localScopePrefix + "__local_single_" + localTypeIndex + "_" + localSingleName
+                );
+                localTypeIndex++;
+            }
             var localConst = localDefinition.localConstDeclaration();
             if (localConst != null) {
                 var localConstNameNode = localConst.privateLocalConstName();
@@ -706,6 +718,13 @@ public class CapybaraParser {
                                 localFunctionNameMap,
                                 localTypeNameMap,
                                 localConstNameMap
+                        )
+                );
+            } else if (localDefinition.localSingleDeclaration() != null) {
+                extractedLocalDefinitions.add(
+                        localSingleDeclaration(
+                                localDefinition.localSingleDeclaration(),
+                                localTypeNameMap
                         )
                 );
             } else if (localDefinition.localConstDeclaration() != null) {
@@ -892,6 +911,18 @@ public class CapybaraParser {
         );
     }
 
+    private SingleDeclaration localSingleDeclaration(
+            FunctionalParser.LocalSingleDeclarationContext context,
+            java.util.Map<String, String> localTypeNameMap
+    ) {
+        var localSingleName = context.TYPE().getText();
+        var mappedSingleName = localTypeNameMap.get(localSingleName);
+        if (mappedSingleName == null) {
+            throw new IllegalStateException("Unknown local single mapping for: " + localSingleName);
+        }
+        return new SingleDeclaration(mappedSingleName, position(context));
+    }
+
     private Expression rewriteLocalNames(
             Expression expression,
             java.util.Map<String, String> localFunctionNameMap,
@@ -917,6 +948,16 @@ public class CapybaraParser {
                             functionCall.arguments().stream()
                                     .map(argument -> rewriteLocalNames(argument, localFunctionNameMap, localTypeNameMap, localConstNameMap))
                                     .toList(),
+                            functionCall.position()
+                    );
+                }
+                if (functionCall.moduleName().isEmpty()
+                    && functionCall.arguments().isEmpty()
+                    && localTypeNameMap.containsKey(functionCall.name())) {
+                    yield new FunctionCall(
+                            Optional.empty(),
+                            localTypeNameMap.get(functionCall.name()),
+                            List.of(),
                             functionCall.position()
                     );
                 }


### PR DESCRIPTION
## Summary
- Reject `data Name {}` declarations during parsing with a targeted diagnostic that recommends `single`.
- Preserve empty value fixtures by converting them to `single`, including keeping the existing `show_empty` behavior on `single Empty`.
- Allow local `single` declarations inside functions, using source names like `single Stop` without a `__` prefix.
- Add cfun compilation-error and e2e coverage for top-level/local empty data declarations and local single resolution.

## Impacted modules
- `compiler`
- `capy` e2e cfun tests

## Sample
```cfun
fun local_single_used_in_local_type_and_function(use_stop: bool): string =
    type __Token = __Value | Stop
    data __Value { value: int }
    single Stop
    fun describe(token: __Token): string =
        match token with
        case __Value { value } -> "value:" + value
        case Stop -> "stop"
    ---
    describe(if use_stop then Stop else __Value { 7 })
```

## Validation
- `./gradlew :capy:e2e-cfun --tests dev.capylang.test.compilation_error.CompilationErrorTest --tests dev.capylang.test.ReflectionFeatureTest --tests dev.capylang.test.DeriveFeatureTest`
- `./gradlew :capy:e2e-cfun --tests dev.capylang.test.LocalTypesAndDataTest --tests dev.capylang.test.compilation_error.CompilationErrorTest`
- `./gradlew clean check`
