### PR TITLE
fix(#113): infer inline generic reduce accumulators

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/EmptyLiteralInference.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/EmptyLiteralInference.cfun
@@ -1,6 +1,8 @@
 from /capy/test/Assert import { * }
 from /capy/test/CapyTest import { * }
 from /capy/lang/Effect import { * }
+from /capy/lang/Option import { * }
+from /capy/lang/Result import { * }
 
 fun reverse_ints(values: list[int]): list[int] =
     fun rev(left: list[int], acc: list[int]): list[int] =
@@ -30,6 +32,7 @@ fun empty_list_of_type_param(v: T): list[T] =
 data JsonBox { value: string }
 data NamedValue { name: string, value: int }
 data ParseCase { source: string, expected: int }
+data Box[T] { value: T }
 
 fun typed_empty_dict_then_append_json_box(name: string): int =
     let values: dict[JsonBox] = {:}
@@ -51,6 +54,33 @@ fun reduce_dict_to_two_lists_and_concat_sizes(values: dict[int]): int =
     let parse_test_cases = values |> [], (acc, source, expected) => acc + NamedValue { name: "parse:" + source, value: expected }
     let format_test_cases = values |> [], (acc, expected, value) => acc + NamedValue { name: "format:" + expected, value }
     (parse_test_cases + format_test_cases).size
+
+fun reduce_list_to_success_values(values: list[int]): Result[list[int]] =
+    values |> Success { [] }, (acc_result, item) => {
+        let acc <- acc_result
+        Success { acc + item }
+    }
+
+fun reduce_set_to_success_values(values: set[string]): Result[set[string]] =
+    values |> Success { {} }, (acc_result, item) => {
+        let acc <- acc_result
+        Success { acc + item }
+    }
+
+fun reduce_dict_to_success_values(values: dict[int]): Result[dict[int]] =
+    values |> Success { {:} }, (acc_result, key, value) => {
+        let acc <- acc_result
+        Success { acc + { key : value } }
+    }
+
+fun reduce_list_to_some_values(values: list[int]): Option[list[int]] =
+    values |> Some { [] }, (acc_option, item) =>
+        match acc_option with
+        case Some { acc } -> Some { acc + item }
+        case None -> None {}
+
+fun reduce_list_to_box_values(values: list[int]): Box[list[int]] =
+    values |> Box { [] }, (acc_box, item) => Box { acc_box.value + item }
 
 type SeqEnd[T] = ConsEnd[T] | EndEnd
 data ConsEnd[T] { value: T, rest: () => SeqEnd[T] }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/EmptyLiteralInferenceTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/EmptyLiteralInferenceTest.java
@@ -1,8 +1,12 @@
 package dev.capylang.test;
 
+import capy.lang.Result;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,6 +52,44 @@ class EmptyLiteralInferenceTest {
     @Test
     void twoIndependentlyInferredReduceListsCanBeConcatenated() {
         assertThat(EmptyLiteralInference.reduceDictToTwoListsAndConcatSizes(java.util.Map.of("a", 1, "b", 2))).isEqualTo(4);
+    }
+
+    @Test
+    void reduceWithInlineSuccessEmptyListInfersResultListType() {
+        var result = EmptyLiteralInference.reduceListToSuccessValues(List.of(1, 2, 3));
+        assertThat(result).isInstanceOf(Result.Success.class);
+        assertThat(((Result.Success<List<Integer>>) result).value()).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void reduceWithInlineSuccessEmptySetInfersResultSetType() {
+        var result = EmptyLiteralInference.reduceSetToSuccessValues(Set.of("a", "b"));
+        assertThat(result).isInstanceOf(Result.Success.class);
+        assertThat(((Result.Success<Set<String>>) result).value()).containsExactlyInAnyOrder("a", "b");
+    }
+
+    @Test
+    void reduceWithInlineSuccessEmptyDictInfersResultDictType() {
+        var values = new LinkedHashMap<String, Integer>();
+        values.put("a", 1);
+        values.put("b", 2);
+
+        var result = EmptyLiteralInference.reduceDictToSuccessValues(values);
+
+        assertThat(result).isInstanceOf(Result.Success.class);
+        assertThat(((Result.Success<java.util.Map<String, Integer>>) result).value()).containsEntry("a", 1).containsEntry("b", 2);
+    }
+
+    @Test
+    void reduceWithInlineSomeEmptyListInfersOptionListType() {
+        assertThat(EmptyLiteralInference.reduceListToSomeValues(List.of(1, 2, 3)))
+                .isEqualTo(Optional.of(List.of(1, 2, 3)));
+    }
+
+    @Test
+    void reduceWithInlineGenericDataEmptyListInfersBoxListType() {
+        assertThat(EmptyLiteralInference.reduceListToBoxValues(List.of(1, 2, 3)).value())
+                .containsExactly(1, 2, 3);
     }
 
     @Test

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -1226,6 +1226,23 @@ public class CompilationErrorTest {
                         + "%3$s^ Expected `Result[list[int]]`, got `Success[dict[any]]`\n"
                 ),
                 Arguments.of(
+                        "any_list_result_not_compatible_with_list_result",
+                        """
+                                type Result[T] = Success[T] | Error
+                                data Success[T] { value: T }
+                                data Error { message: string }
+                                fun accepts_list(value: Result[list[int]]): int = 1
+                                fun broken(value: Result[list[any]]): int =
+                                    accepts_list(value)
+                                """,
+                        new Position(6, 17),
+                        "error: mismatched types\n"
+                        + " --> /foo/boo/any_list_result_not_compatible_with_list_result.cfun:%d:%d\n"
+                        + "fun broken(value: Result[list[any]]): int =\n"
+                        + "    accepts_list(value)\n"
+                        + "%3$s^ Expected `Result[list[int]]`, got `Result[list[any]]`\n"
+                ),
+                Arguments.of(
                         "json_assertion_no_viable_alternative",
                         """
                                 data JsonNumberLong { value: long }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -1204,7 +1204,7 @@ public class CompilationErrorTest {
                         + "fun _deserialize_json_null(json: string): Result[_Parse[JsonBool]] =\n"
                         + "    let parsed: _Parse[JsonNull] = _Parse {\n"
                         + "        JsonNull {  },\n"
-                        + "    ^ Expected `Result`, got `Success`\n"
+                        + "    ^ Expected `_Parse[JsonBool]`, but got `_Parse[JsonNull]`\n"
                 ),
                 Arguments.of(
                         "json_assertion_no_viable_alternative",

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -1207,6 +1207,25 @@ public class CompilationErrorTest {
                         + "    ^ Expected `_Parse[JsonBool]`, but got `_Parse[JsonNull]`\n"
                 ),
                 Arguments.of(
+                        "empty_dict_result_not_compatible_with_list_result",
+                        """
+                                type Result[T] = Success[T] | Error
+                                data Success[T] { value: T }
+                                data Error { message: string }
+                                fun accepts_list(value: Result[list[int]]): int = 1
+                                fun broken(): int =
+                                    let x = Success { {:} }
+                                    accepts_list(x)
+                                """,
+                        new Position(7, 17),
+                        "error: mismatched types\n"
+                        + " --> /foo/boo/empty_dict_result_not_compatible_with_list_result.cfun:%d:%d\n"
+                        + "fun broken(): int =\n"
+                        + "    let x = Success {\n"
+                        + "        {}\n"
+                        + "%3$s^ Expected `Result[list[int]]`, got `Success[dict[any]]`\n"
+                ),
+                Arguments.of(
                         "json_assertion_no_viable_alternative",
                         """
                                 data JsonNumberLong { value: long }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -460,7 +460,7 @@ public class CompilationErrorTest {
 
         assertThat(errors).hasSize(1);
         assertThat(errors.first().message())
-                .contains("Expected `int`, got `Effect`");
+                .contains("Expected `int`, got `Effect[int]`");
     }
 
     @Test
@@ -490,7 +490,7 @@ public class CompilationErrorTest {
 
         assertThat(errors).hasSize(1);
         assertThat(errors.first().message())
-                .contains("Expected `int`, got `Result[T]`");
+                .contains("Expected `int`, got `Result[int]`");
     }
 
     @Test
@@ -534,7 +534,7 @@ public class CompilationErrorTest {
         var errors = ((Result.Error<CompiledProgram>) result).errors();
         assertThat(errors).hasSize(1);
         assertThat(errors.first().message())
-                .contains("Expected `Widget`, got `Success`");
+                .contains("Expected `Widget`, got `Success[Widget]`");
     }
 
     @ParameterizedTest(name = "{index}: should fail when compiling `{0}.cfun`")

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -4191,7 +4191,7 @@ public class CapybaraCompiler {
                 if (matchingExtendedParent.isPresent()) {
                     return areAssignableDataTypeParameters(
                             expectedParent.typeParameters(),
-                            matchingExtendedParent.orElseThrow().typeArguments(),
+                            resolvedExtendedParentTypeArguments(actualData, matchingExtendedParent.orElseThrow(), dataTypes),
                             dataTypes
                     );
                 }
@@ -4234,6 +4234,50 @@ public class CapybaraCompiler {
             return true;
         }
         return false;
+    }
+
+    private List<String> resolvedExtendedParentTypeArguments(
+            CompiledDataType actualData,
+            ParsedGenericTypeName extendedParent,
+            Map<String, GenericDataType> dataTypes
+    ) {
+        if (extendedParent.typeArguments().isEmpty() || actualData.typeParameters().isEmpty()) {
+            return extendedParent.typeArguments();
+        }
+        var rawType = dataTypes.values().stream()
+                .filter(CompiledDataType.class::isInstance)
+                .map(CompiledDataType.class::cast)
+                .filter(candidate -> sameTypeName(candidate.name(), actualData.name()))
+                .findFirst();
+        if (rawType.isEmpty() || rawType.orElseThrow().typeParameters().isEmpty()) {
+            return extendedParent.typeArguments();
+        }
+        var substitutions = new LinkedHashMap<String, String>();
+        var max = Math.min(rawType.orElseThrow().typeParameters().size(), actualData.typeParameters().size());
+        for (var i = 0; i < max; i++) {
+            substitutions.put(rawType.orElseThrow().typeParameters().get(i), actualData.typeParameters().get(i));
+        }
+        if (substitutions.isEmpty()) {
+            return extendedParent.typeArguments();
+        }
+        return extendedParent.typeArguments().stream()
+                .map(typeArgument -> substituteTypeArgumentDescriptor(typeArgument, substitutions))
+                .toList();
+    }
+
+    private String substituteTypeArgumentDescriptor(String descriptor, Map<String, String> substitutions) {
+        var normalized = normalizeDescriptor(descriptor);
+        var direct = substitutions.get(normalized);
+        if (direct != null) {
+            return direct;
+        }
+        var parsed = parseGenericTypeName(normalized);
+        if (parsed.typeArguments().isEmpty()) {
+            return normalized;
+        }
+        return parsed.baseName() + "[" + parsed.typeArguments().stream()
+                .map(typeArgument -> substituteTypeArgumentDescriptor(typeArgument, substitutions))
+                .collect(java.util.stream.Collectors.joining(", ")) + "]";
     }
 
     private boolean isAssignablePrimitiveReturnType(PrimitiveLinkedType expected, PrimitiveLinkedType actual) {
@@ -4816,7 +4860,24 @@ public class CapybaraCompiler {
                 .filter(dataType -> sameTypeName(dataType.name(), normalizedActual))
                 .findFirst();
         if (maybeActual.isEmpty()) {
-            return false;
+            var maybeParent = dataTypes.values().stream()
+                    .filter(CompiledDataParentType.class::isInstance)
+                    .map(CompiledDataParentType.class::cast)
+                    .filter(parentType -> sameTypeName(parentType.name(), normalizedActual))
+                    .findFirst();
+            if (maybeParent.isEmpty()) {
+                return false;
+            }
+            var actualParent = maybeParent.orElseThrow();
+            if (sameTypeName(actualParent.name(), expectedParentName)) {
+                return true;
+            }
+            return dataTypes.values().stream()
+                    .filter(CompiledDataParentType.class::isInstance)
+                    .map(CompiledDataParentType.class::cast)
+                    .filter(parent -> parent.subTypes().stream().anyMatch(subType -> sameTypeName(subType.name(), actualParent.name())))
+                    .anyMatch(parent -> sameTypeName(parent.name(), expectedParentName)
+                                        || isSubtypeNameOfParent(parent.name(), expectedParentName, dataTypes, visited));
         }
         var actualData = maybeActual.orElseThrow();
         for (var extendedType : actualData.extendedTypes()) {

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -3154,7 +3154,7 @@ public class CapybaraExpressionCompiler {
         var parsedActual = parseLinkedTypeDescriptor(actual);
         var parsedExpected = parseLinkedTypeDescriptor(expected);
         if (parsedActual.isPresent() && parsedExpected.isPresent()) {
-            if (hasKnownEmptyCollectionShape(parsedActual.get())) {
+            if (isEmptyCollectionShapeCompatible(parsedActual.get(), parsedExpected.get())) {
                 return true;
             }
             return isTypeCompatible(parsedActual.get(), parsedExpected.get());
@@ -7883,6 +7883,86 @@ public class CapybaraExpressionCompiler {
                             .anyMatch(this::hasKnownEmptyCollectionShape);
             default -> false;
         };
+    }
+
+    private boolean isEmptyCollectionShapeCompatible(CompiledType actual, CompiledType expected) {
+        if (!hasKnownEmptyCollectionShape(actual)) {
+            return false;
+        }
+        return switch (actual) {
+            case CompiledList actualList when expected instanceof CompiledList expectedList ->
+                    isEmptyCollectionElementCompatible(actualList.elementType(), expectedList.elementType());
+            case CompiledSet actualSet when expected instanceof CompiledSet expectedSet ->
+                    isEmptyCollectionElementCompatible(actualSet.elementType(), expectedSet.elementType());
+            case CompiledDict actualDict when expected instanceof CompiledDict expectedDict ->
+                    isEmptyCollectionElementCompatible(actualDict.valueType(), expectedDict.valueType());
+            case CompiledTupleType actualTuple when expected instanceof CompiledTupleType expectedTuple ->
+                    actualTuple.elementTypes().size() == expectedTuple.elementTypes().size()
+                    && java.util.stream.IntStream.range(0, actualTuple.elementTypes().size())
+                            .allMatch(i -> isEmptyShapeTypeArgumentCompatible(
+                                    actualTuple.elementTypes().get(i),
+                                    expectedTuple.elementTypes().get(i)
+                            ));
+            case CompiledFunctionType actualFunction when expected instanceof CompiledFunctionType expectedFunction ->
+                    isEmptyShapeTypeArgumentCompatible(actualFunction.argumentType(), expectedFunction.argumentType())
+                    && isEmptyShapeTypeArgumentCompatible(actualFunction.returnType(), expectedFunction.returnType());
+            case CompiledDataType actualData when expected instanceof CompiledDataType expectedData
+                                               && sameRawTypeName(actualData.name(), expectedData.name()) ->
+                    areEmptyShapeTypeParametersCompatible(actualData.typeParameters(), expectedData.typeParameters());
+            case CompiledDataParentType actualParent when expected instanceof CompiledDataParentType expectedParent
+                                                        && (sameRawTypeName(actualParent.name(), expectedParent.name())
+                                                            || isParentSubtypeOfParent(actualParent, expectedParent, new java.util.HashSet<>())) ->
+                    areEmptyShapeTypeParametersCompatible(actualParent.typeParameters(), expectedParent.typeParameters());
+            case CompiledDataType actualData when expected instanceof CompiledDataParentType expectedParent
+                                               && isSubtypeOfParent(actualData, expectedParent) ->
+                    specializedReduceParentType(actualData, expectedParent)
+                            .map(parentType -> isEmptyCollectionShapeCompatible(parentType, expectedParent))
+                            .orElseGet(() -> areEmptyShapeTypeParametersCompatible(
+                                    actualData.typeParameters(),
+                                    expectedParent.typeParameters()
+                            ));
+            default -> false;
+        };
+    }
+
+    private boolean isEmptyCollectionElementCompatible(CompiledType actual, CompiledType expected) {
+        if (actual == ANY) {
+            return true;
+        }
+        return isEmptyShapeTypeArgumentCompatible(actual, expected);
+    }
+
+    private boolean isEmptyShapeTypeArgumentCompatible(CompiledType actual, CompiledType expected) {
+        if (hasKnownEmptyCollectionShape(actual)) {
+            return isEmptyCollectionShapeCompatible(actual, expected);
+        }
+        return isTypeCompatible(actual, expected);
+    }
+
+    private boolean areEmptyShapeTypeParametersCompatible(
+            List<String> actualTypeParameters,
+            List<String> expectedTypeParameters
+    ) {
+        if (expectedTypeParameters.isEmpty()) {
+            return true;
+        }
+        if (actualTypeParameters.size() != expectedTypeParameters.size()) {
+            return false;
+        }
+        for (var i = 0; i < expectedTypeParameters.size(); i++) {
+            var actualType = parseLinkedTypeDescriptor(actualTypeParameters.get(i));
+            var expectedType = parseLinkedTypeDescriptor(expectedTypeParameters.get(i));
+            if (actualType.isEmpty() || expectedType.isEmpty()) {
+                if (!isTypeDescriptorCompatible(actualTypeParameters.get(i), expectedTypeParameters.get(i))) {
+                    return false;
+                }
+                continue;
+            }
+            if (!isEmptyShapeTypeArgumentCompatible(actualType.orElseThrow(), expectedType.orElseThrow())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean hasGenericTypeParameters(CompiledType type) {

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -571,7 +571,13 @@ public class CapybaraExpressionCompiler {
         ResolvedFunctionCall best = null;
         Result.Error.SingleError deepestError = null;
         for (var candidate : candidates) {
-            var maybeResolved = linkArgumentsForExpectedTypes(functionCall.arguments(), scope, candidate.parameterTypes());
+            var maybeResolved = linkArgumentsForExpectedTypes(
+                    functionCall.arguments(),
+                    scope,
+                    candidate.parameterTypes(),
+                    candidate.returnType(),
+                    expectedType
+            );
             if (maybeResolved instanceof Result.Error<CoercedArguments> error) {
                 deepestError = preferDeeperError(deepestError, firstError(error));
                 continue;
@@ -587,7 +593,11 @@ public class CapybaraExpressionCompiler {
             }
             var returnType = resolveReturnType(candidate, resolved.arguments());
             if (expectedType.isPresent() && !canCoerceToExpectedType(returnType, expectedType.orElseThrow())) {
-                continue;
+                if (canUseExpectedTypeForEmptyShapeReturn(candidate, resolved.arguments(), returnType, expectedType.orElseThrow())) {
+                    returnType = expectedType.orElseThrow();
+                } else {
+                    continue;
+                }
             }
             if (isBetterResolvedCall(candidate, resolved.arguments(), resolved.coercions(), returnType, expectedType, best)) {
                 best = new ResolvedFunctionCall(candidate, resolved.arguments(), resolved.coercions(), returnType);
@@ -725,7 +735,13 @@ public class CapybaraExpressionCompiler {
         ResolvedFunctionCall best = null;
         Result.Error.SingleError deepestError = null;
         for (var candidate : candidates) {
-            var maybeResolved = linkArgumentsForExpectedTypes(functionCall.arguments(), scope, candidate.parameterTypes());
+            var maybeResolved = linkArgumentsForExpectedTypes(
+                    functionCall.arguments(),
+                    scope,
+                    candidate.parameterTypes(),
+                    candidate.returnType(),
+                    expectedType
+            );
             if (maybeResolved instanceof Result.Error<CoercedArguments> error) {
                 deepestError = preferDeeperError(deepestError, firstError(error));
                 continue;
@@ -741,7 +757,11 @@ public class CapybaraExpressionCompiler {
             }
             var returnType = resolveReturnType(candidate, resolved.arguments());
             if (expectedType.isPresent() && !canCoerceToExpectedType(returnType, expectedType.orElseThrow())) {
-                continue;
+                if (canUseExpectedTypeForEmptyShapeReturn(candidate, resolved.arguments(), returnType, expectedType.orElseThrow())) {
+                    returnType = expectedType.orElseThrow();
+                } else {
+                    continue;
+                }
             }
             if (isBetterResolvedCall(candidate, resolved.arguments(), resolved.coercions(), returnType, expectedType, best)) {
                 best = new ResolvedFunctionCall(candidate, resolved.arguments(), resolved.coercions(), returnType);
@@ -773,6 +793,17 @@ public class CapybaraExpressionCompiler {
                 best.arguments(),
                 best.returnType()
         ));
+    }
+
+    private boolean canUseExpectedTypeForEmptyShapeReturn(
+            FunctionSignature signature,
+            List<CompiledExpression> arguments,
+            CompiledType returnType,
+            CompiledType expectedType
+    ) {
+        return containsGenericTypeParameter(signature.returnType())
+               && arguments.stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression)
+               && isEmptyCollectionShapeCompatible(returnType, expectedType);
     }
 
     private boolean isReflectionIntrinsicSignature(FunctionSignature signature) {
@@ -1410,7 +1441,13 @@ public class CapybaraExpressionCompiler {
         ResolvedFunctionCall best = null;
         Result.Error.SingleError deepestError = null;
         for (var candidate : candidates) {
-            var maybeResolved = linkArgumentsForExpectedTypes(functionCall.arguments(), scope, candidate.parameterTypes());
+            var maybeResolved = linkArgumentsForExpectedTypes(
+                    functionCall.arguments(),
+                    scope,
+                    candidate.parameterTypes(),
+                    candidate.returnType(),
+                    expectedType
+            );
             if (maybeResolved instanceof Result.Error<CoercedArguments> error) {
                 deepestError = preferDeeperError(deepestError, firstError(error));
                 continue;
@@ -2213,9 +2250,24 @@ public class CapybaraExpressionCompiler {
             Scope scope,
             List<CompiledType> expectedTypes
     ) {
+        return linkArgumentsForExpectedTypes(arguments, scope, expectedTypes, null, Optional.empty());
+    }
+
+    private Result<CoercedArguments> linkArgumentsForExpectedTypes(
+            List<Expression> arguments,
+            Scope scope,
+            List<CompiledType> expectedTypes,
+            CompiledType returnType,
+            Optional<CompiledType> expectedReturnType
+    ) {
         var coerced = new java.util.ArrayList<CompiledExpression>(arguments.size());
         var coercions = 0;
         var substitutions = new java.util.LinkedHashMap<String, CompiledType>();
+        if (returnType != null
+            && expectedReturnType.isPresent()
+            && arguments.stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression)) {
+            collectTypeSubstitutions(returnType, expectedReturnType.orElseThrow(), substitutions);
+        }
         for (var i = 0; i < arguments.size(); i++) {
             var argument = arguments.get(i);
             var expected = substituteTypeParameters(expectedTypes.get(i), substitutions);
@@ -2488,6 +2540,7 @@ public class CapybaraExpressionCompiler {
                 case IfExpression ifExpression -> linkIfExpression(ifExpression, scope, expected);
                 case MatchExpression matchExpression -> linkMatchExpression(matchExpression, scope, expected);
                 case LetExpression letExpression -> linkLetExpression(letExpression, scope, Optional.of(expected));
+                case FunctionCall functionCall -> linkFunctionCallWithExpectedFallback(functionCall, scope, expected);
                 default -> linkExpression(argument, scope);
             };
         }
@@ -2533,6 +2586,11 @@ public class CapybaraExpressionCompiler {
         var typeParameters = dataType.typeParameters().isEmpty()
                 ? dataType.typeParameters()
                 : expectedParent.typeParameters();
+        var expectedSubtype = expectedSubtypeForParent(dataType, expectedParent);
+        if (expectedSubtype != null
+            && shouldUseExpectedSubtypeForParentConstructor(dataType, expectedSubtype, expectedParent)) {
+            return Result.success(Optional.of(expectedSubtype));
+        }
         return Result.success(Optional.of(new CompiledDataType(
                 dataType.name(),
                 resolvedFields,
@@ -2557,6 +2615,7 @@ public class CapybaraExpressionCompiler {
             case IfExpression ifExpression -> linkIfExpression(ifExpression, scope, expected);
             case MatchExpression matchExpression -> linkMatchExpression(matchExpression, scope, expected);
             case LetExpression letExpression -> linkLetExpression(letExpression, scope, Optional.of(expected));
+            case FunctionCall functionCall -> linkFunctionCallWithExpectedFallback(functionCall, scope, expected);
             default -> linkExpression(argument, scope);
         };
         return linkedArgument.flatMap(linked -> {
@@ -2582,6 +2641,18 @@ public class CapybaraExpressionCompiler {
             }
             return Result.success(maybeCoerced);
         });
+    }
+
+    private Result<CompiledExpression> linkFunctionCallWithExpectedFallback(
+            FunctionCall functionCall,
+            Scope scope,
+            CompiledType expected
+    ) {
+        var linkedForExpected = linkFunctionCall(functionCall, scope, Optional.of(expected));
+        if (linkedForExpected instanceof Result.Success<CompiledExpression>) {
+            return linkedForExpected;
+        }
+        return linkExpression(functionCall, scope);
     }
 
     private Result<CompiledExpression> linkFunctionReference(FunctionReference functionReference, CompiledFunctionType expectedType) {
@@ -2928,6 +2999,12 @@ public class CapybaraExpressionCompiler {
                 || canCoerceToExpectedType(argumentList.elementType(), expectedList.elementType()))) {
             return new CoercedArgument(argument, 1);
         }
+        if (expected instanceof CompiledList
+            && argument.type() instanceof CompiledList
+            && isEmptyShapeCompatibleVariable(argument)
+            && isEmptyCollectionShapeCompatible(argument.type(), expected)) {
+            return new CoercedArgument(argument, 1);
+        }
         if (expected instanceof CompiledSet expectedSet
             && argument.type() instanceof CompiledSet argumentSet
             && argumentSet.elementType() != ANY
@@ -2935,11 +3012,23 @@ public class CapybaraExpressionCompiler {
                 || canCoerceToExpectedType(argumentSet.elementType(), expectedSet.elementType()))) {
             return new CoercedArgument(argument, 1);
         }
+        if (expected instanceof CompiledSet
+            && argument.type() instanceof CompiledSet
+            && isEmptyShapeCompatibleVariable(argument)
+            && isEmptyCollectionShapeCompatible(argument.type(), expected)) {
+            return new CoercedArgument(argument, 1);
+        }
         if (expected instanceof CompiledDict expectedDict
             && argument.type() instanceof CompiledDict argumentDict
             && argumentDict.valueType() != ANY
             && (isTypeCompatible(argumentDict.valueType(), expectedDict.valueType())
                 || canCoerceToExpectedType(argumentDict.valueType(), expectedDict.valueType()))) {
+            return new CoercedArgument(argument, 1);
+        }
+        if (expected instanceof CompiledDict
+            && argument.type() instanceof CompiledDict
+            && isEmptyShapeCompatibleVariable(argument)
+            && isEmptyCollectionShapeCompatible(argument.type(), expected)) {
             return new CoercedArgument(argument, 1);
         }
         if (expected instanceof CompiledFunctionType expectedFunction
@@ -2966,19 +3055,31 @@ public class CapybaraExpressionCompiler {
         if (expected instanceof CompiledDataParentType expectedParent
             && argument.type() instanceof CompiledDataParentType argumentParent
             && (sameRawTypeName(expectedParent.name(), argumentParent.name())
-                || isParentSubtypeOfParent(argumentParent, expectedParent, new java.util.HashSet<>()))
-            && areTypeParameterDescriptorsCompatible(argumentParent.typeParameters(), expectedParent.typeParameters())) {
-            return new CoercedArgument(argument, 1);
+                || isParentSubtypeOfParent(argumentParent, expectedParent, new java.util.HashSet<>()))) {
+            if (areTypeParameterDescriptorsCompatible(argumentParent.typeParameters(), expectedParent.typeParameters())
+                || (isEmptyShapeCompatibleVariable(argument)
+                    && areEmptyShapeTypeParametersCompatible(argumentParent.typeParameters(), expectedParent.typeParameters()))) {
+                return new CoercedArgument(argument, 1);
+            }
         }
         if (expected instanceof CompiledDataType expectedData
             && argument.type() instanceof CompiledDataType argumentData
-            && sameRawTypeName(expectedData.name(), argumentData.name())
-            && areTypeParameterDescriptorsCompatible(argumentData.typeParameters(), expectedData.typeParameters())) {
-            if (!argumentData.typeParameters().equals(expectedData.typeParameters())
-                && argument instanceof CompiledNewData newData) {
+            && sameRawTypeName(expectedData.name(), argumentData.name())) {
+            if (areTypeParameterDescriptorsCompatible(argumentData.typeParameters(), expectedData.typeParameters())) {
+                if (!argumentData.typeParameters().equals(expectedData.typeParameters())
+                    && argument instanceof CompiledNewData newData) {
+                    return new CoercedArgument(rebuildNewDataForExpectedType(newData, argumentData, expectedData), 1);
+                }
+                return new CoercedArgument(argument, 1);
+            }
+            if (isEmptyShapeCompatibleVariable(argument)
+                && areEmptyShapeTypeParametersCompatible(argumentData.typeParameters(), expectedData.typeParameters())) {
+                return new CoercedArgument(argument, 1);
+            }
+            if (argument instanceof CompiledNewData newData
+                && canRebuildNewDataForExpectedType(newData, argumentData, expectedData)) {
                 return new CoercedArgument(rebuildNewDataForExpectedType(newData, argumentData, expectedData), 1);
             }
-            return new CoercedArgument(argument, 1);
         }
         if (argument.type() == ANY) {
             return new CoercedArgument(argument, 1);
@@ -2997,6 +3098,14 @@ public class CapybaraExpressionCompiler {
         if (expected instanceof CompiledDataParentType expectedParentType
             && argument.type() instanceof CompiledDataType argumentDataType
             && isSubtypeOfParent(argumentDataType, expectedParentType)) {
+            if (argument instanceof CompiledNewData newData) {
+                var expectedSubtype = expectedSubtypeForParent(argumentDataType, expectedParentType);
+                if (expectedSubtype != null
+                    && shouldRebuildNewDataForParent(argumentDataType, expectedSubtype, expectedParentType, newData)
+                    && canRebuildNewDataForExpectedType(newData, argumentDataType, expectedSubtype)) {
+                    return new CoercedArgument(rebuildNewDataForExpectedType(newData, argumentDataType, expectedSubtype), 1);
+                }
+            }
             var specializedParent = argumentDataType.extendedTypes().stream()
                     .map(this::parseLinkedTypeDescriptor)
                     .flatMap(Optional::stream)
@@ -3059,10 +3168,123 @@ public class CapybaraExpressionCompiler {
         var rebuiltAssignments = expectedType.fields().stream()
                 .map(field -> new CompiledNewData.FieldAssignment(
                         field.name(),
-                        assignmentsByName.get(field.name())
+                        coerceExpressionToType(assignmentsByName.get(field.name()), field.type())
+                                .orElse(assignmentsByName.get(field.name()))
                 ))
                 .toList();
         return new CompiledNewData(expectedType, rebuiltAssignments);
+    }
+
+    private boolean canRebuildNewDataForExpectedType(
+            CompiledNewData newData,
+            CompiledDataType sourceType,
+            CompiledDataType expectedType
+    ) {
+        var assignmentsByName = orderedAssignmentsByName(newData, sourceType);
+        for (var field : expectedType.fields()) {
+            var assignment = assignmentsByName.get(field.name());
+            if (assignment == null || coerceArgument(assignment, field.type()) == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean shouldRebuildNewDataForParent(
+            CompiledDataType argumentDataType,
+            CompiledDataType expectedSubtype,
+            CompiledDataParentType expectedParentType,
+            CompiledNewData newData
+    ) {
+        return hasKnownEmptyCollectionShapeExpression(newData)
+               || shouldUseExpectedSubtypeForParentConstructor(argumentDataType, expectedSubtype, expectedParentType);
+    }
+
+    private boolean shouldUseExpectedSubtypeForParentConstructor(
+            CompiledDataType argumentDataType,
+            CompiledDataType expectedSubtype,
+            CompiledDataParentType expectedParentType
+    ) {
+        return expectedParentType.typeParameters().isEmpty()
+               && argumentDataType.typeParameters().isEmpty()
+               && expectedSubtype.typeParameters().isEmpty()
+               && !argumentDataType.name().equals(expectedSubtype.name());
+    }
+
+    private CompiledDataType expectedSubtypeForParent(
+            CompiledDataType argumentDataType,
+            CompiledDataParentType expectedParentType
+    ) {
+        var expectedSubtype = expectedParentType.subTypes().stream()
+                .filter(subtype -> sameRawTypeName(subtype.name(), argumentDataType.name()))
+                .findFirst()
+                .orElse(null);
+        if (expectedSubtype == null) {
+            return null;
+        }
+        var typeParameters = expectedSubtype.typeParameters().isEmpty()
+                ? expectedSubtype.typeParameters()
+                : expectedParentType.typeParameters();
+        return new CompiledDataType(
+                expectedSubtypeNameForParent(argumentDataType, expectedSubtype, expectedParentType),
+                resolveConstructorFields(expectedSubtype, expectedParentType),
+                typeParameters,
+                expectedSubtype.extendedTypes(),
+                expectedSubtype.comments(),
+                expectedSubtype.visibility(),
+                expectedSubtype.singleton()
+        );
+    }
+
+    private String expectedSubtypeNameForParent(
+            CompiledDataType argumentDataType,
+            CompiledDataType expectedSubtype,
+            CompiledDataParentType expectedParentType
+    ) {
+        var knownQualifiedSubtype = dataTypes.values().stream()
+                .filter(CompiledDataType.class::isInstance)
+                .map(CompiledDataType.class::cast)
+                .filter(candidate -> sameRawTypeName(candidate.name(), argumentDataType.name()))
+                .filter(candidate -> hasQualifiedTypeName(candidate.name()))
+                .filter(candidate -> parentTypesForSubtype(candidate.name()).stream()
+                        .anyMatch(parentType -> sameRawTypeName(parentType.name(), expectedParentType.name())))
+                .map(CompiledDataType::name)
+                .findFirst();
+        if (knownQualifiedSubtype.isPresent()) {
+            return knownQualifiedSubtype.orElseThrow();
+        }
+        return subtypeNameFromParentName(expectedParentType.name(), expectedSubtype.name());
+    }
+
+    private static String subtypeNameFromParentName(String parentName, String subtypeName) {
+        var rawParentName = stripGenericSuffix(parentName);
+        var rawSubtypeName = simpleRawTypeName(normalizeTypeAlias(subtypeName));
+        if (isProgramParentName(rawParentName)) {
+            return "/capy/lang/Program." + rawSubtypeName;
+        }
+        if (rawParentName.contains("/") && !rawParentName.contains(".")) {
+            return rawParentName + "." + rawSubtypeName;
+        }
+        if (rawParentName.contains(".")) {
+            var slashIndex = rawParentName.lastIndexOf('/');
+            var dotIndex = rawParentName.lastIndexOf('.');
+            if (dotIndex > slashIndex) {
+                return rawParentName.substring(0, dotIndex + 1) + rawSubtypeName;
+            }
+        }
+        return subtypeName;
+    }
+
+    private static boolean hasQualifiedTypeName(String name) {
+        var rawName = stripGenericSuffix(name);
+        return rawName.contains("/") || rawName.contains(".");
+    }
+
+    private static boolean isProgramParentName(String name) {
+        var rawName = stripGenericSuffix(name);
+        return "Program".equals(rawName)
+               || rawName.endsWith("/Program")
+               || rawName.endsWith(".Program");
     }
 
     private boolean areTupleTypesCompatible(CompiledTupleType actual, CompiledTupleType expected) {
@@ -3199,9 +3421,6 @@ public class CapybaraExpressionCompiler {
         var parsedActual = parseLinkedTypeDescriptor(actual);
         var parsedExpected = parseLinkedTypeDescriptor(expected);
         if (parsedActual.isPresent() && parsedExpected.isPresent()) {
-            if (isEmptyCollectionShapeCompatible(parsedActual.get(), parsedExpected.get())) {
-                return true;
-            }
             return isTypeCompatible(parsedActual.get(), parsedExpected.get());
         }
         return sameRawTypeName(actual, expected);
@@ -4301,7 +4520,8 @@ public class CapybaraExpressionCompiler {
                                 } else {
                                     reduceScope = reduceScope.add(
                                             reduceExpression.accumulatorName(),
-                                            initialAccumulatorType
+                                            initialAccumulatorType,
+                                            hasKnownEmptyCollectionShapeExpression(initial)
                                     );
                                 }
                                 if (reduceExpression.keyName().isPresent()) {
@@ -7894,6 +8114,64 @@ public class CapybaraExpressionCompiler {
         return isConcreteResolvedType(type) || hasKnownEmptyCollectionShape(type);
     }
 
+    private boolean isEmptyShapeCompatibleVariable(CompiledExpression expression) {
+        return expression instanceof CompiledVariable variable && variable.emptyShapeCompatible();
+    }
+
+    private boolean hasKnownEmptyCollectionShapeExpression(CompiledExpression expression) {
+        return switch (expression) {
+            case CompiledNewList newList -> newList.values().isEmpty();
+            case CompiledNewSet newSet -> newSet.values().isEmpty();
+            case CompiledNewDict newDict -> newDict.entries().isEmpty();
+            case CompiledNewData newData ->
+                    newData.assignments().stream()
+                            .map(CompiledNewData.FieldAssignment::value)
+                            .anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case CompiledTupleExpression tupleExpression ->
+                    tupleExpression.values().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            default -> false;
+        };
+    }
+
+    private boolean hasKnownEmptyCollectionShapeExpression(Expression expression) {
+        return switch (expression) {
+            case NewListExpression newList -> newList.values().isEmpty()
+                                             || newList.values().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case NewSetExpression newSet -> newSet.values().isEmpty()
+                                           || newSet.values().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case NewDictExpression newDict -> newDict.entries().isEmpty()
+                                             || newDict.entries().stream()
+                                                     .map(NewDictExpression.Entry::value)
+                                                     .anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case NewData newData -> newData.assignments().stream()
+                    .map(NewData.FieldAssignment::value)
+                    .anyMatch(this::hasKnownEmptyCollectionShapeExpression)
+                                    || newData.positionalArguments().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression)
+                                    || newData.spreads().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case TupleExpression tupleExpression ->
+                    tupleExpression.values().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case FunctionCall functionCall ->
+                    functionCall.arguments().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case FunctionInvoke functionInvoke ->
+                    functionInvoke.arguments().stream().anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case IfExpression ifExpression ->
+                    hasKnownEmptyCollectionShapeExpression(ifExpression.thenBranch())
+                    || hasKnownEmptyCollectionShapeExpression(ifExpression.elseBranch());
+            case MatchExpression matchExpression ->
+                    matchExpression.cases().stream()
+                            .map(MatchExpression.MatchCase::expression)
+                            .anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            case LetExpression letExpression ->
+                    hasKnownEmptyCollectionShapeExpression(letExpression.value())
+                    || hasKnownEmptyCollectionShapeExpression(letExpression.rest());
+            case WithExpression withExpression ->
+                    withExpression.assignments().stream()
+                            .map(NewData.FieldAssignment::value)
+                            .anyMatch(this::hasKnownEmptyCollectionShapeExpression);
+            default -> false;
+        };
+    }
+
     private boolean hasKnownEmptyCollectionShape(CompiledType type) {
         return switch (type) {
             case CompiledList linkedList ->
@@ -8399,7 +8677,11 @@ public class CapybaraExpressionCompiler {
 //            } else {
             finalName = value.name();
 //            }
-            return Result.success(new CompiledVariable(finalName, scope.localValues().get(value.name())));
+            return Result.success(new CompiledVariable(
+                    finalName,
+                    scope.localValues().get(value.name()),
+                    scope.isEmptyShapeCompatibleValue(value.name())
+            ));
         }
         return parameters.stream()
                 .filter(parameter -> parameter.name().equals(value.name()))

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -2290,6 +2290,39 @@ public class CapybaraExpressionCompiler {
                     argument.position()
             );
         }
+        if (argument instanceof NewData newData && expected instanceof CompiledDataType expectedDataType) {
+            return linkNewDataAsType(newData, scope, expectedDataType)
+                    .flatMap(linkedArgument -> {
+                        var maybeCoerced = coerceArgument(linkedArgument, expected);
+                        if (maybeCoerced == null) {
+                            return withPosition(
+                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    argument.position()
+                            );
+                        }
+                        return Result.success(maybeCoerced);
+                    });
+        }
+        if (argument instanceof NewData newData && expected instanceof CompiledDataParentType expectedParentType) {
+            var expectedConstructorType = expectedConstructorTypeForParent(newData, scope, expectedParentType);
+            if (expectedConstructorType instanceof Result.Error<Optional<CompiledDataType>> error) {
+                return new Result.Error<>(error.errors());
+            }
+            var maybeExpectedConstructorType = ((Result.Success<Optional<CompiledDataType>>) expectedConstructorType).value();
+            var linkedArgument = maybeExpectedConstructorType
+                    .<Result<CompiledExpression>>map(type -> linkNewDataAsType(newData, scope, type))
+                    .orElseGet(() -> linkExpression(argument, scope));
+            return linkedArgument.flatMap(linked -> {
+                var maybeCoerced = coerceArgument(linked, expected);
+                if (maybeCoerced == null) {
+                    return withPosition(
+                            Result.error("Expected `" + expected + "`, got `" + linked.type() + "`"),
+                            argument.position()
+                    );
+                }
+                return Result.success(maybeCoerced);
+            });
+        }
         if (expected instanceof CompiledDataParentType
             || expected instanceof CompiledGenericTypeParameter
             || expected instanceof CompiledDataType) {
@@ -2395,12 +2428,24 @@ public class CapybaraExpressionCompiler {
         if (expectedResultParent.isEmpty()) {
             return withPosition(Result.error("Expected `Result[...]`, got `" + expected + "`"), argument.position());
         }
-        var linkedArgument = switch (argument) {
-            case IfExpression ifExpression -> linkIfExpression(ifExpression, scope, expected);
-            case MatchExpression matchExpression -> linkMatchExpression(matchExpression, scope, expected);
-            case LetExpression letExpression -> linkLetExpression(letExpression, scope, Optional.of(expected));
-            default -> linkExpression(argument, scope);
-        };
+        Result<CompiledExpression> linkedArgument;
+        if (argument instanceof NewData newData) {
+            var expectedConstructorType = expectedConstructorTypeForParent(newData, scope, expectedResultParent.orElseThrow());
+            if (expectedConstructorType instanceof Result.Error<Optional<CompiledDataType>> error) {
+                return new Result.Error<>(error.errors());
+            }
+            var maybeExpectedConstructorType = ((Result.Success<Optional<CompiledDataType>>) expectedConstructorType).value();
+            linkedArgument = maybeExpectedConstructorType
+                    .<Result<CompiledExpression>>map(type -> linkNewDataAsType(newData, scope, type))
+                    .orElseGet(() -> linkExpression(argument, scope));
+        } else {
+            linkedArgument = switch (argument) {
+                case IfExpression ifExpression -> linkIfExpression(ifExpression, scope, expected);
+                case MatchExpression matchExpression -> linkMatchExpression(matchExpression, scope, expected);
+                case LetExpression letExpression -> linkLetExpression(letExpression, scope, Optional.of(expected));
+                default -> linkExpression(argument, scope);
+            };
+        }
         return linkedArgument.flatMap(linked -> {
             var maybeCoerced = coerceArgument(linked, expected);
             if (maybeCoerced != null) {
@@ -2424,6 +2469,34 @@ public class CapybaraExpressionCompiler {
             }
             return Result.success(maybeCoerced);
         });
+    }
+
+    private Result<Optional<CompiledDataType>> expectedConstructorTypeForParent(
+            NewData newData,
+            Scope scope,
+            CompiledDataParentType expectedParent
+    ) {
+        var linkedType = linkNewDataType(newData.type(), scope);
+        if (linkedType instanceof Result.Error<CompiledType> error) {
+            return new Result.Error<>(error.errors());
+        }
+        var type = ((Result.Success<CompiledType>) linkedType).value();
+        if (!(type instanceof CompiledDataType dataType) || !isSubtypeOfParent(dataType, expectedParent)) {
+            return Result.success(Optional.empty());
+        }
+        var resolvedFields = resolveConstructorFields(dataType, expectedParent);
+        var typeParameters = dataType.typeParameters().isEmpty()
+                ? dataType.typeParameters()
+                : expectedParent.typeParameters();
+        return Result.success(Optional.of(new CompiledDataType(
+                dataType.name(),
+                resolvedFields,
+                typeParameters,
+                dataType.extendedTypes(),
+                dataType.comments(),
+                dataType.visibility(),
+                dataType.singleton()
+        )));
     }
 
     private Result<CoercedArgument> linkArgumentForExpectedEffectType(
@@ -2759,7 +2832,9 @@ public class CapybaraExpressionCompiler {
     }
 
     private CoercedArgument coerceArgument(CompiledExpression argument, CompiledType expected) {
-        if (argument.type().equals(expected)) {
+        if (!(argument.type() instanceof GenericDataType)
+            && !(expected instanceof GenericDataType)
+            && argument.type().equals(expected)) {
             return new CoercedArgument(argument, 0);
         }
         if (expected instanceof PrimitiveLinkedType expectedPrimitive
@@ -2845,7 +2920,8 @@ public class CapybaraExpressionCompiler {
         }
         if (expected instanceof CompiledDataParentType expectedParent
             && argument.type() instanceof CompiledDataParentType argumentParent
-            && sameRawTypeName(expectedParent.name(), argumentParent.name())
+            && (sameRawTypeName(expectedParent.name(), argumentParent.name())
+                || isParentSubtypeOfParent(argumentParent, expectedParent, new java.util.HashSet<>()))
             && areTypeParameterDescriptorsCompatible(argumentParent.typeParameters(), expectedParent.typeParameters())) {
             return new CoercedArgument(argument, 1);
         }
@@ -3012,6 +3088,11 @@ public class CapybaraExpressionCompiler {
                 };
                 return areTypeParameterDescriptorsCompatible(actualTypeParameters, expectedTypeParameters);
             }
+            if (expectedData instanceof CompiledDataParentType expectedParent
+                && actualData instanceof CompiledDataParentType actualParent
+                && isParentSubtypeOfParent(actualParent, expectedParent, new java.util.HashSet<>())) {
+                return areTypeParameterDescriptorsCompatible(actualParent.typeParameters(), expectedParent.typeParameters());
+            }
             if (expectedData instanceof CompiledDataParentType expectedParent && actualData instanceof CompiledDataType actualSubtype) {
                 if (!isSubtypeOfParent(actualSubtype, expectedParent)) {
                     return false;
@@ -3073,6 +3154,9 @@ public class CapybaraExpressionCompiler {
         var parsedActual = parseLinkedTypeDescriptor(actual);
         var parsedExpected = parseLinkedTypeDescriptor(expected);
         if (parsedActual.isPresent() && parsedExpected.isPresent()) {
+            if (hasKnownEmptyCollectionShape(parsedActual.get())) {
+                return true;
+            }
             return isTypeCompatible(parsedActual.get(), parsedExpected.get());
         }
         return sameRawTypeName(actual, expected);
@@ -3112,9 +3196,26 @@ public class CapybaraExpressionCompiler {
     }
 
     private boolean isSubtypeOfParent(CompiledDataType candidate, CompiledDataParentType expectedParentType) {
+        return isSubtypeOfParent(candidate, expectedParentType, new java.util.HashSet<>());
+    }
+
+    private boolean isSubtypeOfParent(
+            CompiledDataType candidate,
+            CompiledDataParentType expectedParentType,
+            java.util.Set<String> visitedParents
+    ) {
         if (expectedParentType.subTypes().stream()
                 .anyMatch(subType -> sameRawTypeName(subType.name(), candidate.name()))) {
             return true;
+        }
+        for (var parentType : knownParentTypes()) {
+            if (parentType.subTypes().stream().noneMatch(subType -> sameRawTypeName(subType.name(), candidate.name()))) {
+                continue;
+            }
+            if (sameRawTypeName(parentType.name(), expectedParentType.name())
+                || isParentSubtypeOfParent(parentType, expectedParentType, visitedParents)) {
+                return true;
+            }
         }
         if (!expectedParentType.subTypes().isEmpty()) {
             return false;
@@ -3125,6 +3226,31 @@ public class CapybaraExpressionCompiler {
         }
         return canonicalParent.subTypes().stream()
                 .anyMatch(subType -> sameRawTypeName(subType.name(), candidate.name()));
+    }
+
+    private boolean isParentSubtypeOfParent(
+            CompiledDataParentType candidateParent,
+            CompiledDataParentType expectedParent,
+            java.util.Set<String> visited
+    ) {
+        if (sameRawTypeName(candidateParent.name(), expectedParent.name())) {
+            return true;
+        }
+        if (!visited.add(simpleRawTypeName(normalizeTypeAlias(candidateParent.name())))) {
+            return false;
+        }
+        if (expectedParent.subTypes().stream().anyMatch(subType -> sameRawTypeName(subType.name(), candidateParent.name()))) {
+            return true;
+        }
+        if (!candidateParent.subTypes().isEmpty()
+            && candidateParent.subTypes().stream()
+                    .allMatch(subType -> isSubtypeOfParent(subType, expectedParent, new java.util.HashSet<>(visited)))) {
+            return true;
+        }
+        return knownParentTypes().stream()
+                .filter(parentType -> parentType.subTypes().stream()
+                        .anyMatch(subType -> sameRawTypeName(subType.name(), candidateParent.name())))
+                .anyMatch(parentType -> isParentSubtypeOfParent(parentType, expectedParent, visited));
     }
 
     private static boolean sameRawTypeName(String left, String right) {
@@ -4122,6 +4248,7 @@ public class CapybaraExpressionCompiler {
                     return linkExpression(reduceExpression.initialValue(), scope)
                             .flatMap(initial -> {
                                 var reduceScope = scope;
+                                var initialAccumulatorType = widenReduceAccumulatorBindingType(initial.type());
                                 if (reduceExpression.accumulatorName().contains("::") && reduceExpression.keyName().isPresent()) {
                                     return withPosition(
                                             Result.error("Reducer with four arguments is not supported for `dict`. Use `|>` mapper and then a standard reduce."),
@@ -4130,7 +4257,7 @@ public class CapybaraExpressionCompiler {
                                 } else {
                                     reduceScope = reduceScope.add(
                                             reduceExpression.accumulatorName(),
-                                            widenReduceAccumulatorBindingType(initial.type())
+                                            initialAccumulatorType
                                     );
                                 }
                                 if (reduceExpression.keyName().isPresent()) {
@@ -4146,7 +4273,11 @@ public class CapybaraExpressionCompiler {
                                 return linkExpression(reduceExpression.reducerExpression(), reduceScope)
                                         .flatMap(reducer -> {
                                             var resolvedInitial = initial;
-                                            var accumulatorType = initial.type();
+                                            var accumulatorType = initialAccumulatorType;
+                                            var initialCoercion = coerceArgument(initial, accumulatorType);
+                                            if (initialCoercion != null) {
+                                                resolvedInitial = initialCoercion.expression();
+                                            }
                                             var coercedReducer = coerceArgument(reducer, accumulatorType);
                                             if (coercedReducer == null) {
                                                 var coercedInitial = coerceArgument(initial, reducer.type());
@@ -4177,13 +4308,40 @@ public class CapybaraExpressionCompiler {
                                                 );
                                             }
                                             var inferredReduceType = inferReduceResultType(accumulatorType, reducer.type());
+                                            var finalReducer = coercedReducer.expression();
+                                            if (!linkedTypeDescriptor(inferredReduceType).equals(linkedTypeDescriptor(accumulatorType))) {
+                                                var refinedReduceScope = scope.add(reduceExpression.accumulatorName(), inferredReduceType);
+                                                if (reduceExpression.keyName().isPresent()) {
+                                                    refinedReduceScope = refinedReduceScope.add(reduceExpression.keyName().orElseThrow(), STRING);
+                                                }
+                                                refinedReduceScope = refinedReduceScope.add(reduceExpression.valueName(), elementType);
+                                                var refinedReducer = linkExpression(reduceExpression.reducerExpression(), refinedReduceScope);
+                                                if (refinedReducer instanceof Result.Error<CompiledExpression> error) {
+                                                    return new Result.Error<>(error.errors());
+                                                }
+                                                var refinedReducerExpression = ((Result.Success<CompiledExpression>) refinedReducer).value();
+                                                finalReducer = refinedReducerExpression;
+                                                var refinedCoercedReducer = coerceArgument(refinedReducerExpression, inferredReduceType);
+                                                if (refinedCoercedReducer != null) {
+                                                    finalReducer = refinedCoercedReducer.expression();
+                                                }
+                                                var refinedInitial = linkArgumentForExpectedType(
+                                                        reduceExpression.initialValue(),
+                                                        scope,
+                                                        inferredReduceType
+                                                );
+                                                if (refinedInitial instanceof Result.Error<CoercedArgument> error) {
+                                                    return new Result.Error<>(error.errors());
+                                                }
+                                                resolvedInitial = ((Result.Success<CoercedArgument>) refinedInitial).value().expression();
+                                            }
                                             return Result.success((CompiledExpression) new CompiledPipeReduceExpression(
                                                     left,
                                                     resolvedInitial,
                                                     reduceExpression.accumulatorName(),
                                                     reduceExpression.keyName(),
                                                     reduceExpression.valueName(),
-                                                    coercedReducer.expression(),
+                                                    finalReducer,
                                                     inferredReduceType
                                             ));
                                         });
@@ -4210,17 +4368,12 @@ public class CapybaraExpressionCompiler {
                 }
             }
         }
-        for (var type : dataTypes.values()) {
-            if (!(type instanceof CompiledDataParentType parentType)) {
-                continue;
-            }
-            var hasInitial = parentType.subTypes().stream()
-                    .anyMatch(subType -> sameRawTypeName(subType.name(), initialData.name()));
+        for (var parentType : knownParentTypes()) {
+            var hasInitial = hasMatchingSubtype(parentType, initialData);
             if (!hasInitial) {
                 continue;
             }
-            var hasReducer = parentType.subTypes().stream()
-                    .anyMatch(subType -> sameRawTypeName(subType.name(), reducerData.name()));
+            var hasReducer = hasMatchingSubtype(parentType, reducerData);
             if (!hasReducer) {
                 continue;
             }
@@ -4235,13 +4388,12 @@ public class CapybaraExpressionCompiler {
         if (!(initialType instanceof CompiledDataType initialData)) {
             return initialType;
         }
-        var sharedParents = dataTypes.values().stream()
-                .filter(CompiledDataParentType.class::isInstance)
-                .map(CompiledDataParentType.class::cast)
-                .filter(parent -> isSubtypeOfParent(initialData, parent))
+        var sharedParents = knownParentTypes().stream()
+                .filter(parent -> hasMatchingSubtype(parent, initialData))
                 .toList();
         if (sharedParents.size() == 1) {
-            return canonicalizeParentAlias(sharedParents.getFirst());
+            return specializedReduceParentType(initialData, sharedParents.getFirst())
+                    .orElseGet(() -> canonicalizeParentAlias(sharedParents.getFirst()));
         }
         if (!sharedParents.isEmpty()) {
             var uniqueByRawName = sharedParents.stream()
@@ -4252,10 +4404,95 @@ public class CapybaraExpressionCompiler {
                             java.util.LinkedHashMap::new
                     ));
             if (uniqueByRawName.size() == 1) {
-                return canonicalizeParentAlias(uniqueByRawName.values().iterator().next());
+                var parent = uniqueByRawName.values().iterator().next();
+                return specializedReduceParentType(initialData, parent)
+                        .orElseGet(() -> canonicalizeParentAlias(parent));
             }
         }
         return initialType;
+    }
+
+    private boolean hasMatchingSubtype(CompiledDataParentType parent, CompiledDataType dataType) {
+        return parent.subTypes().stream()
+                .anyMatch(subType -> sameRawTypeName(subType.name(), dataType.name())
+                                     && hasCompatibleSubtypeFields(subType, dataType));
+    }
+
+    private boolean hasCompatibleSubtypeFields(CompiledDataType declaredSubtype, CompiledDataType actualType) {
+        if (declaredSubtype.fields().size() != actualType.fields().size()) {
+            return false;
+        }
+        for (var i = 0; i < declaredSubtype.fields().size(); i++) {
+            if (!declaredSubtype.fields().get(i).name().equals(actualType.fields().get(i).name())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<CompiledDataParentType> knownParentTypes() {
+        var parentsByRawName = new java.util.LinkedHashMap<String, CompiledDataParentType>();
+        dataTypes.values().stream()
+                .filter(CompiledDataParentType.class::isInstance)
+                .map(CompiledDataParentType.class::cast)
+                .forEach(parent -> putKnownParentType(parentsByRawName, parent));
+        linkCache.parentTypesByRawName.values().forEach(parent -> putKnownParentType(parentsByRawName, parent));
+        if (findOptionType() != null) {
+            putKnownParentType(parentsByRawName, findOptionType());
+        }
+        if (findResultType() != null) {
+            putKnownParentType(parentsByRawName, findResultType());
+        }
+        if (findEffectType() != null) {
+            putKnownParentType(parentsByRawName, findEffectType());
+        }
+        return List.copyOf(parentsByRawName.values());
+    }
+
+    private void putKnownParentType(
+            Map<String, CompiledDataParentType> parentsByRawName,
+            CompiledDataParentType parent
+    ) {
+        parentsByRawName.merge(
+                simpleRawTypeName(normalizeTypeAlias(parent.name())),
+                parent,
+                this::preferQualifiedParent
+        );
+    }
+
+    private Optional<CompiledDataParentType> specializedReduceParentType(
+            CompiledDataType subtype,
+            CompiledDataParentType parent
+    ) {
+        return subtype.extendedTypes().stream()
+                .map(this::parseLinkedTypeDescriptor)
+                .flatMap(Optional::stream)
+                .filter(CompiledDataParentType.class::isInstance)
+                .map(CompiledDataParentType.class::cast)
+                .filter(parentType -> sameRawTypeName(parentType.name(), parent.name()))
+                .findFirst()
+                .or(() -> instantiateExtendedParentFromSubtypeFields(subtype, parent)
+                        .filter(CompiledDataParentType.class::isInstance)
+                        .map(CompiledDataParentType.class::cast))
+                .or(() -> specializeParentFromSubtypeFields(subtype, parent)
+                        .filter(CompiledDataParentType.class::isInstance)
+                        .map(CompiledDataParentType.class::cast))
+                .map(this::canonicalizeSpecializedParentAlias);
+    }
+
+    private CompiledDataParentType canonicalizeSpecializedParentAlias(CompiledDataParentType parent) {
+        var canonical = canonicalizeParentAlias(parent);
+        if (canonical.name().equals(parent.name())
+            && canonical.typeParameters().equals(parent.typeParameters())) {
+            return parent;
+        }
+        return new CompiledDataParentType(
+                canonical.name(),
+                parent.fields(),
+                parent.subTypes(),
+                parent.typeParameters(),
+                canonical.enumType()
+        );
     }
 
     private String rawTypeName(String descriptor) {
@@ -4282,7 +4519,144 @@ public class CapybaraExpressionCompiler {
             && reducerDict.valueType() != ANY) {
             return reducerType;
         }
+        if (initialType instanceof GenericDataType initialDataType) {
+            var reducerDataType = comparableReduceGenericType(initialDataType, reducerType);
+            if (reducerDataType.isPresent()) {
+                return inferGenericReduceResultType(initialDataType, reducerDataType.orElseThrow());
+            }
+        }
         return initialType;
+    }
+
+    private Optional<GenericDataType> comparableReduceGenericType(GenericDataType initialType, CompiledType reducerType) {
+        if (initialType instanceof CompiledDataParentType initialParent) {
+            if (reducerType instanceof CompiledDataParentType reducerParent
+                && sameRawTypeName(initialParent.name(), reducerParent.name())) {
+                return Optional.of(reducerParent);
+            }
+            if (reducerType instanceof CompiledDataType reducerData && isSubtypeOfParent(reducerData, initialParent)) {
+                return specializedReduceParentType(reducerData, initialParent)
+                        .map(GenericDataType.class::cast);
+            }
+        }
+        if (initialType instanceof CompiledDataType initialData
+            && reducerType instanceof CompiledDataType reducerData
+            && sameRawTypeName(initialData.name(), reducerData.name())) {
+            return Optional.of(reducerData);
+        }
+        return Optional.empty();
+    }
+
+    private CompiledType inferGenericReduceResultType(GenericDataType initialType, GenericDataType reducerType) {
+        var initialTypeParameters = switch (initialType) {
+            case CompiledDataType dataType -> dataType.typeParameters();
+            case CompiledDataParentType parentType -> parentType.typeParameters();
+        };
+        var reducerTypeParameters = switch (reducerType) {
+            case CompiledDataType dataType -> dataType.typeParameters();
+            case CompiledDataParentType parentType -> parentType.typeParameters();
+        };
+        if (initialTypeParameters.size() != reducerTypeParameters.size() || initialTypeParameters.isEmpty()) {
+            return (CompiledType) initialType;
+        }
+        var refinedTypeParameters = new java.util.ArrayList<String>(initialTypeParameters.size());
+        var changed = false;
+        for (var i = 0; i < initialTypeParameters.size(); i++) {
+            var refined = inferReduceTypeDescriptor(initialTypeParameters.get(i), reducerTypeParameters.get(i));
+            refinedTypeParameters.add(refined);
+            changed = changed || !refined.equals(initialTypeParameters.get(i));
+        }
+        if (!changed) {
+            return (CompiledType) initialType;
+        }
+        return switch (initialType) {
+            case CompiledDataType dataType -> specializeDataTypeParameters(dataType, refinedTypeParameters);
+            case CompiledDataParentType parentType -> specializeParentTypeParameters(parentType, refinedTypeParameters);
+        };
+    }
+
+    private CompiledDataType specializeDataTypeParameters(
+            CompiledDataType dataType,
+            List<String> typeParameters
+    ) {
+        var rawType = resolveDataTypeByName(dataType.name());
+        if (!(rawType instanceof CompiledDataType rawDataType) || rawDataType.typeParameters().isEmpty()) {
+            return new CompiledDataType(
+                    dataType.name(),
+                    dataType.fields(),
+                    typeParameters,
+                    dataType.extendedTypes(),
+                    dataType.comments(),
+                    dataType.visibility(),
+                    dataType.singleton()
+            );
+        }
+        var substitutions = typeParameterSubstitutions(rawDataType.typeParameters(), typeParameters);
+        if (substitutions.isEmpty()) {
+            return dataType;
+        }
+        var substituted = (CompiledDataType) substituteTypeParameters(rawDataType, substitutions);
+        return new CompiledDataType(
+                substituted.name(),
+                substituted.fields(),
+                typeParameters,
+                substituted.extendedTypes(),
+                dataType.comments(),
+                dataType.visibility(),
+                substituted.singleton()
+        );
+    }
+
+    private CompiledDataParentType specializeParentTypeParameters(
+            CompiledDataParentType parentType,
+            List<String> typeParameters
+    ) {
+        var rawType = resolveDataTypeByName(parentType.name());
+        if (!(rawType instanceof CompiledDataParentType rawParentType) || rawParentType.typeParameters().isEmpty()) {
+            return new CompiledDataParentType(
+                    parentType.name(),
+                    parentType.fields(),
+                    parentType.subTypes(),
+                    typeParameters,
+                    parentType.enumType()
+            );
+        }
+        var substitutions = typeParameterSubstitutions(rawParentType.typeParameters(), typeParameters);
+        if (substitutions.isEmpty()) {
+            return parentType;
+        }
+        var substituted = (CompiledDataParentType) substituteTypeParameters(rawParentType, substitutions);
+        return new CompiledDataParentType(
+                substituted.name(),
+                substituted.fields(),
+                substituted.subTypes(),
+                typeParameters,
+                substituted.enumType()
+        );
+    }
+
+    private Map<String, CompiledType> typeParameterSubstitutions(
+            List<String> declaredTypeParameters,
+            List<String> actualTypeParameters
+    ) {
+        var substitutions = new java.util.LinkedHashMap<String, CompiledType>();
+        var max = Math.min(declaredTypeParameters.size(), actualTypeParameters.size());
+        for (var i = 0; i < max; i++) {
+            var declaredTypeParameter = declaredTypeParameters.get(i);
+            parseLinkedTypeDescriptor(actualTypeParameters.get(i))
+                    .ifPresent(type -> substitutions.put(declaredTypeParameter, type));
+        }
+        return substitutions;
+    }
+
+    private String inferReduceTypeDescriptor(String initialDescriptor, String reducerDescriptor) {
+        var initial = parseLinkedTypeDescriptor(initialDescriptor);
+        var reducer = parseLinkedTypeDescriptor(reducerDescriptor);
+        if (initial.isEmpty() || reducer.isEmpty()) {
+            return initialDescriptor;
+        }
+        var refined = inferReduceResultType(initial.orElseThrow(), reducer.orElseThrow());
+        return linkedTypeDescriptor(refined);
     }
 
     private Result<CompiledExpression> linkPipeFlatMapExpression(InfixExpression expression, Scope scope) {
@@ -4840,6 +5214,14 @@ public class CapybaraExpressionCompiler {
             return right;
         }
         if (right == ANY) {
+            return left;
+        }
+        if (left.equals(right)) {
+            return left;
+        }
+        if (left instanceof GenericDataType leftData
+            && right instanceof GenericDataType rightData
+            && sameRawTypeName(leftData.name(), rightData.name())) {
             return left;
         }
         var sharedDataParent = findSharedCollectionParentType(left, right);
@@ -6937,6 +7319,23 @@ public class CapybaraExpressionCompiler {
                 });
     }
 
+    private Result<CompiledExpression> linkNewDataAsType(
+            NewData newData,
+            Scope scope,
+            CompiledDataType expectedType
+    ) {
+        return rawLinkNewDataWithType(newData, scope, expectedType)
+                .flatMap(expression -> {
+                    if (!(expression instanceof CompiledNewData compiledNewData)) {
+                        return Result.success(expression);
+                    }
+                    if (newData.bypassConstructor()) {
+                        return validateConstructorBypass(compiledNewData, newData.position());
+                    }
+                    return applyProtectedConstructorIfNeeded(compiledNewData, newData.position());
+                });
+    }
+
     private Result<CompiledExpression> validateConstructorBypass(
             CompiledNewData newData,
             Optional<SourcePosition> position
@@ -6976,43 +7375,51 @@ public class CapybaraExpressionCompiler {
 
     private Result<CompiledExpression> rawLinkNewData(NewData newData, Scope scope) {
         return linkNewDataType(newData.type(), scope)
-                .flatMap(type -> linkSpreadAssignments(newData.spreads(), scope)
-                        .flatMap(spreadAssignments ->
-                                linkFieldAssignment(newData.assignments(), scope, type)
-                                        .flatMap(assignments -> linkPositionalAssignments(
-                                                type,
-                                                spreadAssignments,
-                                                assignments,
-                                                newData.positionalArguments(),
-                                                scope,
+                .flatMap(type -> rawLinkNewDataWithType(newData, scope, type));
+    }
+
+    private Result<CompiledExpression> rawLinkNewDataWithType(
+            NewData newData,
+            Scope scope,
+            CompiledType type
+    ) {
+        return linkSpreadAssignments(newData.spreads(), scope)
+                .flatMap(spreadAssignments ->
+                        linkFieldAssignment(newData.assignments(), scope, type)
+                                .flatMap(assignments -> linkPositionalAssignments(
+                                        type,
+                                        spreadAssignments,
+                                        assignments,
+                                        newData.positionalArguments(),
+                                        scope,
+                                        newData
+                                ).flatMap(positionalAssignments -> {
+                                    var allAssignments = new java.util.ArrayList<CompiledNewData.FieldAssignment>(
+                                            spreadAssignments.size() + assignments.size() + positionalAssignments.size()
+                                    );
+                                    allAssignments.addAll(spreadAssignments);
+                                    allAssignments.addAll(assignments);
+                                    allAssignments.addAll(positionalAssignments);
+                                    var validatedAssignments = validateRequiredAssignments(type, allAssignments, newData);
+                                    if (validatedAssignments instanceof Result.Error<List<CompiledNewData.FieldAssignment>> error) {
+                                        return new Result.Error<CompiledExpression>(error.errors());
+                                    }
+                                    return coerceAssignmentsForType(
+                                            type,
+                                            ((Result.Success<List<CompiledNewData.FieldAssignment>>) validatedAssignments).value(),
+                                            newData
+                                    ).flatMap(coercedAssignments -> {
+                                        var resolvedType = inferDataTypeFromAssignments(type, coercedAssignments);
+                                        return coerceAssignmentsForType(
+                                                resolvedType,
+                                                List.copyOf(coercedAssignments),
                                                 newData
-                                        ).flatMap(positionalAssignments -> {
-                                            var allAssignments = new java.util.ArrayList<CompiledNewData.FieldAssignment>(
-                                                    spreadAssignments.size() + assignments.size() + positionalAssignments.size()
-                                            );
-                                            allAssignments.addAll(spreadAssignments);
-                                            allAssignments.addAll(assignments);
-                                            allAssignments.addAll(positionalAssignments);
-                                            var validatedAssignments = validateRequiredAssignments(type, allAssignments, newData);
-                                            if (validatedAssignments instanceof Result.Error<List<CompiledNewData.FieldAssignment>> error) {
-                                                return new Result.Error<CompiledExpression>(error.errors());
-                                            }
-                                            return coerceAssignmentsForType(
-                                                    type,
-                                                    ((Result.Success<List<CompiledNewData.FieldAssignment>>) validatedAssignments).value(),
-                                                    newData
-                                            ).flatMap(coercedAssignments -> {
-                                                var resolvedType = inferDataTypeFromAssignments(type, coercedAssignments);
-                                                return coerceAssignmentsForType(
-                                                        resolvedType,
-                                                        List.copyOf(coercedAssignments),
-                                                        newData
-                                                ).map(resolvedAssignments -> (CompiledExpression) new CompiledNewData(
-                                                        resolvedType,
-                                                        List.copyOf(resolvedAssignments)
-                                                ));
-                                            });
-                                        }))));
+                                        ).map(resolvedAssignments -> (CompiledExpression) new CompiledNewData(
+                                                resolvedType,
+                                                List.copyOf(resolvedAssignments)
+                                        ));
+                                    });
+                                })));
     }
 
     private Result<CompiledType> linkNewDataType(Type type, Scope scope) {
@@ -7331,7 +7738,7 @@ public class CapybaraExpressionCompiler {
             return new Result.Error<>(error.errors());
         }
         var linkedSuccessType = ((Result.Success<CompiledDataType>) successType).value();
-        var valueField = linkedSuccessType.fields().stream()
+        var valueField = resolveConstructorFields(linkedSuccessType, resultParent).stream()
                 .filter(field -> field.name().equals("value"))
                 .findFirst();
         if (valueField.isEmpty()) {
@@ -7440,11 +7847,42 @@ public class CapybaraExpressionCompiler {
             }
             collectTypeSubstitutions(expectedType, assignment.value().type(), substitutions);
         }
-        substitutions.entrySet().removeIf(entry -> !isConcreteResolvedType(entry.getValue()));
+        substitutions.entrySet().removeIf(entry -> !isUsableInferredTypeArgument(entry.getValue()));
         if (substitutions.isEmpty()) {
             return type;
         }
         return substituteTypeParameters(type, substitutions);
+    }
+
+    private boolean isUsableInferredTypeArgument(CompiledType type) {
+        return isConcreteResolvedType(type) || hasKnownEmptyCollectionShape(type);
+    }
+
+    private boolean hasKnownEmptyCollectionShape(CompiledType type) {
+        return switch (type) {
+            case CompiledList linkedList ->
+                    linkedList.elementType() == ANY || hasKnownEmptyCollectionShape(linkedList.elementType());
+            case CompiledSet linkedSet ->
+                    linkedSet.elementType() == ANY || hasKnownEmptyCollectionShape(linkedSet.elementType());
+            case CompiledDict linkedDict ->
+                    linkedDict.valueType() == ANY || hasKnownEmptyCollectionShape(linkedDict.valueType());
+            case CompiledTupleType linkedTupleType ->
+                    linkedTupleType.elementTypes().stream().anyMatch(this::hasKnownEmptyCollectionShape);
+            case CompiledFunctionType linkedFunctionType ->
+                    hasKnownEmptyCollectionShape(linkedFunctionType.argumentType())
+                    || hasKnownEmptyCollectionShape(linkedFunctionType.returnType());
+            case CompiledDataType linkedDataType ->
+                    linkedDataType.typeParameters().stream()
+                            .map(this::parseLinkedTypeDescriptor)
+                            .flatMap(Optional::stream)
+                            .anyMatch(this::hasKnownEmptyCollectionShape);
+            case CompiledDataParentType linkedDataParentType ->
+                    linkedDataParentType.typeParameters().stream()
+                            .map(this::parseLinkedTypeDescriptor)
+                            .flatMap(Optional::stream)
+                            .anyMatch(this::hasKnownEmptyCollectionShape);
+            default -> false;
+        };
     }
 
     private boolean hasGenericTypeParameters(CompiledType type) {
@@ -7724,7 +8162,10 @@ public class CapybaraExpressionCompiler {
     }
 
     private boolean isHardFieldTypeMismatch(CompiledType expected, CompiledType actual) {
-        if (expected.equals(actual) || expected == ANY || actual == ANY || actual == NOTHING) {
+        if ((!(expected instanceof GenericDataType) && !(actual instanceof GenericDataType) && expected.equals(actual))
+            || expected == ANY
+            || actual == ANY
+            || actual == NOTHING) {
             return false;
         }
 
@@ -7754,7 +8195,10 @@ public class CapybaraExpressionCompiler {
             return true;
         }
 
-        if (expected instanceof GenericDataType) {
+        if (expected instanceof GenericDataType expectedGeneric) {
+            if (actual instanceof GenericDataType actualGeneric) {
+                return !isTypeCompatible(actualGeneric, expectedGeneric);
+            }
             return actual instanceof PrimitiveLinkedType;
         }
 
@@ -7996,7 +8440,7 @@ public class CapybaraExpressionCompiler {
             return new Result.Error<>(error.errors());
         }
         var successType = ((Result.Success<CompiledDataType>) successTypeResult).value();
-        var successValueField = successType.fields().stream()
+        var successValueField = resolveConstructorFields(successType, resultParent).stream()
                 .filter(field -> field.name().equals("value"))
                 .findFirst();
         if (successValueField.isEmpty()) {
@@ -8026,7 +8470,7 @@ public class CapybaraExpressionCompiler {
             return new Result.Error<>(error.errors());
         }
         var successType = ((Result.Success<CompiledDataType>) successTypeResult).value();
-        var successValueField = successType.fields().stream()
+        var successValueField = resolveConstructorFields(successType, resultParent).stream()
                 .filter(field -> field.name().equals("value"))
                 .findFirst();
         if (successValueField.isEmpty()) {

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -36,6 +36,8 @@ public class CapybaraExpressionCompiler {
         private final Map<String, Set<String>> methodOwnerCandidatesBySimpleType;
         private final Map<String, Set<String>> subtypeParentOwnerCandidatesBySimpleType;
         private final Map<String, CompiledDataParentType> parentTypesByRawName;
+        private final List<CompiledDataParentType> knownParentTypes;
+        private final Map<String, List<CompiledDataParentType>> parentTypesBySubtypeRawName;
         private final CompiledDataParentType optionType;
         private final CompiledDataParentType resultType;
         private final CompiledDataParentType effectType;
@@ -48,6 +50,8 @@ public class CapybaraExpressionCompiler {
             this.optionType = findParentType(dataTypes, CapybaraExpressionCompiler::isOptionTypeKeyStatic, "Option");
             this.resultType = findParentType(dataTypes, CapybaraExpressionCompiler::isResultTypeKeyStatic, "Result");
             this.effectType = findParentType(dataTypes, CapybaraExpressionCompiler::isEffectTypeKeyStatic, "Effect");
+            this.knownParentTypes = buildKnownParentTypes(dataTypes, parentTypesByRawName, optionType, resultType, effectType);
+            this.parentTypesBySubtypeRawName = buildParentTypesBySubtypeRawName(knownParentTypes);
         }
 
         private static Map<String, CompiledDataParentType> buildParentTypesByRawName(Map<String, GenericDataType> dataTypes) {
@@ -57,6 +61,47 @@ public class CapybaraExpressionCompiler {
                     .map(CompiledDataParentType.class::cast)
                     .forEach(parentType -> parentTypesByRawName.putIfAbsent(normalizeTypeAlias(parentType.name()), parentType));
             return Map.copyOf(parentTypesByRawName);
+        }
+
+        private static List<CompiledDataParentType> buildKnownParentTypes(
+                Map<String, GenericDataType> dataTypes,
+                Map<String, CompiledDataParentType> parentTypesByRawName,
+                CompiledDataParentType optionType,
+                CompiledDataParentType resultType,
+                CompiledDataParentType effectType
+        ) {
+            var parentsByRawName = new java.util.LinkedHashMap<String, CompiledDataParentType>();
+            dataTypes.values().stream()
+                    .filter(CompiledDataParentType.class::isInstance)
+                    .map(CompiledDataParentType.class::cast)
+                    .forEach(parent -> putKnownParentType(parentsByRawName, parent));
+            parentTypesByRawName.values().forEach(parent -> putKnownParentType(parentsByRawName, parent));
+            if (optionType != null) {
+                putKnownParentType(parentsByRawName, optionType);
+            }
+            if (resultType != null) {
+                putKnownParentType(parentsByRawName, resultType);
+            }
+            if (effectType != null) {
+                putKnownParentType(parentsByRawName, effectType);
+            }
+            return List.copyOf(parentsByRawName.values());
+        }
+
+        private static Map<String, List<CompiledDataParentType>> buildParentTypesBySubtypeRawName(
+                List<CompiledDataParentType> knownParentTypes
+        ) {
+            var parentsBySubtypeRawName = new java.util.LinkedHashMap<String, List<CompiledDataParentType>>();
+            for (var parentType : knownParentTypes) {
+                for (var subType : parentType.subTypes()) {
+                    var subtypeKey = simpleRawTypeName(normalizeTypeAlias(subType.name()));
+                    parentsBySubtypeRawName.computeIfAbsent(subtypeKey, ignored -> new java.util.ArrayList<>())
+                            .add(parentType);
+                }
+            }
+            var immutable = new java.util.LinkedHashMap<String, List<CompiledDataParentType>>();
+            parentsBySubtypeRawName.forEach((subtype, parents) -> immutable.put(subtype, List.copyOf(parents)));
+            return Map.copyOf(immutable);
         }
     }
 
@@ -1421,7 +1466,7 @@ public class CapybaraExpressionCompiler {
                 continue;
             }
             var position = rawArguments.get(i).position();
-            var message = "Expected `" + expected + "`, got `" + actual + "`";
+            var message = expectedGotMessage(expected, actual);
             return withPosition(Result.error(message), position) instanceof Result.Error<?> error
                     ? error.errors().first()
                     : null;
@@ -2203,7 +2248,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2216,7 +2261,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2229,7 +2274,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2240,7 +2285,7 @@ public class CapybaraExpressionCompiler {
             && expected instanceof CompiledTupleType expectedTupleType) {
             if (tupleExpression.values().size() != expectedTupleType.elementTypes().size()) {
                 return withPosition(
-                        Result.error("Expected `" + expected + "`, got tuple with "
+                        Result.error("Expected `" + renderTypeForError(expected) + "`, got tuple with "
                                            + tupleExpression.values().size() + " element(s)"),
                         argument.position()
                 );
@@ -2296,7 +2341,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2316,7 +2361,7 @@ public class CapybaraExpressionCompiler {
                 var maybeCoerced = coerceArgument(linked, expected);
                 if (maybeCoerced == null) {
                     return withPosition(
-                            Result.error("Expected `" + expected + "`, got `" + linked.type() + "`"),
+                            Result.error(expectedGotMessage(expected, linked.type())),
                             argument.position()
                     );
                 }
@@ -2331,7 +2376,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2344,7 +2389,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2359,7 +2404,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2372,7 +2417,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2385,7 +2430,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2398,7 +2443,7 @@ public class CapybaraExpressionCompiler {
                         var maybeCoerced = coerceArgument(linkedArgument, expected);
                         if (maybeCoerced == null) {
                             return withPosition(
-                                    Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                    Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                     argument.position()
                             );
                         }
@@ -2411,7 +2456,7 @@ public class CapybaraExpressionCompiler {
                     var maybeCoerced = coerceArgument(linkedArgument, expected);
                     if (maybeCoerced == null) {
                         return withPosition(
-                                Result.error("Expected `" + expected + "`, got `" + linkedArgument.type() + "`"),
+                                Result.error(expectedGotMessage(expected, linkedArgument.type())),
                                 argument.position()
                         );
                     }
@@ -2463,7 +2508,7 @@ public class CapybaraExpressionCompiler {
             maybeCoerced = coerceArgument(resultCompatibleExpression, expected);
             if (maybeCoerced == null) {
                 return withPosition(
-                        Result.error("Expected `" + expected + "`, got `" + linked.type() + "`"),
+                        Result.error(expectedGotMessage(expected, linked.type())),
                         argument.position()
                 );
             }
@@ -2531,7 +2576,7 @@ public class CapybaraExpressionCompiler {
             maybeCoerced = coerceArgument(effectCompatibleExpression, expected);
             if (maybeCoerced == null) {
                 return withPosition(
-                        Result.error("Expected `" + expected + "`, got `" + linked.type() + "`"),
+                        Result.error(expectedGotMessage(expected, linked.type())),
                         argument.position()
                 );
             }
@@ -3208,10 +3253,7 @@ public class CapybaraExpressionCompiler {
                 .anyMatch(subType -> sameRawTypeName(subType.name(), candidate.name()))) {
             return true;
         }
-        for (var parentType : knownParentTypes()) {
-            if (parentType.subTypes().stream().noneMatch(subType -> sameRawTypeName(subType.name(), candidate.name()))) {
-                continue;
-            }
+        for (var parentType : parentTypesForSubtype(candidate.name())) {
             if (sameRawTypeName(parentType.name(), expectedParentType.name())
                 || isParentSubtypeOfParent(parentType, expectedParentType, visitedParents)) {
                 return true;
@@ -3247,10 +3289,12 @@ public class CapybaraExpressionCompiler {
                     .allMatch(subType -> isSubtypeOfParent(subType, expectedParent, new java.util.HashSet<>(visited)))) {
             return true;
         }
-        return knownParentTypes().stream()
-                .filter(parentType -> parentType.subTypes().stream()
-                        .anyMatch(subType -> sameRawTypeName(subType.name(), candidateParent.name())))
-                .anyMatch(parentType -> isParentSubtypeOfParent(parentType, expectedParent, visited));
+        for (var parentType : parentTypesForSubtype(candidateParent.name())) {
+            if (isParentSubtypeOfParent(parentType, expectedParent, visited)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean sameRawTypeName(String left, String right) {
@@ -4400,7 +4444,7 @@ public class CapybaraExpressionCompiler {
                     .collect(java.util.stream.Collectors.toMap(
                             parent -> simpleRawTypeName(normalizeTypeAlias(parent.name())),
                             parent -> parent,
-                            this::preferQualifiedParent,
+                            CapybaraExpressionCompiler::preferQualifiedParent,
                             java.util.LinkedHashMap::new
                     ));
             if (uniqueByRawName.size() == 1) {
@@ -4431,32 +4475,24 @@ public class CapybaraExpressionCompiler {
     }
 
     private List<CompiledDataParentType> knownParentTypes() {
-        var parentsByRawName = new java.util.LinkedHashMap<String, CompiledDataParentType>();
-        dataTypes.values().stream()
-                .filter(CompiledDataParentType.class::isInstance)
-                .map(CompiledDataParentType.class::cast)
-                .forEach(parent -> putKnownParentType(parentsByRawName, parent));
-        linkCache.parentTypesByRawName.values().forEach(parent -> putKnownParentType(parentsByRawName, parent));
-        if (findOptionType() != null) {
-            putKnownParentType(parentsByRawName, findOptionType());
-        }
-        if (findResultType() != null) {
-            putKnownParentType(parentsByRawName, findResultType());
-        }
-        if (findEffectType() != null) {
-            putKnownParentType(parentsByRawName, findEffectType());
-        }
-        return List.copyOf(parentsByRawName.values());
+        return linkCache.knownParentTypes;
     }
 
-    private void putKnownParentType(
+    private List<CompiledDataParentType> parentTypesForSubtype(String subtypeName) {
+        return linkCache.parentTypesBySubtypeRawName.getOrDefault(
+                simpleRawTypeName(normalizeTypeAlias(subtypeName)),
+                List.of()
+        );
+    }
+
+    private static void putKnownParentType(
             Map<String, CompiledDataParentType> parentsByRawName,
             CompiledDataParentType parent
     ) {
         parentsByRawName.merge(
                 simpleRawTypeName(normalizeTypeAlias(parent.name())),
                 parent,
-                this::preferQualifiedParent
+                CapybaraExpressionCompiler::preferQualifiedParent
         );
     }
 
@@ -5938,7 +5974,7 @@ public class CapybaraExpressionCompiler {
         return merged;
     }
 
-    private CompiledDataParentType preferQualifiedParent(CompiledDataParentType first, CompiledDataParentType second) {
+    private static CompiledDataParentType preferQualifiedParent(CompiledDataParentType first, CompiledDataParentType second) {
         var firstQualified = first.name().contains("/") || first.name().contains(".");
         var secondQualified = second.name().contains("/") || second.name().contains(".");
         if (firstQualified == secondQualified) {
@@ -8283,6 +8319,10 @@ public class CapybaraExpressionCompiler {
         }
 
         return false;
+    }
+
+    private String expectedGotMessage(CompiledType expected, CompiledType actual) {
+        return "Expected `" + renderTypeForError(expected) + "`, got `" + renderTypeForError(actual) + "`";
     }
 
     private static boolean isImplicitNumericWidening(PrimitiveLinkedType expected, PrimitiveLinkedType actual) {

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CompiledVariable.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CompiledVariable.java
@@ -2,5 +2,8 @@ package dev.capylang.compiler.expression;
 
 import dev.capylang.compiler.CompiledType;
 
-public record CompiledVariable(String name, CompiledType type) implements CompiledExpression {
+public record CompiledVariable(String name, CompiledType type, boolean emptyShapeCompatible) implements CompiledExpression {
+    public CompiledVariable(String name, CompiledType type) {
+        this(name, type, false);
+    }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/expression/Scope.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/Scope.java
@@ -4,20 +4,27 @@ import dev.capylang.compiler.CompiledType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 final class Scope {
     private static final Logger LOG = Logger.getLogger(Scope.class.getName());
     //    private static final String SEPARATOR = "_L";
 //    private static final Pattern LAST_NUMBER_PATTERN = Pattern.compile("(.+)" + SEPARATOR + "(\\d+)");
-    static final Scope EMPTY = new Scope(Map.of(), Map.of());
+    static final Scope EMPTY = new Scope(Map.of(), Map.of(), Set.of());
 
     private final Map<String, CompiledType> localValues;
     private final Map<String, String> variableNameToUniqueName;
+    private final Set<String> emptyShapeCompatibleValues;
 
-    Scope(Map<String, CompiledType> localValues, Map<String, String> variableNameToUniqueName) {
+    Scope(
+            Map<String, CompiledType> localValues,
+            Map<String, String> variableNameToUniqueName,
+            Set<String> emptyShapeCompatibleValues
+    ) {
         this.localValues = localValues;
         this.variableNameToUniqueName = variableNameToUniqueName;
+        this.emptyShapeCompatibleValues = emptyShapeCompatibleValues;
     }
 
     Map<String, CompiledType> localValues() {
@@ -28,7 +35,15 @@ final class Scope {
         return variableNameToUniqueName;
     }
 
+    boolean isEmptyShapeCompatibleValue(String name) {
+        return emptyShapeCompatibleValues.contains(name);
+    }
+
     public Scope add(String name, CompiledType value) {
+        return add(name, value, false);
+    }
+
+    public Scope add(String name, CompiledType value, boolean emptyShapeCompatible) {
         var updatedVariableNameToUniqueName = new HashMap<>(variableNameToUniqueName);
 //        if (localValues.containsKey(name)) {
 //            var uniqueName = findUniqueName(name);
@@ -38,7 +53,17 @@ final class Scope {
 
         var updatedValues = new HashMap<>(localValues);
         updatedValues.put(name, value);
-        return new Scope(Map.copyOf(updatedValues), Map.copyOf(updatedVariableNameToUniqueName));
+        var updatedEmptyShapeCompatibleValues = new java.util.LinkedHashSet<>(emptyShapeCompatibleValues);
+        if (emptyShapeCompatible) {
+            updatedEmptyShapeCompatibleValues.add(name);
+        } else {
+            updatedEmptyShapeCompatibleValues.remove(name);
+        }
+        return new Scope(
+                Map.copyOf(updatedValues),
+                Map.copyOf(updatedVariableNameToUniqueName),
+                Set.copyOf(updatedEmptyShapeCompatibleValues)
+        );
     }
 
 //    private String findUniqueName(String name) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -1221,25 +1221,27 @@ public class JavaExpressionEvaluator {
                         + ".orElseGet(() -> " + initialExSc.expression() + ")"
                 );
             }
+            var reducerBaseScope = initialExSc.scope()
+                    .addLocalValue(pipeReduceExpression.accumulatorName())
+                    .addValueOverride(keyName, entryVar + ".getKey()")
+                    .addValueOverride(pipeReduceExpression.valueName(), entryVar + ".getValue()");
             var reducerExSc = evaluateExpression(
                     pipeReduceExpression.reducerExpression(),
-                    initialExSc.scope()
-                            .addLocalValue(pipeReduceExpression.accumulatorName())
-                            .addValueOverride(keyName, entryVar + ".getKey()")
-                            .addValueOverride(pipeReduceExpression.valueName(), entryVar + ".getValue()")
+                    reducerBaseScope
             ).popExpression();
             var reduceInitialExpression = reduceInitialExpression(pipeReduceExpression.initialValue(), pipeReduceExpression.type(), initialExSc.expression());
-            var javaAccumulatorName = resolveJavaLocalIdentifier(reducerExSc.scope(), pipeReduceExpression.accumulatorName());
-            var javaReducerExpression = pipeReduceExpression.accumulatorName().equals(javaAccumulatorName)
-                    ? reducerExSc.expression()
-                    : replaceIdentifier(reducerExSc.expression(), pipeReduceExpression.accumulatorName(), javaAccumulatorName);
-            return reducerExSc.scope().addExpression(
+            var reducerLambda = biLambdaExpression(
+                    pipeReduceExpression.accumulatorName(),
+                    entryVar,
+                    reducerBaseScope,
+                    reducerExSc.scope(),
+                    reducerExSc.expression()
+            );
+            return reducerExSc.scope().withStatements(initialExSc.scope().getStatements()).addExpression(
                     sourceExSc.expression()
                     + ".entrySet().stream().reduce("
                     + reduceInitialExpression
-                    + ", (" + javaAccumulatorName
-                    + ", " + entryVar
-                    + ") -> (" + javaReducerExpression + ")"
+                    + ", " + reducerLambda
                     + ", (left, right) -> left)"
             );
         }
@@ -2082,6 +2084,10 @@ public class JavaExpressionEvaluator {
                     if (fieldType instanceof dev.capylang.compiler.CompiledFunctionType) {
                         return null;
                     }
+                    var resolvedDescriptorCast = sanitizePatternCastType(genericCasts.get(capyTypeDescriptor(fieldType)));
+                    if (resolvedDescriptorCast != null) {
+                        return resolvedDescriptorCast;
+                    }
                     if (fieldType instanceof dev.capylang.compiler.CompiledGenericTypeParameter genericTypeParameter) {
                         var resolvedGenericCast = sanitizePatternCastType(genericCasts.get(genericTypeParameter.name()));
                         return resolvedGenericCast != null ? resolvedGenericCast : genericTypeParameter.name();
@@ -2095,6 +2101,38 @@ public class JavaExpressionEvaluator {
                     return sanitizePatternCastType(javaCastType(fieldType));
                 })
                 .toList();
+    }
+
+    private static String capyTypeDescriptor(dev.capylang.compiler.CompiledType type) {
+        return switch (type) {
+            case dev.capylang.compiler.PrimitiveLinkedType primitiveType ->
+                    primitiveType.name().toLowerCase(java.util.Locale.ROOT);
+            case dev.capylang.compiler.CollectionLinkedType.CompiledList listType ->
+                    "list[" + capyTypeDescriptor(listType.elementType()) + "]";
+            case dev.capylang.compiler.CollectionLinkedType.CompiledSet setType ->
+                    "set[" + capyTypeDescriptor(setType.elementType()) + "]";
+            case dev.capylang.compiler.CollectionLinkedType.CompiledDict dictType ->
+                    "dict[" + capyTypeDescriptor(dictType.valueType()) + "]";
+            case dev.capylang.compiler.CompiledTupleType tupleType ->
+                    "tuple[" + tupleType.elementTypes().stream()
+                            .map(JavaExpressionEvaluator::capyTypeDescriptor)
+                            .reduce((left, right) -> left + ", " + right)
+                            .orElse("") + "]";
+            case dev.capylang.compiler.CompiledFunctionType functionType ->
+                    "fn[" + capyTypeDescriptor(functionType.argumentType())
+                    + ", " + capyTypeDescriptor(functionType.returnType()) + "]";
+            case dev.capylang.compiler.CompiledGenericTypeParameter genericTypeParameter ->
+                    genericTypeParameter.name();
+            case dev.capylang.compiler.CompiledDataType dataType ->
+                    dataType.typeParameters().isEmpty()
+                            ? dataType.name()
+                            : dataType.name() + "[" + String.join(", ", dataType.typeParameters()) + "]";
+            case dev.capylang.compiler.CompiledDataParentType parentType ->
+                    parentType.typeParameters().isEmpty()
+                            ? parentType.name()
+                            : parentType.name() + "[" + String.join(", ", parentType.typeParameters()) + "]";
+            default -> type.name();
+        };
     }
 
     private static String sanitizePatternCastType(String castType) {

--- a/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
@@ -842,7 +842,7 @@ class CapybaraCompilerLibrariesTest {
                         """)
         ));
 
-        assertThat(error.message()).contains("Expected `Widget`, got `Success`");
+        assertThat(error.message()).contains("Expected `Widget`, got `Success[Widget]`");
     }
 
     @Test

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -41,8 +41,7 @@ fun to_json(obj: data): Result[JsonObject] =
         case float f -> Success { JsonNumberDouble { f } }
         case bool b -> Success { JsonBool { b } }
         case list l -> {
-            let initial: Result[list[Json]] = Success { [] }
-            let values <- l |> initial, (acc_result, item) => {
+            let values <- l |> Success { [] }, (acc_result, item) => {
                 let acc <- acc_result
                 let encoded <- any_to_json(item)
                 Success { acc + encoded }
@@ -50,8 +49,7 @@ fun to_json(obj: data): Result[JsonObject] =
             JsonArray { values }
         }
         case set s -> {
-            let initial: Result[list[Json]] = Success { [] }
-            let values <- s |> initial, (acc_result, item) => {
+            let values <- s |> Success { [] }, (acc_result, item) => {
                 let acc <- acc_result
                 let encoded <- any_to_json(item)
                 Success { acc + encoded }
@@ -59,10 +57,9 @@ fun to_json(obj: data): Result[JsonObject] =
             JsonArray { values }
         }
         case dict d -> {
-            let initial: Result[dict[Json]] = Success { {:} }
             d
                 | (key, item) => __JsonEntry { key, any_to_json(item) }
-                |> initial, (acc, entry) => __merge_json_entry(acc, entry)
+                |> Success { {:} }, (acc, entry) => __merge_json_entry(acc, entry)
                 | values => Success { JsonObject { values } }
         }
         case Option o -> {
@@ -78,9 +75,8 @@ fun to_json(obj: data): Result[JsonObject] =
         case data d -> to_json(d) | object => Success { object }
         case _ -> Error { "unsupported value" }
     ---
-    let initial: Result[dict[Json]] = Success { {:} }
     let values <- reflection(obj).fields
-        |> initial, (acc_result, field) => {
+        |> Success { {:} }, (acc_result, field) => {
             let acc <- acc_result
             match any_to_json(field.value) with
             case Success { encoded } -> Success { acc + { field.name : encoded } }


### PR DESCRIPTION
## What changed
- Infer generic reduce accumulator types from inline `Success { [] }`, `Success { {:} }`, `Some { [] }`, and generic data constructors.
- Removed explicit `Result[...]` accumulator annotations from JSON serialization reductions.
- Tightened generic constructor/field mismatch handling so invalid nested generic results still fail with precise diagnostics.

## Impacted modules
- `compiler`: expression linking, generic type compatibility, return assignability, Java generation for reduce/match casts.
- `capy`: functional e2e inference and compilation-error coverage.
- `lib/capybara-lib`: JSON serialization source cleanup using inferred inline accumulators.

## Validation
- `./gradlew :capy:e2e-cfun --rerun-tasks`
- `./gradlew clean check`

## Example
```cfun
values |> Success { [] }, (acc_result, item) => {
    let acc <- acc_result
    Success { acc + item }
}
```
