### PR TITLE
feat(#110): add user-defined indexing syntax

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/UserDefinedIndexing.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/UserDefinedIndexing.cfun
@@ -1,0 +1,38 @@
+data IntIndexed { value: string }
+
+fun IntIndexed.get(idx: int): string =
+    if idx == 1 then this.value else ""
+
+data StringIndexed { age: double }
+
+fun StringIndexed.get(key: string): double =
+    if key == "age" then this.age else 0.0
+
+data Cell { name: string }
+
+data Matrix { first: Cell, second: Cell }
+
+fun Matrix.get(row: int, col: int): Cell =
+    if row == 1 & col == 2 then this.second else this.first
+
+data RowBox { rows: list[list[string]] }
+
+fun RowBox.get(row: int): list[string] =
+    match this.rows[row] with
+    case Some { value } -> value
+    case None -> []
+
+fun int_index(): string =
+    IntIndexed { "one" }[1]
+
+fun string_index(): double =
+    StringIndexed { 42.5 }["age"]
+
+fun matrix_index_name(): string =
+    Matrix { Cell { "first" }, Cell { "second" } }[1, 2].name
+
+fun chained_index(): Option[string] =
+    RowBox { [["a", "b"], ["c", "d", "e"]] }[1][2]
+
+fun list_variable_index(values: list[string], idx: int): Option[string] =
+    values[idx]

--- a/capy/src/e2e-cfun/java/dev/capylang/test/UserDefinedIndexingTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/UserDefinedIndexingTest.java
@@ -1,0 +1,36 @@
+package dev.capylang.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserDefinedIndexingTest {
+    @Test
+    void intIndex() {
+        assertThat(UserDefinedIndexing.intIndex()).isEqualTo("one");
+    }
+
+    @Test
+    void stringIndex() {
+        assertThat(UserDefinedIndexing.stringIndex()).isEqualTo(42.5);
+    }
+
+    @Test
+    void matrixIndexName() {
+        assertThat(UserDefinedIndexing.matrixIndexName()).isEqualTo("second");
+    }
+
+    @Test
+    void chainedIndex() {
+        assertThat(UserDefinedIndexing.chainedIndex()).isEqualTo(Optional.of("e"));
+    }
+
+    @Test
+    void listVariableIndex() {
+        assertThat(UserDefinedIndexing.listVariableIndex(List.of("a", "b", "c"), 1)).isEqualTo(Optional.of("b"));
+        assertThat(UserDefinedIndexing.listVariableIndex(List.of("a"), 3)).isEmpty();
+    }
+}

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -93,6 +93,34 @@ public class CompilationErrorTest {
     }
 
     @Test
+    void shouldRejectEmptyIndexAccess() {
+        var errors = compileProgram("""
+                        data Box { value: string }
+                        fun Box.get(): string = this.value
+                        fun broken(box: Box): string = box[]
+                        """,
+                "empty_index_access");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Index access requires at least one argument.");
+    }
+
+    @Test
+    void shouldRejectIndexAccessWithoutMatchingGetMethod() {
+        var errors = compileProgram("""
+                        data Box { value: string }
+                        fun broken(box: Box): string = box[1]
+                        """,
+                "index_access_without_matching_get");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Type 'Box' cannot be indexed with arguments: int.")
+                .contains("No matching method 'Box.get(int)' found.");
+    }
+
+    @Test
     void shouldRejectParameterizedRuntimeTypePatterns() {
         var errors = compileProgram("""
                         fun classify(value: any): int =

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -4,6 +4,20 @@ grammar Functional;
 package dev.capylang.parser.antlr;
 }
 
+@lexer::members {
+private boolean lineStart = true;
+
+private boolean containsNewline(String text) {
+    return text.indexOf('\n') >= 0 || text.indexOf('\r') >= 0;
+}
+
+@Override
+public org.antlr.v4.runtime.Token emit() {
+    lineStart = false;
+    return super.emit();
+}
+}
+
 program : definition+ EOF;
 
 definition:
@@ -54,7 +68,8 @@ fieldDeclarationList: fieldDeclaration (',' fieldDeclaration)* ','?;
 fieldDeclaration: identifier ':' type
                 | STRING_LITERAL ':' type
                 | SPREAD TYPE;
-genericTypeDeclaration: TYPE ('[' TYPE (',' TYPE)* ']')?;
+genericTypeDeclaration: TYPE (typeLbrack TYPE (',' TYPE)* RBRACK)?;
+typeLbrack: LBRACK | LINE_START_LBRACK;
 
 VISIBILITY: 'local' | 'private';
 BOOL_LITERAL: 'true' | 'false';
@@ -65,8 +80,8 @@ identifier: NAME | REC | COLLECTION | 'derive' | 'deriver' | 'fun' | 'type' | 'b
 parameters: parameter (',' parameter)*;
 parameter: identifier ':' type;
 functionType: ':' type;
-type: COLLECTION '[' type ']'
-    | 'tuple' '[' type (COMMA type)+ ']'
+type: COLLECTION typeLbrack type RBRACK
+    | 'tuple' typeLbrack type (COMMA type)+ RBRACK
     | LPAREN RPAREN FAT_ARROW type
     | LPAREN type (COMMA type)+ RPAREN FAT_ARROW type
     | type FAT_ARROW type
@@ -80,7 +95,7 @@ type: COLLECTION '[' type ']'
     | 'any'
     | 'data'
     | 'nothing'
-    | qualifiedType ('[' type (',' type)* ']')?;
+    | qualifiedType (typeLbrack type (',' type)* RBRACK)?;
 qualifiedType: TYPE (DOT TYPE)*;
 TYPE: [_]* [A-Z][a-zA-Z0-9_]*
       | TYPE_FULL ;
@@ -105,8 +120,8 @@ expressionNoLet: ifExpression
                | BANG expressionNoLet
                | BITWISE_NOT expressionNoLet
                | MINUS expressionNoLet
-               | expressionNoLet LBRACK indexLiteral RBRACK
                | expressionNoLet LBRACK sliceIndexLiteral? COLON sliceIndexLiteral? RBRACK
+               | expressionNoLet LBRACK argumentList? RBRACK
                | expressionNoLet LPAREN argumentList? RPAREN
                | expressionNoLet DOT methodIdentifier LPAREN methodArgumentList? RPAREN
                | expressionNoLet INFIX_METHOD_LITERAL expressionNoLet
@@ -116,7 +131,6 @@ expressionNoLet: ifExpression
                | newData
                | constructorData
                | matchExpression;
-indexLiteral: MINUS? INT_LITERAL;
 sliceIndexLiteral: MINUS? INT_LITERAL;
 lambdaExpression: lambdaArgument FAT_ARROW expressionNoPipe
                 | LPAREN (lambdaArgument (COMMA lambdaArgument)*)? RPAREN FAT_ARROW expressionNoPipe;
@@ -135,8 +149,8 @@ expressionNoLetNoPipe: ifExpression
                      | BANG expressionNoLetNoPipe
                      | BITWISE_NOT expressionNoLetNoPipe
                      | MINUS expressionNoLetNoPipe
-                     | expressionNoLetNoPipe LBRACK indexNoPipeLiteral RBRACK
                      | expressionNoLetNoPipe LBRACK sliceIndexNoPipeLiteral? COLON sliceIndexNoPipeLiteral? RBRACK
+                     | expressionNoLetNoPipe LBRACK argumentList? RBRACK
                      | expressionNoLetNoPipe LPAREN argumentList? RPAREN
                      | expressionNoLetNoPipe DOT methodIdentifier LPAREN methodArgumentList? RPAREN
                      | expressionNoLetNoPipe INFIX_METHOD_LITERAL expressionNoLetNoPipe
@@ -146,7 +160,6 @@ expressionNoLetNoPipe: ifExpression
                      | newData
                      | constructorData
                      | matchExpressionNoPipe;
-indexNoPipeLiteral: MINUS? INT_LITERAL;
 sliceIndexNoPipeLiteral: MINUS? INT_LITERAL;
 tupleLiteral: LPAREN expression (COMMA expression)+ RPAREN;
 
@@ -208,8 +221,8 @@ pattern: TYPE
         | constructorPattern;
 wildcardPattern: UNDERSCORE NAME?;
 typedPattern: patternType (NAME | UNDERSCORE);
-patternType: COLLECTION ('[' type ']')?
-           | 'tuple' '[' type (COMMA type)+ ']'
+patternType: COLLECTION (typeLbrack type RBRACK)?
+           | 'tuple' typeLbrack type (COMMA type)+ RBRACK
            | 'byte'
            | 'int'
            | 'long'
@@ -220,13 +233,13 @@ patternType: COLLECTION ('[' type ']')?
            | 'any'
            | 'data'
            | 'nothing'
-           | qualifiedType ('[' type (',' type)* ']')?;
+           | qualifiedType (typeLbrack type (',' type)* RBRACK)?;
 constructorPattern: TYPE '{' fieldPatternList? '}';
 fieldPatternList: pattern (',' pattern)*;
 
 newData: type BANG? '{' fieldAssignmentList? '}';
 constructorData: MUL '{' fieldAssignmentList? '}';
-new_list: '[' (expression (',' expression)* ','?)? ']';
+new_list: (LBRACK | LINE_START_LBRACK) (expression (',' expression)* ','?)? RBRACK;
 new_set: '{' (expression (',' expression)* ','?)? '}';
 new_dict: '{' (dict_entry (',' dict_entry)* ','? | COLON) '}';
 dict_entry: expression ':' expression;
@@ -298,6 +311,7 @@ LPAREN : '(';
 RPAREN : ')';
 LBRACE : '{';
 RBRACE : '}';
+LINE_START_LBRACK : {lineStart}? '[';
 LBRACK : '[';
 RBRACK : ']';
 SEMI : ';';
@@ -358,5 +372,5 @@ URSHIFT_ASSIGN : '>>>=';
 
 DOC_COMMENT : '///' ~[\r\n]*;
 LINE_COMMENT : '//' ~[\r\n]* -> skip;
-BLOCK_COMMENT : '/*' .*? '*/' -> skip;
-WS : [ \t\r\n]+ -> skip;
+BLOCK_COMMENT : '/*' .*? '*/' { if (containsNewline(getText())) lineStart = true; } -> skip;
+WS : [ \t\r\n]+ { if (containsNewline(getText())) lineStart = true; } -> skip;

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -1751,8 +1751,8 @@ public class CapybaraCompiler {
                                     reduceExpression.position()
                             )));
             case IndexExpression indexExpression -> expandDeriverExpression(indexExpression.source(), targetType, moduleSourceFile, boundNames)
-                    .flatMap(source -> expandDeriverExpression(indexExpression.index(), targetType, moduleSourceFile, boundNames)
-                            .map(index -> new IndexExpression(source, index, indexExpression.position())));
+                    .flatMap(source -> expandDeriverExpressions(indexExpression.arguments(), targetType, moduleSourceFile, boundNames)
+                            .map(arguments -> new IndexExpression(source, arguments, indexExpression.position())));
             case SliceExpression sliceExpression -> expandDeriverExpression(sliceExpression.source(), targetType, moduleSourceFile, boundNames)
                     .flatMap(source -> expandOptionalDeriverExpression(sliceExpression.start(), targetType, moduleSourceFile, boundNames)
                             .flatMap(start -> expandOptionalDeriverExpression(sliceExpression.end(), targetType, moduleSourceFile, boundNames)
@@ -3886,7 +3886,9 @@ public class CapybaraCompiler {
             case Value value -> restorePrivateFunctionNameForDisplay(value.name());
             case FieldAccess fieldAccess -> formatExpressionPreview(fieldAccess.source()) + "." + fieldAccess.field();
             case IndexExpression indexExpression -> formatExpressionPreview(indexExpression.source())
-                                                    + "[" + formatExpressionPreview(indexExpression.index()) + "]";
+                                                    + "[" + indexExpression.arguments().stream()
+                                                            .map(this::formatExpressionPreview)
+                                                            .collect(java.util.stream.Collectors.joining(", ")) + "]";
             case FunctionCall functionCall -> formatFunctionCallPreview(functionCall);
             case FunctionInvoke functionInvoke -> formatExpressionPreview(functionInvoke.function())
                                                   + "(" + functionInvoke.arguments().stream()

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -292,28 +292,29 @@ public class CapybaraExpressionCompiler {
     }
 
     private Result<CompiledExpression> linkIndexExpression(IndexExpression expression, Scope scope) {
+        if (expression.arguments().isEmpty()) {
+            return withPosition(
+                    Result.error("Index access requires at least one argument."),
+                    expression.position()
+            );
+        }
         return linkExpression(expression.source(), scope)
                 .flatMap(source -> {
-                    if (!(source.type() instanceof CompiledList)
-                        && source.type() != STRING
-                        && !(source.type() instanceof CompiledTupleType)) {
-                        return withPosition(
-                                Result.error("Index source has to be `list`, `string` or `tuple`, was `" + source.type() + "`"),
-                                expression.position()
-                        );
+                    if (expression.arguments().size() != 1 || !isBuiltinIndexSource(source.type())) {
+                        return linkCustomIndexExpression(expression, scope, source);
                     }
-                    return linkExpression(expression.index(), scope)
+                    return linkExpression(expression.arguments().getFirst(), scope)
                             .flatMap(index -> {
                                 if (index.type() != PrimitiveLinkedType.INT) {
                                     return withPosition(
                                             Result.error("Index has to be `int`, was `" + index.type() + "`"),
-                                            expression.index().position()
+                                            expression.arguments().getFirst().position()
                                     );
                                 }
                                 var elementType = switch (source.type()) {
                                     case CompiledList linkedList -> Result.success(linkedList.elementType());
                                     case PrimitiveLinkedType primitive when primitive == STRING -> Result.<CompiledType>success(STRING);
-                                    case CompiledTupleType tupleType -> tupleElementType(tupleType, index, expression.index().position());
+                                    case CompiledTupleType tupleType -> tupleElementType(tupleType, index, expression.arguments().getFirst().position());
                                     default -> Result.<CompiledType>error("Unsupported index source `" + source.type() + "`");
                                 };
                                 if (elementType instanceof Result.Error<CompiledType> error) {
@@ -335,6 +336,69 @@ public class CapybaraExpressionCompiler {
                                 return Result.success((CompiledExpression) new CompiledIndexExpression(source, index, resolvedElementType, optionType));
                             });
                 });
+    }
+
+    private boolean isBuiltinIndexSource(CompiledType sourceType) {
+        return sourceType instanceof CompiledList
+               || sourceType == STRING
+               || sourceType instanceof CompiledTupleType;
+    }
+
+    private Result<CompiledExpression> linkCustomIndexExpression(
+            IndexExpression expression,
+            Scope scope,
+            CompiledExpression source
+    ) {
+        var args = new java.util.ArrayList<Expression>(expression.arguments().size() + 1);
+        args.add(expression.source());
+        args.addAll(expression.arguments());
+        var getCall = new FunctionCall(
+                Optional.empty(),
+                METHOD_INVOKE_PREFIX + "get",
+                List.copyOf(args),
+                expression.position()
+        );
+        var resolved = resolveMethodInvokeCall(getCall, scope);
+        if (resolved instanceof Result.Success<CompiledExpression>) {
+            return resolved;
+        }
+        if (!isIndexMethodResolutionError((Result.Error<CompiledExpression>) resolved)) {
+            return resolved;
+        }
+        return linkIndexArgumentTypes(expression.arguments(), scope)
+                .flatMap(argumentTypes -> withPosition(
+                        Result.error(indexMethodResolutionMessage(source.type(), argumentTypes)),
+                        expression.position()
+                ));
+    }
+
+    private boolean isIndexMethodResolutionError(Result.Error<CompiledExpression> error) {
+        return error.errors().stream()
+                .map(Result.Error.SingleError::message)
+                .anyMatch(message -> message.contains("No method `get`")
+                                     || message.contains("No matching method `get`"));
+    }
+
+    private Result<List<CompiledType>> linkIndexArgumentTypes(List<Expression> arguments, Scope scope) {
+        return arguments.stream()
+                .map(argument -> linkExpression(argument, scope).map(CompiledExpression::type))
+                .collect(new ResultCollectionCollector<>());
+    }
+
+    private String indexMethodResolutionMessage(CompiledType sourceType, List<CompiledType> argumentTypes) {
+        var ownerType = simpleTypeNameStatic(sourceType.name());
+        var arguments = argumentTypes.stream()
+                .map(this::diagnosticTypeName)
+                .toList();
+        return "Type '" + ownerType + "' cannot be indexed with arguments: " + String.join(", ", arguments) + ".\n"
+               + "No matching method '" + ownerType + ".get(" + String.join(", ", arguments) + ")' found.";
+    }
+
+    private String diagnosticTypeName(CompiledType type) {
+        if (type instanceof PrimitiveLinkedType) {
+            return type.name().toLowerCase(Locale.ROOT);
+        }
+        return type.name();
     }
 
     private Result<CompiledExpression> linkTupleExpression(TupleExpression expression, Scope scope) {
@@ -3765,7 +3829,8 @@ public class CapybaraExpressionCompiler {
                     || containsValueReference(ifExpression.elseBranch(), variableName);
             case IndexExpression indexExpression ->
                     containsValueReference(indexExpression.source(), variableName)
-                    || containsValueReference(indexExpression.index(), variableName);
+                    || indexExpression.arguments().stream()
+                            .anyMatch(argument -> containsValueReference(argument, variableName));
             case SliceExpression sliceExpression ->
                     containsValueReference(sliceExpression.source(), variableName)
                     || sliceExpression.start().map(start -> containsValueReference(start, variableName)).orElse(false)
@@ -5710,8 +5775,14 @@ public class CapybaraExpressionCompiler {
             CompiledExpression index,
             Optional<SourcePosition> position
     ) {
-        var size = tupleType.elementTypes().size();
         var indexValue = intLiteralValue(index);
+        if (indexValue == null) {
+            return withPosition(
+                    Result.error("Tuple index has to be an int literal"),
+                    position
+            );
+        }
+        var size = tupleType.elementTypes().size();
         var normalized = normalizeTupleIndex(indexValue, size);
         if (normalized < 0 || normalized >= size) {
             return withPosition(
@@ -5722,11 +5793,18 @@ public class CapybaraExpressionCompiler {
         return Result.success(tupleType.elementTypes().get(normalized));
     }
 
-    private int intLiteralValue(CompiledExpression expression) {
+    private Integer intLiteralValue(CompiledExpression expression) {
         if (expression instanceof CompiledIntValue intValue) {
             return Integer.parseInt(intValue.intValue());
         }
-        throw new IllegalStateException("Expected int literal expression, got: " + expression);
+        if (expression instanceof CompiledInfixExpression infixExpression
+            && infixExpression.operator() == InfixOperator.MINUS
+            && infixExpression.left() instanceof CompiledIntValue left
+            && "0".equals(left.intValue())
+            && infixExpression.right() instanceof CompiledIntValue right) {
+            return -Integer.parseInt(right.intValue());
+        }
+        return null;
     }
 
     private int normalizeTupleIndex(int index, int size) {
@@ -9220,7 +9298,8 @@ public class CapybaraExpressionCompiler {
             }
             case IndexExpression indexExpression -> {
                 collectGenericBindingsFromExpression(variableName, parentType, indexExpression.source(), scope, bindings);
-                collectGenericBindingsFromExpression(variableName, parentType, indexExpression.index(), scope, bindings);
+                indexExpression.arguments().forEach(argument ->
+                        collectGenericBindingsFromExpression(variableName, parentType, argument, scope, bindings));
             }
             case LambdaExpression lambdaExpression ->
                     collectGenericBindingsFromExpression(variableName, parentType, lambdaExpression.expression(), scope, bindings);

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -1033,7 +1033,9 @@ public class CapybaraParser {
             );
             case IndexExpression indexExpression -> new IndexExpression(
                     rewriteLocalNames(indexExpression.source(), localFunctionNameMap, localTypeNameMap, localConstNameMap),
-                    rewriteLocalNames(indexExpression.index(), localFunctionNameMap, localTypeNameMap, localConstNameMap),
+                    indexExpression.arguments().stream()
+                            .map(argument -> rewriteLocalNames(argument, localFunctionNameMap, localTypeNameMap, localConstNameMap))
+                            .toList(),
                     indexExpression.position()
             );
             case SliceExpression sliceExpression -> new SliceExpression(
@@ -1890,7 +1892,7 @@ public class CapybaraParser {
                     .orElseGet(() -> new TrailingPostfix(expressionNoLet(sourceContext), java.util.function.UnaryOperator.identity()));
             return java.util.Optional.of(new TrailingPostfix(
                     nested.base(),
-                    source -> indexExpression(nested.apply().apply(source), expression.indexLiteral(), position(expression))
+                    source -> indexExpression(nested.apply().apply(source), expression.argumentList(), position(expression))
             ));
         }
         if (isSlice(expression)) {
@@ -1960,14 +1962,14 @@ public class CapybaraParser {
             if (isUnaryBang(sourceContext)) {
                 return java.util.Optional.of(new TrailingPostfix(
                         expressionNoLet(sourceContext.expressionNoLet(0)),
-                        source -> indexExpression(source, expression.indexLiteral(), position(expression))
+                        source -> indexExpression(source, expression.argumentList(), position(expression))
                 ));
             }
             var nested = splitUnaryBangTrailingPostfix(sourceContext);
             if (nested.isPresent()) {
                 return java.util.Optional.of(new TrailingPostfix(
                         nested.get().base(),
-                        source -> indexExpression(nested.get().apply().apply(source), expression.indexLiteral(), position(expression))
+                        source -> indexExpression(nested.get().apply().apply(source), expression.argumentList(), position(expression))
                 ));
             }
         }
@@ -2091,14 +2093,14 @@ public class CapybaraParser {
             if (isUnaryBang(sourceContext)) {
                 return java.util.Optional.of(new TrailingPostfix(
                         expressionNoLetNoPipe(sourceContext.expressionNoLetNoPipe(0)),
-                        source -> indexExpression(source, expression.indexNoPipeLiteral(), position(expression))
+                        source -> indexExpression(source, expression.argumentList(), position(expression))
                 ));
             }
             var nested = splitUnaryBangTrailingPostfix(sourceContext);
             if (nested.isPresent()) {
                 return java.util.Optional.of(new TrailingPostfix(
                         nested.get().base(),
-                        source -> indexExpression(nested.get().apply().apply(source), expression.indexNoPipeLiteral(), position(expression))
+                        source -> indexExpression(nested.get().apply().apply(source), expression.argumentList(), position(expression))
                 ));
             }
         }
@@ -2722,7 +2724,9 @@ public class CapybaraParser {
             );
             case IndexExpression value -> new IndexExpression(
                     shiftInterpolationPositions(value.source(), stringPosition, interpolationOffset),
-                    shiftInterpolationPositions(value.index(), stringPosition, interpolationOffset),
+                    value.arguments().stream()
+                            .map(argument -> shiftInterpolationPositions(argument, stringPosition, interpolationOffset))
+                            .toList(),
                     shiftPosition(value.position(), stringPosition, interpolationOffset)
             );
             case InfixExpression value -> new InfixExpression(
@@ -3126,56 +3130,43 @@ public class CapybaraParser {
 
     private IndexExpression indexExpression(FunctionalParser.ExpressionNoLetContext expression) {
         var source = expressionNoLet(expression.expressionNoLet(0));
-        var index = indexExpression(expression.indexLiteral());
-        return new IndexExpression(source, index, position(expression));
+        return new IndexExpression(source, indexArguments(expression.argumentList()), position(expression));
     }
 
     private IndexExpression indexExpression(
             FunctionalParser.ExpressionNoLetContext sourceContext,
-            FunctionalParser.IndexLiteralContext indexContext,
+            FunctionalParser.ArgumentListContext argumentListContext,
             Optional<SourcePosition> position
     ) {
-        return new IndexExpression(expressionNoLet(sourceContext), indexExpression(indexContext), position);
+        return new IndexExpression(expressionNoLet(sourceContext), indexArguments(argumentListContext), position);
     }
 
     private IndexExpression indexExpression(FunctionalParser.ExpressionNoLetNoPipeContext expression) {
         var source = expressionNoLetNoPipe(expression.expressionNoLetNoPipe(0));
-        var index = indexExpression(expression.indexNoPipeLiteral());
-        return new IndexExpression(source, index, position(expression));
+        return new IndexExpression(source, indexArguments(expression.argumentList()), position(expression));
     }
 
     private IndexExpression indexExpression(
             FunctionalParser.ExpressionNoLetNoPipeContext sourceContext,
-            FunctionalParser.IndexNoPipeLiteralContext indexContext,
+            FunctionalParser.ArgumentListContext argumentListContext,
             Optional<SourcePosition> position
     ) {
-        return new IndexExpression(expressionNoLetNoPipe(sourceContext), indexExpression(indexContext), position);
+        return new IndexExpression(expressionNoLetNoPipe(sourceContext), indexArguments(argumentListContext), position);
     }
 
     private IndexExpression indexExpression(
             Expression source,
-            FunctionalParser.IndexLiteralContext indexContext,
+            FunctionalParser.ArgumentListContext argumentListContext,
             Optional<SourcePosition> position
     ) {
-        return new IndexExpression(source, indexExpression(indexContext), position);
+        return new IndexExpression(source, indexArguments(argumentListContext), position);
     }
 
-    private IndexExpression indexExpression(
-            Expression source,
-            FunctionalParser.IndexNoPipeLiteralContext indexContext,
-            Optional<SourcePosition> position
-    ) {
-        return new IndexExpression(source, indexExpression(indexContext), position);
-    }
-
-    private Expression indexExpression(FunctionalParser.IndexLiteralContext index) {
-        var sign = index.MINUS() == null ? "" : "-";
-        return new IntValue(sign + index.INT_LITERAL().getText(), position(index));
-    }
-
-    private Expression indexExpression(FunctionalParser.IndexNoPipeLiteralContext index) {
-        var sign = index.MINUS() == null ? "" : "-";
-        return new IntValue(sign + index.INT_LITERAL().getText(), position(index));
+    private List<Expression> indexArguments(FunctionalParser.ArgumentListContext argumentListContext) {
+        if (argumentListContext == null) {
+            return List.of();
+        }
+        return argumentListContext.expression().stream().map(this::expression).toList();
     }
 
     private SliceExpression sliceExpression(FunctionalParser.ExpressionNoLetNoPipeContext expression) {
@@ -3345,7 +3336,9 @@ public class CapybaraParser {
         return expression.LBRACK() != null
                && expression.RBRACK() != null
                && expression.COLON() != null
+               && expression.new_list() == null
                && expression.expressionNoLet().size() == 1
+               && isSameLinePostfixBracket(expression.LBRACK().getSymbol(), expression.expressionNoLet(0))
                && expression.sliceIndexLiteral().size() <= 2;
     }
 
@@ -3353,15 +3346,18 @@ public class CapybaraParser {
         return expression.LBRACK() != null
                && expression.RBRACK() != null
                && expression.COLON() == null
+               && expression.new_list() == null
                && expression.expressionNoLet().size() == 1
-               && expression.indexLiteral() != null;
+               && isSameLinePostfixBracket(expression.LBRACK().getSymbol(), expression.expressionNoLet(0));
     }
 
     private static boolean isSlice(FunctionalParser.ExpressionNoLetNoPipeContext expression) {
         return expression.LBRACK() != null
                && expression.RBRACK() != null
                && expression.COLON() != null
+               && expression.new_list() == null
                && expression.expressionNoLetNoPipe().size() == 1
+               && isSameLinePostfixBracket(expression.LBRACK().getSymbol(), expression.expressionNoLetNoPipe(0))
                && expression.sliceIndexNoPipeLiteral().size() <= 2;
     }
 
@@ -3369,8 +3365,13 @@ public class CapybaraParser {
         return expression.LBRACK() != null
                && expression.RBRACK() != null
                && expression.COLON() == null
+               && expression.new_list() == null
                && expression.expressionNoLetNoPipe().size() == 1
-               && expression.indexNoPipeLiteral() != null;
+               && isSameLinePostfixBracket(expression.LBRACK().getSymbol(), expression.expressionNoLetNoPipe(0));
+    }
+
+    private static boolean isSameLinePostfixBracket(Token bracket, ParserRuleContext sourceContext) {
+        return sourceContext.getStop() != null && bracket.getLine() == sourceContext.getStop().getLine();
     }
 
     private record DataFieldDeclarations(List<DataDeclaration.DataField> fields, List<String> extendsTypes) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/IndexExpression.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/IndexExpression.java
@@ -1,11 +1,18 @@
 package dev.capylang.compiler.parser;
 
+import java.util.List;
 import java.util.Optional;
 
 public record IndexExpression(
         Expression source,
-        Expression index,
+        List<Expression> arguments,
         Optional<SourcePosition> position
 ) implements Expression {
-}
+    public IndexExpression(Expression source, Expression index, Optional<SourcePosition> position) {
+        this(source, List.of(index), position);
+    }
 
+    public Expression index() {
+        return arguments.getFirst();
+    }
+}

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -429,10 +429,32 @@ public class JavaAstBuilder {
     private JavaType buildJavaReturnType(CompiledFunction function) {
         if (function.returnType() instanceof GenericDataType genericDataType
             && ("Option".equals(genericDataType.name()) || isOptionTypeName(genericDataType.name()))) {
-            var elementType = inferOptionElementType(function.expression());
+            var elementDescriptor = optionElementTypeDescriptor(genericDataType);
+            if (elementDescriptor.isPresent()) {
+                return new JavaType("java.util.Optional<" + mapTypeParameterDescriptor(elementDescriptor.orElseThrow()) + ">");
+            }
+            var elementType = optionElementType(function.returnType())
+                    .orElseGet(() -> inferOptionElementType(function.expression()));
             return new JavaType("java.util.Optional<" + buildJavaBoxedType(elementType) + ">");
         }
         return buildJavaType(function.returnType());
+    }
+
+    private Optional<String> optionElementTypeDescriptor(GenericDataType type) {
+        var typeParameters = switch (type) {
+            case CompiledDataType linkedDataType -> linkedDataType.typeParameters();
+            case CompiledDataParentType linkedDataParentType -> linkedDataParentType.typeParameters();
+        };
+        return typeParameters.stream().findFirst();
+    }
+
+    private Optional<CompiledType> optionElementType(CompiledType type) {
+        if (!isOptionType(type) || !(type instanceof GenericDataType genericDataType)) {
+            return Optional.empty();
+        }
+        return genericDataType.fields().stream()
+                .findFirst()
+                .map(CompiledDataType.CompiledField::type);
     }
 
     private CompiledType inferOptionElementType(dev.capylang.compiler.expression.CompiledExpression expression) {

--- a/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
@@ -1,6 +1,7 @@
 package dev.capylang.compiler;
 
 import dev.capylang.compiler.expression.CompiledFunctionCall;
+import dev.capylang.compiler.expression.CompiledFieldAccess;
 import dev.capylang.compiler.expression.CompiledLetExpression;
 import dev.capylang.compiler.expression.CompiledMatchExpression;
 import dev.capylang.compiler.expression.CompiledNewData;
@@ -139,6 +140,45 @@ class CapybaraCompilerLibrariesTest {
         assertThat(mixedParameters.parameters()).extracting(parameter -> parameter.type().name())
                 .containsExactly("User", "INT", "AgeLimit");
         assertThat(mixedParameters.returnType()).isEqualTo(PrimitiveLinkedType.BOOL);
+    }
+
+    @Test
+    void shouldResolveUserDefinedIndexAccessAsGetMethod() {
+        var compiled = compileProgram(List.of(new RawModule("Consumer", "/foo/app", """
+                data Box { value: string }
+                data Bag { age: double }
+                data Cell { name: string }
+                data Matrix { cell: Cell }
+
+                fun Box.get(idx: int): string = this.value
+                fun Bag.get(key: string): double = this.age
+                fun Matrix.get(row: int, col: int): Cell = this.cell
+
+                fun read_box(box: Box): string = box[1]
+                fun read_bag(bag: Bag): double = bag["age"]
+                fun read_cell(matrix: Matrix): string = matrix[1, 2].name
+                """)), new java.util.TreeSet<>());
+
+        assertThat(compiledFunction(compiled, "Consumer", "read_box").expression())
+                .isInstanceOfSatisfying(CompiledFunctionCall.class, call -> {
+                    assertThat(call.name()).isEqualTo("__method__Box__get");
+                    assertThat(call.arguments()).hasSize(2);
+                    assertThat(call.returnType()).isEqualTo(PrimitiveLinkedType.STRING);
+                });
+        assertThat(compiledFunction(compiled, "Consumer", "read_bag").expression())
+                .isInstanceOfSatisfying(CompiledFunctionCall.class, call -> {
+                    assertThat(call.name()).isEqualTo("__method__Bag__get");
+                    assertThat(call.arguments()).hasSize(2);
+                    assertThat(call.returnType()).isEqualTo(PrimitiveLinkedType.DOUBLE);
+                });
+        assertThat(compiledFunction(compiled, "Consumer", "read_cell").expression())
+                .isInstanceOfSatisfying(CompiledFieldAccess.class, fieldAccess -> {
+                    assertThat(fieldAccess.field()).isEqualTo("name");
+                    assertThat(fieldAccess.source()).isInstanceOfSatisfying(CompiledFunctionCall.class, call -> {
+                        assertThat(call.name()).isEqualTo("__method__Matrix__get");
+                        assertThat(call.arguments()).hasSize(3);
+                    });
+                });
     }
 
     @Test

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -472,6 +472,35 @@ class CapybaraParserTest {
     }
 
     @Test
+    @DisplayName("should parse line-wrapped type brackets")
+    void parseLineWrappedTypeBrackets() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                data Box
+                [T] { value: T }
+
+                fun list_identity(xs: list
+                [string]): list
+                [string] = xs
+
+                fun box_identity(box: Box
+                [string]): Box
+                [string] = box
+
+                fun match_list(value: any): int =
+                    match value with
+                    case list
+                    [string] _ -> 1
+                    case _ -> 0
+                """));
+
+        findDefinition(DataDeclaration.class, "Box", module.functional());
+        assertThat(findFunction("list_identity", module.functional()).returnType())
+                .hasValue(new CollectionType.ListType(PrimitiveType.STRING));
+        findFunction("box_identity", module.functional());
+        findFunction("match_list", module.functional());
+    }
+
+    @Test
     @DisplayName("should parse doc comments for data and type declarations")
     void parseDataAndTypeComments() {
         var module = parseSuccess(new RawModule("Test", "/parser", """
@@ -708,6 +737,42 @@ class CapybaraParserTest {
         assertThat(((Value) fieldAccess.source()).name()).isEqualTo("parse");
         assertThat(indexExpression.index()).isInstanceOf(IntValue.class);
         assertThat(((IntValue) indexExpression.index()).intValue()).isEqualTo("0");
+    }
+
+    @Test
+    @DisplayName("should parse index access with multiple arguments")
+    void parseIndexAccessWithMultipleArguments() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                data Cell { name: string }
+                data Matrix { cell: Cell }
+                fun test(matrix: Matrix): string = matrix[1, 2].name
+                """));
+
+        var function = findFunction("test", module.functional());
+        assertThat(function.expression()).isInstanceOf(FieldAccess.class);
+        var fieldAccess = (FieldAccess) function.expression();
+        assertThat(fieldAccess.field()).isEqualTo("name");
+        assertThat(fieldAccess.source()).isInstanceOf(IndexExpression.class);
+        var indexExpression = (IndexExpression) fieldAccess.source();
+        assertThat(indexExpression.arguments()).hasSize(2);
+        assertThat(indexExpression.arguments().get(0)).isInstanceOf(IntValue.class);
+        assertThat(((IntValue) indexExpression.arguments().get(0)).intValue()).isEqualTo("1");
+        assertThat(indexExpression.arguments().get(1)).isInstanceOf(IntValue.class);
+        assertThat(((IntValue) indexExpression.arguments().get(1)).intValue()).isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("should parse empty index access for compiler diagnostics")
+    void parseEmptyIndexAccessForCompilerDiagnostics() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                data Box { value: string }
+                fun test(box: Box): string = box[]
+                """));
+
+        var function = findFunction("test", module.functional());
+        assertThat(function.expression()).isInstanceOf(IndexExpression.class);
+        var indexExpression = (IndexExpression) function.expression();
+        assertThat(indexExpression.arguments()).isEmpty();
     }
 
     @Test

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -6,9 +6,14 @@ type Json = JsonObject | JsonArray | JsonValue
 data JsonObject { value: dict[Json] }
 fun JsonObject.`+`(other: JsonObject): JsonObject = JsonObject { value: this.value + other.value }
 fun JsonObject.`+`(other: tuple[string, Json]): JsonObject = JsonObject { value: this.value + other }
+fun JsonObject.get(key: string): Option[Json] =
+    this.value |> None {}, (acc, item_key, item_value) =>
+        if item_key == key then Some { item_value } else acc
+
 data JsonArray { value: list[Json] }
 fun JsonArray.`+`(other: JsonArray): JsonArray = JsonArray { value: this.value + other.value }
 fun JsonArray.`+`(other: Json): JsonArray = JsonArray { value: this.value + other }
+fun JsonArray.get(index: int): Option[Json] = this.value[index]
 
 type JsonValue = JsonString | JsonValueObject | JsonNumber | JsonValueArray | JsonBool | JsonNull
 data JsonString { value: string }
@@ -16,7 +21,9 @@ type JsonNumber = JsonNumberDouble | JsonNumberLong
 data JsonNumberDouble { value: double }
 data JsonNumberLong { value: long }
 data JsonValueObject { value: JsonObject }
+fun JsonValueObject.get(key: string): Option[Json] = this.value.get(key)
 data JsonValueArray { value: JsonArray }
+fun JsonValueArray.get(index: int): Option[Json] = this.value.get(index)
 data JsonBool { value: bool }
 single JsonNull
 

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -42,6 +42,8 @@ fun tests(): Effect[TestFile] =
         test("should fail converting lambda field", () => should_fail_converting_lambda_field()),
         test("should derive Jsonable to_json for primitive fields", () => should_derive_jsonable_to_json_for_primitive_fields()),
         test("should derive Jsonable to_json for nested and collection fields", () => should_derive_jsonable_to_json_for_nested_and_collection_fields()),
+        test("should index json object and array containers", () => should_index_json_object_and_array_containers()),
+        test("should index json value container wrappers", () => should_index_json_value_container_wrappers()),
         test("should serialize simple object", () => test_serialize_simple_object()),
         test("should serialize empty object", () => test_empty()),
         test("should serialize object with primitive types", () => test_serialize_object_with_primitive_types()),
@@ -204,6 +206,47 @@ fun should_derive_jsonable_to_json_for_nested_and_collection_fields(): Assert =
 fun _json_field(json: JsonObject, name: string): Option[Json] =
     json.value |> None {}, (acc, key, value) =>
         if key == name then Some { value } else acc
+
+fun should_index_json_object_and_array_containers(): Assert =
+    let object = JsonObject {
+        value: {
+            "name": JsonString { value: "Ada" },
+            "numbers": JsonArray {
+                value: [
+                    JsonNumberLong { value: 1 },
+                    JsonNumberLong { value: 2 },
+                ]
+            },
+        }
+    }
+    let array = JsonArray {
+        value: [
+            JsonString { value: "first" },
+            JsonBool { value: true },
+        ]
+    }
+    assert_all([
+        assert_that(object["name"]).contains(JsonString { value: "Ada" }),
+        assert_that(object["missing"]).is_empty(),
+        assert_that(array[1]).contains(JsonBool { value: true }),
+        assert_that(array[3]).is_empty(),
+    ])
+
+fun should_index_json_value_container_wrappers(): Assert =
+    let object = JsonValueObject {
+        value: JsonObject {
+            value: { "enabled": JsonBool { value: true } }
+        }
+    }
+    let array = JsonValueArray {
+        value: JsonArray {
+            value: [JsonNumberLong { value: 7 }]
+        }
+    }
+    assert_all([
+        assert_that(object["enabled"]).contains(JsonBool { value: true }),
+        assert_that(array[0]).contains(JsonNumberLong { value: 7 }),
+    ])
 
 fun test_serialize_simple_object(): Assert =
     let json = JsonObject { value: { "foo": JsonString { value: "boo" } } }


### PR DESCRIPTION
## Summary
- Add user-defined indexing syntax: `value[arg]` resolves through existing built-in indexing for lists/strings/tuples or through a matching `get` method for user data.
- Support string, numeric, multi-argument, and chained user-defined indexing, with explicit diagnostics for empty index access and missing `get` overloads.
- Keep line-start `[` valid in type/generic grammar contexts while preserving newline disambiguation for postfix indexing.
- Add JSON `get` helpers for `JsonObject`, `JsonArray`, `JsonValueObject`, and `JsonValueArray`; scalar JSON values remain non-indexable.
- Fix Java generation for declared `Option[T]` return types so concise forwarding methods like `Option[Json] = this.value.get(index)` generate `Optional<Json>`.

## Impacted Modules
- `compiler`: grammar, parser AST, expression linking, Java generation, parser/compiler tests.
- `capy`: functional e2e coverage and compilation-error diagnostics.
- `lib/capybara-lib`: JSON indexing helpers and generated Capybara library tests.

## Validation
- `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest --tests dev.capylang.compiler.CapybaraCompilerLibrariesTest`
- `./gradlew :capy:e2e-cfun --tests dev.capylang.test.UserDefinedIndexingTest --tests dev.capylang.test.compilation_error.CompilationErrorTest`
- `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest.parseLineWrappedTypeBrackets --tests dev.capylang.parser.CapybaraParserTest.parseIndexAccessWithMultipleArguments --tests dev.capylang.parser.CapybaraParserTest.parseFieldAccessFollowedByIndex`
- `./gradlew :compiler:compileJava :lib:capybara-lib:testCapybara`
- `/usr/bin/time -f 'FINAL_CLEAN_CHECK_SECONDS=%e' ./gradlew clean check` -> `FINAL_CLEAN_CHECK_SECONDS=204.61`

## Performance
- Fresh `master` baseline: `./gradlew clean check` -> `BASELINE_CLEAN_CHECK_SECONDS=200.91`
- Branch final clean check: `204.61s`
- Delta: `+3.70s` / `+1.8%`; no meaningful clean-check performance regression observed.

CLOSE #110
