### PR TITLE
feat(#111): add partial function binding

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
@@ -15,3 +15,36 @@ fun invoke_field_supplier(): string =
     let holder = Holder { supplier: () => "hello", suppliers: [() => "x", () => "y"] }
     let supplier = holder.supplier
     supplier()
+
+fun add(a: int, b: int): int = a + b
+
+fun add_10(): int => int = add(10, _)
+
+fun invoke_partial_add(): int =
+    let f: int => int = add(10, _)
+    f(5)
+
+fun concat(a: string, b: string, c: string): string = a + b + c
+
+fun invoke_partial_concat(): string =
+    let f: (string, string) => string = concat(_, "-", _)
+    f("A", "B")
+
+fun combine(a: int, b: int, c: int): int =
+    a * 100 + b * 10 + c
+
+fun invoke_partial_combine(): int =
+    let f: (int, int) => int = combine(_, 5, _)
+    f(1, 9)
+
+fun pair(a: int, b: int): string =
+    a + ":" + b
+
+fun invoke_partial_pair(): string =
+    let f: (int, int) => string = pair(_, _)
+    f(1, 2)
+
+fun between(min: int, value: int, max: int): bool =
+    value >= min & value <= max
+
+fun is_age_valid(): int => bool = between(0, _, 150)

--- a/capy/src/e2e-cfun/java/dev/capylang/test/LambdaValuesTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/LambdaValuesTest.java
@@ -25,6 +25,31 @@ class LambdaValuesTest {
     }
 
     @Test
+    void invokesPartiallyBoundFunction() {
+        assertThat(LambdaValues.add10().apply(5)).isEqualTo(15);
+        assertThat(LambdaValues.invokePartialAdd()).isEqualTo(15);
+    }
+
+    @Test
+    void invokesPartiallyBoundFunctionWithMultiplePlaceholders() {
+        assertThat(LambdaValues.invokePartialConcat()).isEqualTo("A-B");
+        assertThat(LambdaValues.invokePartialCombine()).isEqualTo(159);
+    }
+
+    @Test
+    void treatsEachPlaceholderAsSeparateParameter() {
+        assertThat(LambdaValues.invokePartialPair()).isEqualTo("1:2");
+    }
+
+    @Test
+    void invokesPartiallyBoundFunctionWithFixedOuterArguments() {
+        var isAgeValid = LambdaValues.isAgeValid();
+        assertThat(isAgeValid.apply(42)).isTrue();
+        assertThat(isAgeValid.apply(-1)).isFalse();
+        assertThat(isAgeValid.apply(200)).isFalse();
+    }
+
+    @Test
     void generatesSupplierReturnType() throws NoSuchMethodException {
         var returnType = (ParameterizedType) LambdaValues.class.getMethod("makeSupplier").getGenericReturnType();
         assertThat(returnType.getRawType().getTypeName()).isEqualTo(Supplier.class.getTypeName());

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -462,6 +462,31 @@ public class CompilationErrorTest {
     }
 
     @Test
+    void shouldRejectStandalonePlaceholder() {
+        var errors = compileProgram("""
+                        fun broken(): int => int = _
+                        """,
+                "standalone_placeholder");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Placeholder `_` can only be used inside invocation arguments.");
+    }
+
+    @Test
+    void shouldRejectPlaceholderAsDataFieldValue() {
+        var errors = compileProgram("""
+                        data User { name: string, age: int }
+                        fun broken(): User = User { name: "Ada", age: _ }
+                        """,
+                "data_field_placeholder");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Placeholder `_` cannot be used in data construction.");
+    }
+
+    @Test
     void shouldRejectResultBindOnNonResultExpression() {
         var errors = compileProgram("""
                         fun broken(): int =

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -111,6 +111,7 @@ expressionNoLet: ifExpression
                | reduceExpression
                | functionReference
                | functionCall
+               | placeholder
                | new_list
                | new_dict
                | tupleLiteral
@@ -140,6 +141,7 @@ expressionNoLetNoPipe: ifExpression
                      | lambdaExpression
                      | functionReference
                      | functionCall
+                     | placeholder
                      | new_list
                      | new_dict
                      | tupleLiteral
@@ -165,6 +167,7 @@ tupleLiteral: LPAREN expression (COMMA expression)+ RPAREN;
 
 ifExpression: 'if' expression 'then' expression 'else' expression;
 functionReference: COLON identifier;
+placeholder: UNDERSCORE;
 functionCall: NAME '(' argumentList? ')'
             | REC '(' argumentList? ')'
             | COLLECTION '(' argumentList? ')'

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -2707,6 +2707,7 @@ public class CapybaraCompiler {
             case IntValue ignored -> false;
             case LongValue ignored -> false;
             case NothingValue ignored -> false;
+            case PlaceholderExpression ignored -> false;
             case StringValue ignored -> false;
             case WithExpression withExpression -> expressionMayProduceResult(withExpression.source());
         };
@@ -3884,6 +3885,7 @@ public class CapybaraCompiler {
             case ByteValue byteValue -> byteValue.byteValue();
             case BooleanValue booleanValue -> String.valueOf(booleanValue.value());
             case Value value -> restorePrivateFunctionNameForDisplay(value.name());
+            case PlaceholderExpression ignored -> "_";
             case FieldAccess fieldAccess -> formatExpressionPreview(fieldAccess.source()) + "." + fieldAccess.field();
             case IndexExpression indexExpression -> formatExpressionPreview(indexExpression.source())
                                                     + "[" + indexExpression.arguments().stream()

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -222,6 +222,10 @@ public class CapybaraExpressionCompiler {
             case NewData newData -> linkNewData(newData, scope);
             case WithExpression withExpression -> linkWithExpression(withExpression, scope);
             case NothingValue nothingValue -> linkNothingValue(nothingValue);
+            case PlaceholderExpression placeholderExpression -> withPosition(
+                    Result.error("Placeholder `_` can only be used inside invocation arguments."),
+                    placeholderExpression.position()
+            );
             case StringValue stringValue -> linkStringValue(stringValue, scope);
             case TupleExpression tupleExpression -> linkTupleExpression(tupleExpression, scope);
             case Value value -> linkValue(value, scope);
@@ -601,6 +605,164 @@ public class CapybaraExpressionCompiler {
                 .flatMap(function -> resolveFunctionInvoke(functionInvoke, scope, function));
     }
 
+    private boolean hasPlaceholderArguments(List<Expression> arguments) {
+        return arguments.stream().anyMatch(PlaceholderExpression.class::isInstance);
+    }
+
+    private Result<CompiledExpression> resolvePartialFunctionCall(
+            FunctionCall functionCall,
+            Scope scope,
+            Optional<CompiledType> expectedType,
+            List<FunctionSignature> candidates,
+            java.util.function.Function<FunctionSignature, String> resolvedName
+    ) {
+        ResolvedPartialFunctionCall best = null;
+        Result.Error.SingleError deepestError = null;
+        for (var candidate : candidates) {
+            var maybeArguments = linkPartialArguments(functionCall.arguments(), scope, candidate.parameterTypes());
+            if (maybeArguments instanceof Result.Error<PartialArguments> error) {
+                deepestError = preferDeeperError(deepestError, firstError(error));
+                continue;
+            }
+            var partial = ((Result.Success<PartialArguments>) maybeArguments).value();
+            var unsafeCollectionError = findUnsafeCollectionArgumentError(functionCall.arguments(), partial.arguments(), candidate.parameterTypes());
+            if (unsafeCollectionError != null) {
+                deepestError = preferDeeperError(deepestError, unsafeCollectionError);
+                continue;
+            }
+            var returnType = resolveReturnType(candidate, partial.arguments());
+            var expression = wrapPartialArguments(
+                    partial,
+                    new CompiledFunctionCall(resolvedName.apply(candidate), partial.arguments(), returnType),
+                    returnType
+            );
+            var coercions = partial.coercions();
+            if (expectedType.isPresent()) {
+                var maybeCoerced = coerceArgument(expression, expectedType.orElseThrow());
+                if (maybeCoerced == null) {
+                    continue;
+                }
+                expression = maybeCoerced.expression();
+                coercions += maybeCoerced.coercions();
+            }
+            if (!(expression.type() instanceof CompiledFunctionType functionType)) {
+                continue;
+            }
+            var resolved = new ResolvedPartialFunctionCall(
+                    expression,
+                    candidate,
+                    partial.arguments(),
+                    coercions,
+                    functionType
+            );
+            if (isBetterResolvedPartialCall(resolved, expectedType, best)) {
+                best = resolved;
+            }
+        }
+        if (best == null) {
+            if (deepestError != null) {
+                return new Result.Error<>(deepestError);
+            }
+            return withPosition(
+                    Result.error("No matching partial function binding for argument types " + partialArgumentTypes(functionCall.arguments(), scope)),
+                    functionCall.position()
+            );
+        }
+        return Result.success(best.expression());
+    }
+
+    private Result<PartialArguments> linkPartialArguments(
+            List<Expression> arguments,
+            Scope scope,
+            List<CompiledType> expectedTypes
+    ) {
+        var callArguments = new java.util.ArrayList<CompiledExpression>(arguments.size());
+        var placeholderNames = new java.util.ArrayList<String>();
+        var placeholderTypes = new java.util.ArrayList<CompiledType>();
+        var coercions = 0;
+        for (var i = 0; i < arguments.size(); i++) {
+            var argument = arguments.get(i);
+            var expected = expectedTypes.get(i);
+            if (argument instanceof PlaceholderExpression) {
+                var name = "__capybaraPartial" + (placeholderNames.size() + 1);
+                placeholderNames.add(name);
+                placeholderTypes.add(expected);
+                callArguments.add(new CompiledVariable(name, expected));
+                continue;
+            }
+            var linked = linkArgumentForExpectedType(argument, scope, expected);
+            if (linked instanceof Result.Error<CoercedArgument> error) {
+                return new Result.Error<>(error.errors());
+            }
+            var coerced = ((Result.Success<CoercedArgument>) linked).value();
+            callArguments.add(coerced.expression());
+            coercions += coerced.coercions();
+        }
+        return Result.success(new PartialArguments(
+                List.copyOf(callArguments),
+                List.copyOf(placeholderNames),
+                List.copyOf(placeholderTypes),
+                coercions
+        ));
+    }
+
+    private CompiledExpression wrapPartialArguments(
+            PartialArguments partial,
+            CompiledExpression body,
+            CompiledType returnType
+    ) {
+        CompiledExpression expression = body;
+        var nestedType = returnType;
+        for (var i = partial.placeholderNames().size() - 1; i >= 0; i--) {
+            var functionType = new CompiledFunctionType(partial.placeholderTypes().get(i), nestedType);
+            expression = new CompiledLambdaExpression(partial.placeholderNames().get(i), expression, functionType);
+            nestedType = functionType;
+        }
+        return expression;
+    }
+
+    private boolean isBetterResolvedPartialCall(
+            ResolvedPartialFunctionCall candidate,
+            Optional<CompiledType> expectedType,
+            ResolvedPartialFunctionCall currentBest
+    ) {
+        if (currentBest == null) {
+            return true;
+        }
+        var candidateExactType = expectedType.isPresent() && candidate.functionType().equals(expectedType.orElseThrow());
+        var currentExactType = expectedType.isPresent() && currentBest.functionType().equals(expectedType.orElseThrow());
+        if (candidateExactType != currentExactType) {
+            return candidateExactType;
+        }
+        if (candidate.coercions() < currentBest.coercions()) {
+            return true;
+        }
+        if (candidate.coercions() > currentBest.coercions()) {
+            return false;
+        }
+        var candidateExactParameters = exactParameterMatches(candidate.signature(), candidate.arguments());
+        var currentExactParameters = exactParameterMatches(currentBest.signature(), currentBest.arguments());
+        if (candidateExactParameters != currentExactParameters) {
+            return candidateExactParameters > currentExactParameters;
+        }
+        return isSignatureMoreSpecific(candidate.signature(), currentBest.signature());
+    }
+
+    private List<String> partialArgumentTypes(List<Expression> arguments, Scope scope) {
+        var actualTypes = new java.util.ArrayList<String>();
+        for (var argument : arguments) {
+            if (argument instanceof PlaceholderExpression) {
+                actualTypes.add("_");
+                continue;
+            }
+            var linked = linkExpression(argument, scope);
+            if (linked instanceof Result.Success<CompiledExpression> value) {
+                actualTypes.add(value.value().type().name());
+            }
+        }
+        return List.copyOf(actualTypes);
+    }
+
     private Result<CompiledExpression> resolveQualifiedFunctionCall(
             FunctionCall functionCall,
             Scope scope,
@@ -629,6 +791,15 @@ public class CapybaraExpressionCompiler {
                             + functionCall.arguments().size() + " argument(s)"
                     ),
                     functionCall.position()
+            );
+        }
+        if (hasPlaceholderArguments(functionCall.arguments())) {
+            return resolvePartialFunctionCall(
+                    functionCall,
+                    scope,
+                    expectedType,
+                    candidates,
+                    candidate -> resolvedModule.javaModuleName() + "." + functionCall.name()
             );
         }
 
@@ -779,6 +950,12 @@ public class CapybaraExpressionCompiler {
         }
         var candidates = functionsByNameAndArity(functionSignatures, functionCall.name(), functionCall.arguments().size());
         if (candidates.isEmpty()) {
+            if (hasPlaceholderArguments(functionCall.arguments())) {
+                return withPosition(
+                        Result.error("No function `" + functionCall.name() + "` with " + functionCall.arguments().size() + " argument(s) for partial binding"),
+                        functionCall.position()
+                );
+            }
             if (functionCall.arguments().isEmpty()) {
                 var singleton = findSingletonDataType(functionCall.name());
                 if (singleton.isPresent()) {
@@ -794,6 +971,9 @@ public class CapybaraExpressionCompiler {
                     .map((Expression expression) -> linkExpression(expression, scope))
                     .collect(new ResultCollectionCollector<>())
                     .map(args -> (CompiledExpression) new CompiledFunctionCall(functionCall.name(), args, ANY));
+        }
+        if (hasPlaceholderArguments(functionCall.arguments())) {
+            return resolvePartialFunctionCall(functionCall, scope, expectedType, candidates, this::resolvedFunctionName);
         }
 
         ResolvedFunctionCall best = null;
@@ -1500,6 +1680,15 @@ public class CapybaraExpressionCompiler {
                             Result.error("No method `" + methodName + "` with " + functionCall.arguments().size() + " argument(s)"),
                             functionCall.position()
                     ));
+        }
+        if (hasPlaceholderArguments(functionCall.arguments())) {
+            return resolvePartialFunctionCall(
+                    functionCall,
+                    scope,
+                    expectedType,
+                    candidates,
+                    FunctionSignature::name
+            );
         }
 
         ResolvedFunctionCall best = null;
@@ -2241,6 +2430,9 @@ public class CapybaraExpressionCompiler {
         if (!(function.type() instanceof CompiledFunctionType functionType)) {
             return withPosition(Result.error("Variable `" + function.name() + "` is not callable"), functionCall.position());
         }
+        if (hasPlaceholderArguments(functionCall.arguments())) {
+            return resolvePartialFunctionInvoke(functionCall.arguments(), scope, function, functionCall.position(), "Function variable `" + function.name() + "`");
+        }
         if (functionCall.arguments().isEmpty()) {
             if (functionType.argumentType().equals(NOTHING)) {
                 return Result.success(new CompiledFunctionInvoke(function, List.of(), functionType.returnType()));
@@ -2279,6 +2471,9 @@ public class CapybaraExpressionCompiler {
         if (!(function.type() instanceof CompiledFunctionType functionType)) {
             return withPosition(Result.error("Expression is not callable, was `" + function.type() + "`"), functionInvoke.position());
         }
+        if (hasPlaceholderArguments(functionInvoke.arguments())) {
+            return resolvePartialFunctionInvoke(functionInvoke.arguments(), scope, function, functionInvoke.position(), "Callable expression");
+        }
         if (functionInvoke.arguments().isEmpty()) {
             if (functionType.argumentType().equals(NOTHING)) {
                 return Result.success(new CompiledFunctionInvoke(function, List.of(), functionType.returnType()));
@@ -2307,6 +2502,55 @@ public class CapybaraExpressionCompiler {
         }
 
         return Result.success(new CompiledFunctionInvoke(function, List.copyOf(coercedArguments), currentType));
+    }
+
+    private Result<CompiledExpression> resolvePartialFunctionInvoke(
+            List<Expression> arguments,
+            Scope scope,
+            CompiledExpression function,
+            Optional<SourcePosition> position,
+            String errorSubject
+    ) {
+        var callArguments = new java.util.ArrayList<CompiledExpression>(arguments.size());
+        var placeholderNames = new java.util.ArrayList<String>();
+        var placeholderTypes = new java.util.ArrayList<CompiledType>();
+        var currentType = function.type();
+        var coercions = 0;
+        for (var argument : arguments) {
+            if (!(currentType instanceof CompiledFunctionType currentFunctionType)) {
+                return withPosition(
+                        Result.error(errorSubject + " called with too many arguments"),
+                        position
+                );
+            }
+            var expected = currentFunctionType.argumentType();
+            if (argument instanceof PlaceholderExpression) {
+                var name = "__capybaraPartial" + (placeholderNames.size() + 1);
+                placeholderNames.add(name);
+                placeholderTypes.add(expected);
+                callArguments.add(new CompiledVariable(name, expected));
+            } else {
+                var linked = linkArgumentForExpectedType(argument, scope, expected);
+                if (linked instanceof Result.Error<CoercedArgument> error) {
+                    return withPosition(new Result.Error<>(error.errors()), argument.position());
+                }
+                var coerced = ((Result.Success<CoercedArgument>) linked).value();
+                callArguments.add(coerced.expression());
+                coercions += coerced.coercions();
+            }
+            currentType = currentFunctionType.returnType();
+        }
+        var partial = new PartialArguments(
+                List.copyOf(callArguments),
+                List.copyOf(placeholderNames),
+                List.copyOf(placeholderTypes),
+                coercions
+        );
+        return Result.success(wrapPartialArguments(
+                partial,
+                new CompiledFunctionInvoke(function, partial.arguments(), currentType),
+                currentType
+        ));
     }
 
     private Result<CoercedArguments> linkArgumentsForExpectedTypes(
@@ -7717,6 +7961,13 @@ public class CapybaraExpressionCompiler {
             Scope scope,
             CompiledType type
     ) {
+        var directPlaceholder = directDataPlaceholder(newData);
+        if (directPlaceholder.isPresent()) {
+            return withPosition(
+                    Result.error("Placeholder `_` cannot be used in data construction."),
+                    directPlaceholder.orElseThrow().position()
+            );
+        }
         return linkSpreadAssignments(newData.spreads(), scope)
                 .flatMap(spreadAssignments ->
                         linkFieldAssignment(newData.assignments(), scope, type)
@@ -7754,6 +8005,28 @@ public class CapybaraExpressionCompiler {
                                         ));
                                     });
                                 })));
+    }
+
+    private Optional<PlaceholderExpression> directDataPlaceholder(NewData newData) {
+        var fieldPlaceholder = newData.assignments().stream()
+                .map(NewData.FieldAssignment::value)
+                .filter(PlaceholderExpression.class::isInstance)
+                .map(PlaceholderExpression.class::cast)
+                .findFirst();
+        if (fieldPlaceholder.isPresent()) {
+            return fieldPlaceholder;
+        }
+        var positionalPlaceholder = newData.positionalArguments().stream()
+                .filter(PlaceholderExpression.class::isInstance)
+                .map(PlaceholderExpression.class::cast)
+                .findFirst();
+        if (positionalPlaceholder.isPresent()) {
+            return positionalPlaceholder;
+        }
+        return newData.spreads().stream()
+                .filter(PlaceholderExpression.class::isInstance)
+                .map(PlaceholderExpression.class::cast)
+                .findFirst();
     }
 
     private Result<CompiledType> linkNewDataType(Type type, Scope scope) {
@@ -9567,11 +9840,28 @@ public class CapybaraExpressionCompiler {
     private record CoercedArguments(List<CompiledExpression> arguments, int coercions) {
     }
 
+    private record PartialArguments(
+            List<CompiledExpression> arguments,
+            List<String> placeholderNames,
+            List<CompiledType> placeholderTypes,
+            int coercions
+    ) {
+    }
+
     private record ResolvedFunctionCall(
             FunctionSignature signature,
             List<CompiledExpression> arguments,
             int coercions,
             CompiledType returnType
+    ) {
+    }
+
+    private record ResolvedPartialFunctionCall(
+            CompiledExpression expression,
+            FunctionSignature signature,
+            List<CompiledExpression> arguments,
+            int coercions,
+            CompiledFunctionType functionType
     ) {
     }
 

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -1124,6 +1124,7 @@ public class CapybaraParser {
                             .toList(),
                     tupleExpression.position()
             );
+            case PlaceholderExpression placeholderExpression -> placeholderExpression;
             default -> expression;
         };
     }
@@ -1348,6 +1349,9 @@ public class CapybaraParser {
 
         if (expression.functionCall() != null) {
             return functionCall(expression.functionCall());
+        }
+        if (expression.placeholder() != null) {
+            return new PlaceholderExpression(position(expression.placeholder()));
         }
         if (expression.new_list() != null) {
             return newListExpression(expression.new_list());
@@ -1638,6 +1642,9 @@ public class CapybaraParser {
         }
         if (expression.functionReference() != null) {
             return functionReference(expression.functionReference());
+        }
+        if (expression.placeholder() != null) {
+            return new PlaceholderExpression(position(expression.placeholder()));
         }
         if (expression.new_list() != null) {
             return newListExpression(expression.new_list());
@@ -2822,6 +2829,7 @@ public class CapybaraParser {
                     value.values().stream().map(argument -> shiftInterpolationPositions(argument, stringPosition, interpolationOffset)).toList(),
                     shiftPosition(value.position(), stringPosition, interpolationOffset)
             );
+            case PlaceholderExpression value -> new PlaceholderExpression(shiftPosition(value.position(), stringPosition, interpolationOffset));
             case Value value -> new Value(value.name(), shiftPosition(value.position(), stringPosition, interpolationOffset));
         };
     }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/Expression.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/Expression.java
@@ -2,6 +2,6 @@ package dev.capylang.compiler.parser;
 
 import java.util.Optional;
 
-public sealed interface Expression permits BooleanValue, ByteValue, ConstructorData, DoubleValue, FieldAccess, FloatValue, FunctionCall, FunctionInvoke, FunctionReference, IfExpression, IndexExpression, InfixExpression, IntValue, LambdaExpression, LetExpression, LongValue, MatchExpression, NewData, NewDictExpression, NewListExpression, NewSetExpression, NothingValue, ReduceExpression, SliceExpression, StringValue, TupleExpression, Value, WithExpression {
+public sealed interface Expression permits BooleanValue, ByteValue, ConstructorData, DoubleValue, FieldAccess, FloatValue, FunctionCall, FunctionInvoke, FunctionReference, IfExpression, IndexExpression, InfixExpression, IntValue, LambdaExpression, LetExpression, LongValue, MatchExpression, NewData, NewDictExpression, NewListExpression, NewSetExpression, NothingValue, PlaceholderExpression, ReduceExpression, SliceExpression, StringValue, TupleExpression, Value, WithExpression {
     Optional<SourcePosition> position();
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/PlaceholderExpression.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/PlaceholderExpression.java
@@ -1,0 +1,6 @@
+package dev.capylang.compiler.parser;
+
+import java.util.Optional;
+
+public record PlaceholderExpression(Optional<SourcePosition> position) implements Expression {
+}

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import dev.capylang.compiler.*;
+import dev.capylang.compiler.expression.CompiledLambdaExpression;
 import dev.capylang.compiler.parser.RawModule;
 import dev.capylang.generator.JavaGenerator;
 
@@ -156,6 +157,48 @@ class JavaExpressionEvaluatorTest {
         var error = (Result.Error<CompiledProgram>) programResult;
         assertThat(error.errors().stream().map(Result.Error.SingleError::message).collect(joining(",")))
                 .contains("dict keys must be of type `STRING`");
+    }
+
+    @Test
+    void shouldLowerPartialFunctionBindingToLambda() {
+        var program = compileProgram("""
+                fun add(a: int, b: int): int = a + b
+                fun add_10(): int => int = add(10, _)
+                """);
+
+        var expression = findFunction("add_10", program)
+                .map(CompiledFunction::expression)
+                .orElseThrow();
+
+        assertThat(expression).isInstanceOf(CompiledLambdaExpression.class);
+        var lambda = (CompiledLambdaExpression) expression;
+        assertThat(lambda.argumentName()).isEqualTo("__capybaraPartial1");
+        assertThat(lambda.functionType()).isEqualTo(new CompiledFunctionType(PrimitiveLinkedType.INT, PrimitiveLinkedType.INT));
+    }
+
+    @Test
+    void shouldLowerMultiplePartialFunctionBindingPlaceholdersInOrder() {
+        var program = compileProgram("""
+                fun foo(a: int, b: string, c: double, d: int): string = b
+                fun bind_b(b: string): (int, double, int) => string = foo(_, b, _, _)
+                """);
+
+        var expression = findFunction("bind_b", program)
+                .map(CompiledFunction::expression)
+                .orElseThrow();
+
+        assertThat(expression).isInstanceOf(CompiledLambdaExpression.class);
+        var first = (CompiledLambdaExpression) expression;
+        assertThat(first.argumentName()).isEqualTo("__capybaraPartial1");
+        assertThat(first.functionType().argumentType()).isEqualTo(PrimitiveLinkedType.INT);
+        assertThat(first.expression()).isInstanceOf(CompiledLambdaExpression.class);
+        var second = (CompiledLambdaExpression) first.expression();
+        assertThat(second.argumentName()).isEqualTo("__capybaraPartial2");
+        assertThat(second.functionType().argumentType()).isEqualTo(PrimitiveLinkedType.DOUBLE);
+        assertThat(second.expression()).isInstanceOf(CompiledLambdaExpression.class);
+        var third = (CompiledLambdaExpression) second.expression();
+        assertThat(third.argumentName()).isEqualTo("__capybaraPartial3");
+        assertThat(third.functionType().argumentType()).isEqualTo(PrimitiveLinkedType.INT);
     }
 
     @Test

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -143,6 +143,49 @@ class CapybaraParserTest {
     }
 
     @Test
+    @DisplayName("should parse placeholder arguments in function calls")
+    void parsePlaceholderArgumentsInFunctionCalls() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun add(a: int, b: int): int = a + b
+                fun test(): int => int = add(1, _)
+                """));
+
+        var function = findFunction("test", module.functional());
+        assertThat(function.expression()).isInstanceOf(FunctionCall.class);
+        var call = (FunctionCall) function.expression();
+        assertThat(call.arguments()).hasSize(2);
+        assertThat(call.arguments().get(1)).isInstanceOf(PlaceholderExpression.class);
+    }
+
+    @Test
+    @DisplayName("should parse multiple placeholder arguments in order")
+    void parseMultiplePlaceholderArgumentsInOrder() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun foo(a: int, b: string, c: double, d: int): string = b
+                fun test(b: string): (int, double, int) => string = foo(_, b, _, _)
+                """));
+
+        var function = findFunction("test", module.functional());
+        assertThat(function.expression()).isInstanceOf(FunctionCall.class);
+        var call = (FunctionCall) function.expression();
+        assertThat(call.arguments()).hasSize(4);
+        assertThat(call.arguments().get(0)).isInstanceOf(PlaceholderExpression.class);
+        assertThat(call.arguments().get(2)).isInstanceOf(PlaceholderExpression.class);
+        assertThat(call.arguments().get(3)).isInstanceOf(PlaceholderExpression.class);
+    }
+
+    @Test
+    @DisplayName("should parse standalone placeholder for compiler diagnostics")
+    void parseStandalonePlaceholderForCompilerDiagnostics() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun test(): int => int = _
+                """));
+
+        var function = findFunction("test", module.functional());
+        assertThat(function.expression()).isInstanceOf(PlaceholderExpression.class);
+    }
+
+    @Test
     @DisplayName("should parse data extension from multiple parent data declarations")
     void parseDataExtensionFromMultipleParents() {
         var module = parseSuccess(new RawModule("Test", "/parser", """


### PR DESCRIPTION
## What changed
- Added `_` placeholder parsing as a first-class expression for diagnostics.
- Lowered function, method, and callable invocations with placeholder arguments into nested lambdas with left-to-right generated parameters.
- Added parser, compiler lowering, generated-Java e2e, and invalid placeholder diagnostics coverage.

## Why
Issue #111 requests partial function binding syntax such as `add(10, _)` and `foo(_, b, _, _)`.

## Impacted modules
- `compiler`: grammar, parser AST, expression linker/lowering, diagnostics.
- `capy`: functional e2e examples and compilation-error tests.

## Validation
- `./gradlew :compiler:test`
- `./gradlew :capy:e2e-cfun`
- `./gradlew clean check`

## Performance
- Baseline fresh-branch `./gradlew clean check`: `221.38s`
- Final PR `./gradlew clean check`: `208.04s`
- Result: no clean-check performance regression observed.

## Sample
```cfun
fun add(a: int, b: int): int = a + b
fun add_10(): int => int = add(10, _)
```