### PR TITLE
fix(#115): require constructor syntax for single values

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/Data.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/Data.cfun
@@ -22,7 +22,7 @@ type Knight = EnglishKnight | Tom
 data EnglishKnight { power: double }
 single Tom
 
-fun summon_tom(): Knight = Tom
+fun summon_tom(): Knight = Tom {}
 
 fun is_tom(knight: Knight): bool =
     match knight with
@@ -33,7 +33,7 @@ type King[T] = FrenchKing[T] | Jerry
 data FrenchKing[T] { head: bool, foo: T }
 single Jerry
 
-fun summon_jerry(): King[int] = Jerry
+fun summon_jerry(): King[int] = Jerry {}
 
 fun jerry_or_french(king: King[int]): string =
     match king with
@@ -59,7 +59,7 @@ fun string_plus_data_right(): string =
     PrintableData { foo: "abc", boo: 123 } + "=suffix"
 
 fun knight_holder_to_string(): string =
-    KnightHolder { knight: Tom } + ""
+    KnightHolder { knight: Tom {} } + ""
 
 fun create_positional_data(text: string, number: int): PositionalData =
     PositionalData { text, number }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/DeriveFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/DeriveFeature.cfun
@@ -38,7 +38,7 @@ fun show_user(): string =
     DerivedUser { name: "Ada", age: 42 }.show()
 
 fun show_empty(): string =
-    let info: DataValueInfo = reflection(Empty)
+    let info: DataValueInfo = reflection(Empty {})
     info.name + " {  }"
 
 fun show_employee(): string =

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/EmptyLiteralInference.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/EmptyLiteralInference.cfun
@@ -63,7 +63,7 @@ data OutcomeBatch { outcomes: list[Outcome] }
 
 fun to_seq_using_end_literal(list: list[T]): SeqEnd[T] =
     list
-        |> EndEnd, (acc, value) => ConsEnd { value, () => acc }
+        |> EndEnd {}, (acc, value) => ConsEnd { value, () => acc }
 
 fun seq_end_head_or_default(s: SeqEnd[int], d: int): int =
     match s with

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -51,7 +51,7 @@ fun local_single_used_in_local_type_and_function(use_stop: bool): string =
         case __Value { value } -> "value:" + value
         case Stop -> "stop"
     ---
-    describe(if use_stop then Stop else __Value { 7 })
+    describe(if use_stop then Stop {} else __Value { 7 })
 
 fun local_generic_data_field_access_followed_by_index(buffer: string): string =
     data __Parse[T] { buffer: string, value: T }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchWhen.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchWhen.cfun
@@ -36,8 +36,8 @@ fun sign(sign: Sign): string =
 
 fun letter(letter: Letter): string =
     match letter with
-    case Vowel when letter == Vowel -> "vowel"
-    case Consonant when letter == Consonant -> "hard"
+    case Vowel when letter == Vowel {} -> "vowel"
+    case Consonant when letter == Consonant {} -> "hard"
     case Consonant -> "consonant"
     case Vowel -> "other vowel"
 
@@ -50,4 +50,3 @@ fun range_label(range: Range): string =
     case Range { start, _, _, enabled } when enabled == false -> "disabled " + start
     case Range { _, _, step, _ } when step == 0 -> "stuck"
     case Range -> "other"
-

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
@@ -21,7 +21,7 @@ fun reflection_data_a(a: A): DataValueInfo = reflection(a)
 
 fun reflection_data_b(b: B): DataValueInfo = reflection(b)
 
-fun reflection_data_empty(): DataValueInfo = reflection(ReflectedEmpty)
+fun reflection_data_empty(): DataValueInfo = reflection(ReflectedEmpty {})
 
 fun reflection_data_employee(employee: ReflectedEmployee): DataValueInfo = reflection(employee)
 
@@ -39,7 +39,7 @@ fun reflection_any_to_json(value: any): ReflectedJson =
     case int i -> ReflectedJsonNumber { i }
     case bool b -> ReflectedJsonBool { b }
     case data d -> reflection_data_to_json(d)
-    case _ -> ReflectedJsonNull
+    case _ -> ReflectedJsonNull {}
 
 fun reflection_json_shape(obj: data): ReflectedJsonObject =
     match reflection_any_to_json(obj) with

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SeqCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SeqCollection.cfun
@@ -3,7 +3,7 @@ data Cons[T] { value: T, rest: Seq[T] }
 single End
 
 fun one_two_three(): Seq[int] =
-    Cons { 1, Cons { 2, Cons { 3, End } } }
+    Cons { 1, Cons { 2, Cons { 3, End {} } } }
 
 fun head_or_default(s: Seq[int], d: int): int =
     match s with
@@ -28,7 +28,7 @@ fun first_short_singleton(s: Seq[int]): /capy/lang/Option[int] =
 fun tail(s: Seq[int]): Seq[int] =
     match s with
     case Cons { value, rest } -> rest
-    case End -> End
+    case End -> End {}
 
 fun sum_first_two(s: Seq[int]): int =
     match s with
@@ -41,7 +41,7 @@ fun drop_local(s: Seq[int], n: int): Seq[int] =
         then seq
         else
             match seq with
-            case End -> End
+            case End -> End {}
             case Cons { value, rest } -> drop(rest, left - 1)
     ---
     drop(s, n)
@@ -49,10 +49,10 @@ fun drop_local(s: Seq[int], n: int): Seq[int] =
 fun until_local(s: Seq[int], stop: int): Seq[int] =
     fun until(seq: Seq[int], x: int) =
         match seq with
-        case End -> End
+        case End -> End {}
         case Cons { value, rest } ->
             if value == x
-            then End
+            then End {}
             else Cons { value, until(rest, x) }
     ---
     until(s, stop)

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -46,7 +46,7 @@ public class CompilationErrorTest {
                                                 case None -> Some { next_digit_parse.value }
                                         }
                                         __parse_digits(new_parse)
-                            __parse_digits(__Parse { buffer: version, value: None })|version_parse =>
+                            __parse_digits(__Parse { buffer: version, value: None {} })|version_parse =>
                                 if version_parse.buffer==false.is_empty then Error { "Unexpected characters after patch version: `"+version_parse.buffer+"`!" } else Success { version_parse.value }
                         """,
                 "local_names_in_errors");
@@ -77,6 +77,19 @@ public class CompilationErrorTest {
                 .contains("`match` is not exhaustive. Use wildcard `case _ -> ...` or add missing branches:`Stop`.")
                 .doesNotContain("__local_type_")
                 .doesNotContain("__local_single_");
+    }
+
+    @Test
+    void shouldRejectBareSingleExpression() {
+        var errors = compileProgram("""
+                        single Empty
+                        fun empty(): Empty = Empty
+                        """,
+                "bare_single_expression");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Singleton data value `Empty` must be constructed with `Empty {}`");
     }
 
     @Test
@@ -740,7 +753,7 @@ public class CompilationErrorTest {
                                 from /capy/lang/Option import { * }
                                 fun foo(v: string): Option[string] =
                                     match v[0] with
-                                    case None -> None
+                                    case None -> None {}
                                     case Some { value } -> value + ""
                                 """,
                         new Position(5, 33),
@@ -998,7 +1011,7 @@ public class CompilationErrorTest {
                                 fun to_seq(list: list[int]): Seq[int] =
                                     if list.size > 0
                                     then Cons { list[0], to_seq(list[1:])
-                                    else End
+                                    else End {}
                                 """,
                         new Position(7, 4),
                         """
@@ -1010,7 +1023,7 @@ public class CompilationErrorTest {
                                 fun to_seq(list: list[int]): Seq[int] =
                                     if list.size > 0
                                     then Cons { list[0], to_seq(list[1:])
-                                    else End
+                                    else End {}
                                     ^ Syntax error near `iflist.size>0thenCons{list[0],to_seq(list[1:])else`
                                 """
                 ),
@@ -1073,7 +1086,7 @@ public class CompilationErrorTest {
                         """
                                 fun parse(): int =
                                     let new_parse: __Parse[Option[int] = __Parse {
-                                        value: None
+                                        value: None {}
                                     }
                                     1
                                 """,
@@ -1182,7 +1195,7 @@ public class CompilationErrorTest {
                                 data JsonBool { value: bool }
                                 single JsonNull
                                   fun _deserialize_json_null(json: string): Result[_Parse[JsonBool]] =
-                                    let parsed: _Parse[JsonNull] = _Parse { JsonNull, json[4:] }
+                                    let parsed: _Parse[JsonNull] = _Parse { JsonNull {}, json[4:] }
                                     Success { parsed }
                                 """,
                         new Position(9, 4),
@@ -1190,7 +1203,7 @@ public class CompilationErrorTest {
                         + " --> /foo/boo/function_json_null_wrong_generic_return_type.cfun:%d:%d\n"
                         + "fun _deserialize_json_null(json: string): Result[_Parse[JsonBool]] =\n"
                         + "    let parsed: _Parse[JsonNull] = _Parse {\n"
-                        + "        JsonNull(),\n"
+                        + "        JsonNull {  },\n"
                         + "    ^ Expected `Result`, got `Success`\n"
                 ),
                 Arguments.of(

--- a/compiler/src/integrationTest/java/dev/capylang/compiler/CapybaraCompilerLibrariesIntegrationTest.java
+++ b/compiler/src/integrationTest/java/dev/capylang/compiler/CapybaraCompilerLibrariesIntegrationTest.java
@@ -61,7 +61,7 @@ class CapybaraCompilerLibrariesIntegrationTest {
                 fun Regex.`~>`(replacement: string): string => string = this.replace(replacement)
                 fun Regex.`/>`(input: string): list[string] = [input]
                 fun Match.group(index: int): /capy/lang/Option[string] =
-                    if index == 0 then /capy/lang/Option.Some { value: this.group_value } else /capy/lang/Option.None
+                    if index == 0 then /capy/lang/Option.Some { value: this.group_value } else /capy/lang/Option.None {}
                 fun Match.groups(): list[/capy/lang/Option[string]] = [/capy/lang/Option.Some { value: this.group_value }]
                 """;
         var libraries = compileProgram(List.of(new RawModule("Regex", "/capy/lang", regexLibrarySource)), new TreeSet<>()).modules();

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -4302,6 +4302,11 @@ public class CapybaraCompiler {
         if (returnType instanceof CompiledDataParentType parentType
             && expression instanceof dev.capylang.compiler.expression.CompiledNewData newData
             && newData.type() instanceof CompiledDataType actualDataType) {
+            if (parentType.enumType()
+                && actualDataType.singleton()
+                && parentType.subTypes().stream().anyMatch(subType -> sameTypeName(subType.name(), actualDataType.name()))) {
+                return expression;
+            }
             var matchingSubtype = parentType.subTypes().stream()
                     .filter(subType -> sameTypeName(subType.name(), actualDataType.name()))
                     .findFirst();

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -663,7 +663,11 @@ public class CapybaraExpressionCompiler {
             if (functionCall.arguments().isEmpty()) {
                 var singleton = findSingletonDataType(functionCall.name());
                 if (singleton.isPresent()) {
-                    return Result.success(new CompiledNewData(singleton.get(), List.of()));
+                    return withPosition(
+                            Result.error("Singleton data value `" + functionCall.name() + "` must be constructed with `"
+                                         + functionCall.name() + " {}`"),
+                            functionCall.position()
+                    );
                 }
             }
             return functionCall.arguments()
@@ -1151,7 +1155,17 @@ public class CapybaraExpressionCompiler {
                 + "\"");
     }
 
-    private Optional<CompiledDataType> findSingletonDataType(String constructorName) {
+    private record SingletonDataType(CompiledDataType type, Optional<CompiledDataParentType> enumParent) {
+    }
+
+    private Optional<SingletonDataType> findSingletonDataType(String constructorName) {
+        var qualified = qualifiedConstructorName(constructorName);
+        if (qualified.isPresent()) {
+            var qualifiedEnum = findEnumSingletonDataType(constructorName, qualified);
+            if (qualifiedEnum.isPresent()) {
+                return qualifiedEnum;
+            }
+        }
         var direct = dataTypes.values().stream()
                 .filter(CompiledDataType.class::isInstance)
                 .map(CompiledDataType.class::cast)
@@ -1159,15 +1173,47 @@ public class CapybaraExpressionCompiler {
                 .filter(dataType -> typeNameMatches(dataType.name(), constructorName))
                 .findFirst();
         if (direct.isPresent()) {
-            return direct;
+            return direct.map(dataType -> new SingletonDataType(dataType, Optional.empty()));
         }
-        return dataTypes.values().stream()
-                .filter(CompiledDataParentType.class::isInstance)
-                .map(CompiledDataParentType.class::cast)
-                .filter(CompiledDataParentType::enumType)
-                .flatMap(parentType -> parentType.subTypes().stream())
-                .filter(dataType -> typeNameMatches(dataType.name(), constructorName))
-                .findFirst();
+        return findEnumSingletonDataType(constructorName, qualified);
+    }
+
+    private Optional<SingletonDataType> findEnumSingletonDataType(
+            String constructorName,
+            Optional<QualifiedConstructorName> qualified
+    ) {
+        for (var type : dataTypes.values()) {
+            if (!(type instanceof CompiledDataParentType parentType) || !parentType.enumType()) {
+                continue;
+            }
+            for (var subType : parentType.subTypes()) {
+                var matches = qualified
+                        .map(parts -> typeNameMatches(parentType.name(), parts.ownerName())
+                                      && typeNameMatches(subType.name(), parts.valueName()))
+                        .orElseGet(() -> typeNameMatches(subType.name(), constructorName));
+                if (matches) {
+                    return Optional.of(new SingletonDataType(subType, Optional.of(parentType)));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private record QualifiedConstructorName(String ownerName, String valueName) {
+    }
+
+    private Optional<QualifiedConstructorName> qualifiedConstructorName(String constructorName) {
+        var normalized = constructorName.replace('\\', '/');
+        var valueSeparator = normalized.lastIndexOf('.');
+        if (valueSeparator < 0 || valueSeparator == normalized.length() - 1) {
+            return Optional.empty();
+        }
+        var ownerName = normalized.substring(0, valueSeparator);
+        var valueName = normalized.substring(valueSeparator + 1);
+        if (ownerName.isBlank() || valueName.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(new QualifiedConstructorName(ownerName, valueName));
     }
 
     private Optional<Result<CompiledExpression>> tryLinkEnumValuesFieldAccess(FieldAccess fieldAccess, Scope scope) {
@@ -6929,7 +6975,7 @@ public class CapybaraExpressionCompiler {
     }
 
     private Result<CompiledExpression> rawLinkNewData(NewData newData, Scope scope) {
-        return linkTypeInScope(newData.type(), scope)
+        return linkNewDataType(newData.type(), scope)
                 .flatMap(type -> linkSpreadAssignments(newData.spreads(), scope)
                         .flatMap(spreadAssignments ->
                                 linkFieldAssignment(newData.assignments(), scope, type)
@@ -6967,6 +7013,47 @@ public class CapybaraExpressionCompiler {
                                                 ));
                                             });
                                         }))));
+    }
+
+    private Result<CompiledType> linkNewDataType(Type type, Scope scope) {
+        var linkedType = linkTypeInScope(type, scope);
+        Optional<SingletonDataType> singleton = Optional.empty();
+        if (type instanceof DataType dataType) {
+            singleton = findSingletonDataType(dataType.name());
+            if (singleton.isPresent() && singleton.orElseThrow().enumParent().isPresent()) {
+                return Result.success(singletonConstructionType(singleton.orElseThrow()));
+            }
+        }
+        if (linkedType instanceof Result.Success<CompiledType>) {
+            var value = ((Result.Success<CompiledType>) linkedType).value();
+            if (value instanceof CompiledDataType dataType && dataType.singleton()) {
+                var enumParent = findEnumParentForValue(dataType.name());
+                if (enumParent != null) {
+                    return Result.success(singletonConstructionType(new SingletonDataType(dataType, Optional.of(enumParent))));
+                }
+            }
+            return linkedType;
+        }
+        if (singleton.isPresent()) {
+            return Result.success(singletonConstructionType(singleton.orElseThrow()));
+        }
+        return linkedType;
+    }
+
+    private CompiledDataType singletonConstructionType(SingletonDataType singleton) {
+        if (singleton.enumParent().isEmpty()) {
+            return singleton.type();
+        }
+        var enumParent = singleton.enumParent().orElseThrow();
+        return new CompiledDataType(
+                enumParent.name() + "." + singleton.type().name(),
+                singleton.type().fields(),
+                singleton.type().typeParameters(),
+                singleton.type().extendedTypes(),
+                singleton.type().comments(),
+                singleton.type().visibility(),
+                singleton.type().singleton()
+        );
     }
 
     private Result<CompiledExpression> applyProtectedConstructorIfNeeded(

--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -30,10 +30,10 @@ public final class JavaGenerator implements Generator {
         var functionNameOverrides = buildFunctionNameOverrides(program);
         var astBuilder = new JavaAstBuilder(functionNameOverrides);
         JavaExpressionEvaluator.setFunctionNameOverrides(functionNameOverrides);
-        var modules = program.modules().stream()
-                .map(module -> modules(module, timings, astBuilder))
-                .flatMap(List::stream)
-                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+        var modules = new ArrayList<GeneratedModule>();
+        for (var module : program.modules()) {
+            modules.addAll(modules(module, timings, astBuilder));
+        }
         modules.addAll(time(timings::addSourceRenderNanos, () -> objectOrientedJavaGenerator.generate(program.objectOrientedModules())));
         log.info(() -> "Java generation timings: AST build="
                        + Duration.ofNanos(timings.astBuildNanos())
@@ -44,51 +44,57 @@ public final class JavaGenerator implements Generator {
 
     private List<GeneratedModule> modules(CompiledModule module, GenerationTimings timings, JavaAstBuilder astBuilder) {
         var javaClass = time(timings::addAstBuildNanos, () -> astBuilder.build(module));
-        if (!hasTypeOrDataNameConflictWithFile(javaClass)) {
-            return List.of(new GeneratedModule(
-                    relativePath(javaClass, javaClass.name().toString()),
-                    time(timings::addSourceRenderNanos, () -> code(javaClass, javaClass.name().toString(), true))
-            ));
-        }
+        JavaExpressionEvaluator.setEnumValueOwnerOverrides(javaClass.enumValueOwnerOverrides());
+        try {
+            if (!hasTypeOrDataNameConflictWithFile(javaClass)) {
+                return List.of(new GeneratedModule(
+                        relativePath(javaClass, javaClass.name().toString()),
+                        time(timings::addSourceRenderNanos, () -> code(javaClass, javaClass.name().toString(), true))
+                ));
+            }
 
-        var ownerInterface = javaClass.interfaces().stream()
-                .filter(javaInterface -> javaInterface.name().toString().equals(javaClass.name().toString()))
-                .findFirst();
-        if (ownerInterface.isPresent()) {
-            return List.of(new GeneratedModule(
-                    relativePath(javaClass, javaClass.name().toString()),
-                    time(timings::addSourceRenderNanos, () -> codeNestedInOwnerInterface(javaClass, ownerInterface.get(), ownerInterface.get().name().toString()))
-            ));
-        }
+            var ownerInterface = javaClass.interfaces().stream()
+                    .filter(javaInterface -> javaInterface.name().toString().equals(javaClass.name().toString()))
+                    .findFirst();
+            if (ownerInterface.isPresent()) {
+                return List.of(new GeneratedModule(
+                        relativePath(javaClass, javaClass.name().toString()),
+                        time(timings::addSourceRenderNanos, () -> codeNestedInOwnerInterface(javaClass, ownerInterface.get(), ownerInterface.get().name().toString()))
+                ));
+            }
 
-        var helperCallOwnerName = javaClass.name() + "Module";
-        var compiled = new ArrayList<GeneratedModule>();
-        for (var declaration : topLevelDeclarations(javaClass, helperCallOwnerName)) {
-            compiled.add(new GeneratedModule(
-                    relativePath(javaClass, declaration.name()),
-                    time(timings::addSourceRenderNanos, () -> codeTopLevelDeclaration(javaClass, declaration.code()))
-            ));
-        }
+            var helperCallOwnerName = javaClass.name() + "Module";
+            var compiled = new ArrayList<GeneratedModule>();
+            for (var declaration : topLevelDeclarations(javaClass, helperCallOwnerName)) {
+                compiled.add(new GeneratedModule(
+                        relativePath(javaClass, declaration.name()),
+                        time(timings::addSourceRenderNanos, () -> codeTopLevelDeclaration(javaClass, declaration.code()))
+                ));
+            }
             var utilityStaticImports = new TreeSet<>(javaClass.staticImports());
             javaClass.enums().forEach(javaEnum -> utilityStaticImports.add(javaClass.javaPackage() + "." + javaEnum.name() + ".*"));
-        if (!javaClass.staticMethods().isEmpty() || !javaClass.staticConsts().isEmpty()) {
-            var utilityClass = new JavaClass(
-                    javaClass.annotations(),
-                    new JavaType(javaClass.name() + "Module"),
-                    javaClass.javaPackage(),
-                    utilityStaticImports,
-                    javaClass.staticConsts(),
-                    javaClass.staticMethods(),
-                    new TreeSet<>(),
-                    new TreeSet<>(),
-                    new TreeSet<>()
-            );
-            compiled.add(new GeneratedModule(
-                    relativePath(javaClass, utilityClass.name().toString()),
-                    time(timings::addSourceRenderNanos, () -> code(utilityClass, utilityClass.name().toString(), false))
-            ));
+            if (!javaClass.staticMethods().isEmpty() || !javaClass.staticConsts().isEmpty()) {
+                var utilityClass = new JavaClass(
+                        javaClass.annotations(),
+                        new JavaType(javaClass.name() + "Module"),
+                        javaClass.javaPackage(),
+                        utilityStaticImports,
+                        javaClass.staticConsts(),
+                        javaClass.staticMethods(),
+                        new TreeSet<>(),
+                        new TreeSet<>(),
+                        new TreeSet<>(),
+                        javaClass.enumValueOwnerOverrides()
+                );
+                compiled.add(new GeneratedModule(
+                        relativePath(javaClass, utilityClass.name().toString()),
+                        time(timings::addSourceRenderNanos, () -> code(utilityClass, utilityClass.name().toString(), false))
+                ));
+            }
+            return List.copyOf(compiled);
+        } finally {
+            JavaExpressionEvaluator.setEnumValueOwnerOverrides(java.util.Map.of());
         }
-        return List.copyOf(compiled);
     }
 
 

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -59,6 +59,7 @@ public class JavaAstBuilder {
                 .filter(parentType -> !parentType.enumType())
                 .collect(toCollection(TreeSet::new)), functionsByOwnerPrefix);
         var subClassToInterface = findSubClassToInterface(typeIndex.dataParentTypes(), interfaces);
+        var enumValueOwnerOverrides = enumValueOwnerOverrides(typeIndex);
         return new JavaClass(
                 sortedSetOf(generatedAnnotation()),
                 javaClassName,
@@ -70,7 +71,8 @@ public class JavaAstBuilder {
                 buildStaticMethods(module.functions(), staticMethodsSelfCallClassNames),
                 interfaces,
                 buildRecords(typeIndex.dataTypes(), subClassToInterface, functionsByOwnerPrefix, reflectionFallbackPackagePath),
-                buildEnums(typeIndex, subClassToInterface, reflectionFallbackPackagePath));
+                buildEnums(typeIndex, subClassToInterface, reflectionFallbackPackagePath),
+                enumValueOwnerOverrides);
     }
 
     private String reflectionFallbackPackagePath(CompiledModule module) {
@@ -128,6 +130,25 @@ public class JavaAstBuilder {
             }
         }
         return new ModuleTypeIndex(dataParentTypes, dataTypes, Set.copyOf(enumValueTypeNames));
+    }
+
+    private Map<String, String> enumValueOwnerOverrides(ModuleTypeIndex typeIndex) {
+        var ownersByValue = new LinkedHashMap<String, LinkedHashSet<String>>();
+        for (var parentType : typeIndex.dataParentTypes()) {
+            if (!parentType.enumType()) {
+                continue;
+            }
+            for (var subType : parentType.subTypes()) {
+                ownersByValue.computeIfAbsent(subType.name(), ignored -> new LinkedHashSet<>()).add(parentType.name());
+            }
+        }
+        var overrides = new LinkedHashMap<String, String>();
+        ownersByValue.forEach((valueName, ownerNames) -> {
+            if (ownerNames.size() == 1) {
+                overrides.put(valueName, ownerNames.iterator().next());
+            }
+        });
+        return Map.copyOf(overrides);
     }
 
     private SortedMap<String, List<CompiledFunction>> indexFunctionsByOwnerPrefix(Set<CompiledFunction> functions) {
@@ -478,6 +499,12 @@ public class JavaAstBuilder {
         if (genericStart > 0) {
             rawTypeName = rawTypeName.substring(0, genericStart);
         }
+        if (type instanceof CompiledDataType dataType && dataType.singleton()) {
+            var enumOwner = qualifiedEnumValueOwner(rawTypeName);
+            if (enumOwner.isPresent()) {
+                return buildGenericDataType(new CompiledDataParentType(enumOwner.orElseThrow(), List.of(), List.of(), List.of(), true));
+            }
+        }
         if ("Option".equals(rawTypeName) || isOptionTypeName(rawTypeName)) {
             return new JavaType("java.util.Optional");
         }
@@ -519,6 +546,19 @@ public class JavaAstBuilder {
             return withTypeParametersIfGeneric(type, qualifiedName);
         }
         return withTypeParametersIfGeneric(type, buildClassName(rawTypeName).toString());
+    }
+
+    private Optional<String> qualifiedEnumValueOwner(String typeName) {
+        var normalized = typeName.replace('\\', '/');
+        var valueSeparator = normalized.lastIndexOf('.');
+        if (valueSeparator <= 0 || valueSeparator == normalized.length() - 1) {
+            return Optional.empty();
+        }
+        var valueName = normalized.substring(valueSeparator + 1);
+        if (!valueName.equals(valueName.toUpperCase(Locale.ROOT))) {
+            return Optional.empty();
+        }
+        return Optional.of(normalized.substring(0, valueSeparator));
     }
 
     private JavaType withTypeParametersIfGeneric(GenericDataType type, String rawJavaTypeName) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaClass.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaClass.java
@@ -1,5 +1,6 @@
 package dev.capylang.generator.java;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -12,5 +13,6 @@ public record JavaClass(
         SortedSet<JavaMethod> staticMethods,
         SortedSet<JavaInterface> interfaces,
         SortedSet<JavaRecord> records,
-        SortedSet<JavaEnum> enums) {
+        SortedSet<JavaEnum> enums,
+        Map<String, String> enumValueOwnerOverrides) {
 }

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -20,9 +20,15 @@ import static java.lang.System.lineSeparator;
 public class JavaExpressionEvaluator {
     private static final ThreadLocal<java.util.Map<String, String>> FUNCTION_NAME_OVERRIDES =
             ThreadLocal.withInitial(java.util.Map::of);
+    private static final ThreadLocal<java.util.Map<String, String>> ENUM_VALUE_OWNER_OVERRIDES =
+            ThreadLocal.withInitial(java.util.Map::of);
 
     public static void setFunctionNameOverrides(java.util.Map<String, String> functionNameOverrides) {
         FUNCTION_NAME_OVERRIDES.set(java.util.Map.copyOf(functionNameOverrides));
+    }
+
+    public static void setEnumValueOwnerOverrides(java.util.Map<String, String> enumValueOwnerOverrides) {
+        ENUM_VALUE_OWNER_OVERRIDES.set(java.util.Map.copyOf(enumValueOwnerOverrides));
     }
     private static final java.util.concurrent.atomic.AtomicLong OPTION_CASE_VAR_COUNTER =
             new java.util.concurrent.atomic.AtomicLong();
@@ -1757,7 +1763,8 @@ public class JavaExpressionEvaluator {
             case dev.capylang.compiler.CompiledDataType linkedDataType ->
                     isOptionSomeTypeName(linkedDataType.name()) || isOptionNoneTypeName(linkedDataType.name())
                             ? "java.util.Optional"
-                            : normalizeJavaTypeReference(linkedDataType.name());
+                            : enumValueOwnerTypeReference(linkedDataType)
+                                    .orElseGet(() -> normalizeJavaTypeReference(linkedDataType.name()));
             case dev.capylang.compiler.CompiledDataParentType linkedDataParentType ->
                     normalizeJavaTypeReference(linkedDataParentType.name());
             case dev.capylang.compiler.CompiledGenericTypeParameter genericTypeParameter ->
@@ -2424,6 +2431,12 @@ public class JavaExpressionEvaluator {
             case CompiledMatchExpression.ConstructorPattern constructorPattern -> {
                 var constructorType = resolveConstructorType(matchType, constructorPattern.constructorName());
                 var patternType = constructorPatternTypeName(matchType, constructorType, constructorPattern.constructorName());
+                if (constructorType != null && constructorType.singleton() && constructorPattern.fieldPatterns().isEmpty()) {
+                    if (matchType instanceof CompiledDataParentType parentType && parentType.enumType()) {
+                        yield "case " + enumValuePatternName(constructorType.name());
+                    }
+                    yield "case " + patternType + " __ignored";
+                }
                 var bindingNames = constructorPatternBindingNames(constructorPattern, caseBindingNames);
                 var constructorCasePattern = "case " + patternType + "("
                                              + bindingNames.stream().map(name -> "var " + name).reduce((a, b) -> a + ", " + b).orElse("")
@@ -2432,6 +2445,12 @@ public class JavaExpressionEvaluator {
                 yield guard.map(s -> constructorCasePattern + " when " + s).orElse(constructorCasePattern);
             }
         };
+    }
+
+    private static String enumValuePatternName(String constructorName) {
+        var normalized = constructorName.replace('\\', '/');
+        var separator = Math.max(normalized.lastIndexOf('/'), normalized.lastIndexOf('.'));
+        return separator >= 0 ? normalized.substring(separator + 1) : normalized;
     }
 
     private static String optionParentCasePattern(
@@ -2975,7 +2994,7 @@ public class JavaExpressionEvaluator {
         if (dataType.singleton()) {
             var javaType = normalizeJavaTypeReference(dataType.name());
             if (isEnumValueType(dataType)) {
-                return current.addExpression(javaType);
+                return current.addExpression(enumValueReference(dataType));
             }
             return current.addExpression(javaType + ".INSTANCE");
         }
@@ -3028,8 +3047,57 @@ public class JavaExpressionEvaluator {
     }
 
     private static boolean isEnumValueType(CompiledDataType dataType) {
-        return dataType.name().equals(dataType.name().toUpperCase(java.util.Locale.ROOT));
+        return qualifiedEnumValueName(dataType.name())
+                .map(name -> isUppercaseName(name.valueName()))
+                .orElseGet(() -> isUppercaseName(dataType.name()));
     }
+
+    private static boolean isUppercaseName(String name) {
+        return name.equals(name.toUpperCase(java.util.Locale.ROOT));
+    }
+
+    private static String enumValueReference(CompiledDataType dataType) {
+        return qualifiedEnumValueName(dataType.name())
+                .map(name -> normalizeJavaTypeReference(name.ownerName()) + "." + enumValuePatternName(name.valueName()))
+                .orElseGet(() -> {
+                    var ownerName = enumValueOwnerOverrides().get(dataType.name());
+                    if (ownerName != null) {
+                        return normalizeJavaTypeReference(ownerName) + "." + enumValuePatternName(dataType.name());
+                    }
+                    return normalizeJavaTypeReference(dataType.name());
+                });
+    }
+
+    private static Optional<String> enumValueOwnerTypeReference(CompiledDataType dataType) {
+        return qualifiedEnumValueName(dataType.name())
+                .filter(name -> isUppercaseName(name.valueName()))
+                .map(name -> normalizeJavaTypeReference(name.ownerName()))
+                .or(() -> Optional.ofNullable(enumValueOwnerOverrides().get(dataType.name()))
+                        .filter(ignored -> isUppercaseName(dataType.name()))
+                        .map(JavaExpressionEvaluator::normalizeJavaTypeReference));
+    }
+
+    private record QualifiedEnumValueName(String ownerName, String valueName) {
+    }
+
+    private static Optional<QualifiedEnumValueName> qualifiedEnumValueName(String typeName) {
+        var normalized = typeName.replace('\\', '/');
+        var valueSeparator = normalized.lastIndexOf('.');
+        if (valueSeparator < 0 || valueSeparator == normalized.length() - 1) {
+            return Optional.empty();
+        }
+        var ownerName = normalized.substring(0, valueSeparator);
+        var valueName = normalized.substring(valueSeparator + 1);
+        if (ownerName.isBlank() || valueName.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(new QualifiedEnumValueName(ownerName, valueName));
+    }
+
+    private static java.util.Map<String, String> enumValueOwnerOverrides() {
+        return ENUM_VALUE_OWNER_OVERRIDES.get();
+    }
+
     private static Scope evaluateStringValue(CompiledStringValue stringValue, Scope scope) {
         return scope.addExpression(stringValue.toString());
     }

--- a/compiler/src/test/java/dev/capylang/compiler/InfixOperatorCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/InfixOperatorCompilerTest.java
@@ -149,8 +149,8 @@ class InfixOperatorCompilerTest {
                         data Some[T] { value: T }
                         single None
 
-                        fun to_seq(values: list[T]): Seq[T] = End
-                        fun Seq[T].first_match(pred: T => bool): Option[T] = None
+                        fun to_seq(values: list[T]): Seq[T] = End {}
+                        fun Seq[T].first_match(pred: T => bool): Option[T] = None {}
                         """)
         )).modules();
 
@@ -176,7 +176,7 @@ class InfixOperatorCompilerTest {
                         data Cons[T] { value: T, rest: () => Seq[T] }
                         single End
 
-                        fun to_seq(values: list[T]): Seq[T] = End
+                        fun to_seq(values: list[T]): Seq[T] = End {}
                         """)
         )).modules();
 

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -250,7 +250,7 @@ class JavaExpressionEvaluatorTest {
                 type TestResult = Passed
                 data TestCase { name: string, result: TestResult, assertions_count: int, execution_time: long }
 
-                private fun execute(assertions: list[Assertion]): TestResult = Passed
+                private fun execute(assertions: list[Assertion]): TestResult = Passed {}
                 fun test(name: string, assert_: Assert): TestCase =
                     TestCase {
                         name: name,
@@ -279,7 +279,7 @@ class JavaExpressionEvaluatorTest {
                 type TestResult = Passed
                 data TestCase { name: string, result: TestResult, assertions_count: int, execution_time: long }
 
-                private fun execute(assertions: list[Assertion]): TestResult = Passed
+                private fun execute(assertions: list[Assertion]): TestResult = Passed {}
                 fun test(name: string, assert_: Assert): TestCase =
                     TestCase {
                         name: name,
@@ -326,6 +326,24 @@ class JavaExpressionEvaluatorTest {
         assertThat(generated).contains("enum Color implements dev.capylang.CapybaraDataValue {RED, BLUE;");
         assertThat(generated).contains("new capy.metaProg.Reflection.DataValueInfo(\"Lonely\"");
         assertThat(generated).contains("case RED -> new capy.metaProg.Reflection.DataValueInfo(\"RED\"");
+    }
+
+    @Test
+    void shouldQualifyConstructedEnumValuesInGeneratedJava() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram("Consumer", "/foo/app", """
+                enum PathRoot { RELATIVE, ABSOLUTE }
+                fun root(): PathRoot = PathRoot.ABSOLUTE {}
+                fun inferred_root() = PathRoot.RELATIVE {}
+                """));
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated)
+                .contains("public static PathRoot inferredRoot()")
+                .contains("return PathRoot.ABSOLUTE;")
+                .contains("return PathRoot.RELATIVE;");
+        assertGeneratedJavaCompiles(generatedProgram);
     }
 
     @Test
@@ -1031,7 +1049,7 @@ class JavaExpressionEvaluatorTest {
                                 type Knight = EnglishKnight | Tom
                                 data EnglishKnight { power: float }
                                 single Tom
-                                fun summon_tom(): Knight = Tom
+                                fun summon_tom(): Knight = Tom {}
                                 """,
                         "return Tom.INSTANCE;"
                 ),

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -36,10 +36,10 @@ fun from_string(string: string): Path =
     Path {
         root:
             if string.starts_with('/')
-            then PathRoot.ABSOLUTE
+            then PathRoot.ABSOLUTE {}
             else if string.starts_with('~')
-            then PathRoot.HOME
-            else PathRoot.RELATIVE,
+            then PathRoot.HOME {}
+            else PathRoot.RELATIVE {},
         prefix: None {},
         segments: __segments(value, "", [])
     }.normalize()
@@ -108,6 +108,5 @@ fun Path.normalize(): Path =
         prefix: this.prefix,
         segments: __normalize_path(this.root, this.segments, [])
     }
-
 
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
@@ -50,7 +50,7 @@ fun Regex.matches(input: string): bool = input ? this.pattern
 fun Regex.find(input: string): Option[Match] =
     match _find_all(this.pattern, input, [])[0] with
     case Some { value } -> Some { value }
-    case None -> None
+    case None -> None {}
 
 fun Regex.find_all(input: string): /capy/lang/Seq[Match] =
     /capy/lang/Seq.to_seq(_find_all(this.pattern, input, []))
@@ -66,6 +66,6 @@ fun Regex.`~~`(input: string): /capy/lang/Seq[Match] = this.find_all(input)
 fun Regex.`~>`(replacement: string): string => string = this.replace(replacement)
 fun Regex.`/>`(input: string): list[string] = this.split(input)
 
-fun Match.group(index: int): Option[string] = if index == 0 then Some { value: this.group_value } else None
+fun Match.group(index: int): Option[string] = if index == 0 then Some { value: this.group_value } else None {}
 
 fun Match.groups(): list[Option[string]] = [Some { value: this.group_value }]

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -68,15 +68,15 @@ fun Seq[T].as_list(): list[T] =
 
 /// Converts a `list` into a finite `Seq`.
 fun to_seq(list: list[T]): Seq[T] =
-    list |> End, (acc, value) => acc + Cons { value, () => End }
+    list |> End {}, (acc, value) => acc + Cons { value, () => End {} }
 
 /// Converts a `set` into a finite `Seq`.
 fun to_seq(list: set[T]): Seq[T] =
-    list |> End, (acc, value) => acc + Cons { value, () => End }
+    list |> End {}, (acc, value) => acc + Cons { value, () => End {} }
 
 /// Converts a `dict` into a finite `Seq` of `(key, value)` tuples.
 fun to_seq(list: dict[T]): Seq[tuple[string, T]] =
-    list |> End, (acc, key, value) => acc + Cons { (key, value), () => End }
+    list |> End {}, (acc, key, value) => acc + Cons { (key, value), () => End {} }
 
 /// Collects the last `n` elements into a `list`.
 ///
@@ -102,7 +102,7 @@ fun Seq[T].take_last(n: int): list[T] =
 fun Seq[T].filter(pred: T => bool): Seq[T] =
     fun __filter(seq: Seq[T], pred: T => bool): Seq[T] =
         match seq with
-        case End -> End
+        case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
             then Cons { value, () => __filter(rest(), pred) }
@@ -117,7 +117,7 @@ fun Seq[T].drop(n: int): Seq[T] =
         then seq
         else
             match seq with
-            case End -> End
+            case End -> End {}
             case Cons { value, rest } -> __drop(rest(), n - 1)
     ---
     __drop(this, n)
@@ -132,7 +132,7 @@ fun Seq[T].drop(n: int): Seq[T] =
 fun Seq[T].drop_until(pred: T => bool): Seq[T] =
     fun rec __drop_until(seq: Seq[T], pred: T => bool) =
         match seq with
-        case End -> End
+        case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
             then Cons { value, rest }
@@ -146,10 +146,10 @@ fun Seq[T].drop_until(pred: T => bool): Seq[T] =
 fun Seq[T].until(pred: T => bool): Seq[T] =
     fun __until(seq: Seq[T], pred: T => bool) =
         match seq with
-        case End -> End
+        case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
-            then End
+            then End {}
             else Cons { value, () => __until(rest(), pred) }
     ---
     __until(this, pred)
@@ -168,12 +168,12 @@ fun Seq[T].`+`(other: Seq[T]): Seq[T] =
 /// Transforms each element using `map`.
 fun Seq[T].`|`(map: T => Y): Seq[Y] =
     match this with
-    case End -> End
+    case End -> End {}
     case Cons { value, rest } -> Cons { map(value), () => (rest() | map) }
 
 fun Seq[T].map(map: T => Y): Seq[Y] =
     match this with
-    case End -> End
+    case End -> End {}
     case Cons { value, rest } -> Cons { map(value), () => rest().map(map) }
 
 /// Applies `map` and flattens the resulting sequences.
@@ -185,7 +185,7 @@ fun Seq[T].map(map: T => Y): Seq[Y] =
 fun Seq[T].`|*`(map: T => Seq[Y]): Seq[Y] =
     fun __flat_map(seq: Seq[T], map: T => Seq[Y]) =
         match seq with
-        case End -> End
+        case End -> End {}
         case Cons { value, rest } ->
             map(value) + __flat_map(rest(), map)
     ---
@@ -194,7 +194,7 @@ fun Seq[T].`|*`(map: T => Seq[Y]): Seq[Y] =
 fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
     fun __flat_map(seq: Seq[T], map: T => Seq[Y]) =
         match seq with
-        case End -> End
+        case End -> End {}
         case Cons { value, rest } ->
             map(value) + __flat_map(rest(), map)
     ---
@@ -221,10 +221,10 @@ fun Seq[T].reduce_left(initial: R, reducer: (R, T) => R): R = this.reduce(initia
 fun Seq[T].zip(other: Seq[Y]): Seq[tuple[T,Y]] =
     fun __zip(this: Seq[T], other: Seq[Y]): Seq[tuple[T,Y]] =
         match this with
-        case End -> End
+        case End -> End {}
         case Cons { v1, r1 } ->
             match other with
-            case End -> End
+            case End -> End {}
             case Cons { v2, r2 } -> Cons { (v1, v2), () => __zip(r1, r2) }
     ---
     __zip(this, other)
@@ -234,7 +234,7 @@ fun Seq[T].zip(other: Seq[Y]): Seq[tuple[T,Y]] =
 /// Returns `None` for an empty sequence.
 fun Seq[T].first(): /capy/lang/Option[T] =
     match this with
-    case End -> /capy/lang/Option.None
+    case End -> /capy/lang/Option.None {}
     case Cons { value, _ } -> /capy/lang/Option.Some { value }
 
 /// Returns the first element matching `pred`, wrapped in `Option`.

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -68,7 +68,7 @@ fun to_json(obj: data): Result[JsonObject] =
         case Option o -> {
             match o with
             case Some { value } -> any_to_json(value)
-            case None -> Success { JsonNull }
+            case None -> Success { JsonNull {} }
         }
         case Result r -> {
             match r with
@@ -158,7 +158,7 @@ fun _deserialize_json_array(json: string): Result[_Parse[JsonArray]] =
 
 fun _deserialize_json_null(json: string): Result[_Parse[JsonNull]] =
     if json.starts_with('null')
-    then Success { _Parse { JsonNull, json[4:] } }
+    then Success { _Parse { JsonNull {}, json[4:] } }
     else {
         let actual =
             if json.size > 4

--- a/lib/capybara-lib/src/test/capybara/capy/lang/SeqTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/SeqTest.cfun
@@ -29,11 +29,11 @@ fun should_assert_finite_sequence(): Assert =
         .does_not_contain(4)
 
 fun should_assert_empty_sequence(): Assert =
-    let seq: Seq[int] = End
+    let seq: Seq[int] = End {}
     assert_that(seq)
         .has_size(0)
         .is_empty()
-        .is_equal_to(End)
+        .is_equal_to(End {})
 
 fun should_take_from_infinite_sequence(): Assert =
     let l = natural_seq().take(5)
@@ -64,7 +64,7 @@ fun should_return_first_element(): Assert =
     assert_that(seq.first()).contains(3)
 
 fun should_return_empty_first_on_empty_sequence(): Assert =
-    let seq: Seq[int] = End
+    let seq: Seq[int] = End {}
     assert_that(seq.first()).is_equal_to(None {})
 
 fun should_find_first_matching_element(): Assert =
@@ -82,5 +82,4 @@ fun should_detect_any_matching_element(): Assert =
 fun should_detect_no_matching_element(): Assert =
     let seq = to_seq([1, 2, 3])
     assert_that(seq.any(x => x > 10)).is_equal_to(false)
-
 

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -135,7 +135,7 @@ fun should_convert_data_with_wrapper_and_nested_fields_to_json_object(): Assert 
     assert_that(to_json(sample)).succeeds(JsonObject {
         value: {
             "present": JsonString { value: "value" },
-            "absent": JsonNull,
+            "absent": JsonNull {},
             "success": JsonNumberLong { value: 7 },
             "error": JsonString { value: "bad" },
             "inner": JsonObject {
@@ -223,7 +223,7 @@ fun test_serialize_object_with_primitive_types(): Assert =
         "ageDouble" : JsonNumberDouble { value: 50.5 },
         "ageFloat" : JsonNumberDouble { value: 60.5f },
         "married" : JsonBool { value: true },
-        "car" : JsonNull,
+        "car" : JsonNull {},
     }};
     let ser = serialize(json)
     assert_that(ser)
@@ -256,7 +256,7 @@ fun should_stringify_top_level_json_values(): Assert =
         assert_that(stringify(JsonNumberLong { value: 7L })).is_equal_to("7"),
         assert_that(stringify(JsonNumberDouble { value: 1.5 })).is_equal_to("1.5"),
         assert_that(stringify(JsonBool { value: true })).is_equal_to("true"),
-        assert_that(stringify(JsonNull)).is_equal_to("null"),
+        assert_that(stringify(JsonNull {})).is_equal_to("null"),
     ])
 
 fun should_deserialize_simple_object(): Assert =
@@ -328,7 +328,7 @@ fun should_fail_deserialize_object_as_bool_types(): Assert =
 
 fun should_deserialize_object_as_null(): Assert =
     assert_that(deserialize('{"foo":null}'))
-        .succeeds(JsonObject { value: { "foo": JsonNull } })
+        .succeeds(JsonObject { value: { "foo": JsonNull {} } })
 
 fun should_fail_deserialize_object_as_null(): Assert =
     assert_that(deserialize('{"foo":nul}')).fails('Expected `null`, but got `nul`!')
@@ -346,7 +346,7 @@ fun should_deserialize_array_with_values(): Assert =
                         JsonNumberLong { value: 1 },
                         JsonString { value: "x" },
                         JsonBool { value: false },
-                        JsonNull
+                        JsonNull {}
                     ]
                 }
             }


### PR DESCRIPTION
## Summary
- require singleton data values to use constructor syntax in expressions (`Name {}`)
- keep bare zero-field singleton patterns valid in `match` cases (`case Name -> ...`)
- resolve qualified singleton constructors and generate valid Java for explicit zero-field constructor patterns
- port existing Capybara sources and tests to use constructor syntax only where values are constructed

## Example
```cfun
single Empty

fun e(): Empty = Empty {}

fun is_empty(value: Empty): bool =
    match value with
    case Empty -> true
```

Bare expression usage like `Empty` now fails compilation; bare match patterns remain valid.

## Tests
- `./gradlew :compiler:test`
- `./gradlew :capy:e2e-cfun`
- `env GRADLE_USER_HOME=/tmp/capybara-gradle-home ./gradlew clean check`