### PR TITLE
feat(#108): support enum type matching

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchByType.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchByType.cfun
@@ -20,6 +20,7 @@ fun match_int_ignore_binding(value: any): int =
 
 data Person { name: string }
 type Entity = Person
+enum MatchStatus { READY, DONE }
 
 fun is_data(value: any): bool =
     match value with
@@ -30,6 +31,18 @@ fun is_data_from_entity(value: Entity): bool =
     match value with
     case data d -> true
     case _ -> false
+
+fun classify_enum(value: any): string =
+    match value with
+    case enum e -> e.name()
+    case data d -> "data"
+    case _ -> "any"
+
+fun generic_enum_name(value: enum): string = value.name()
+
+fun exhaustive_enum_type_match(value: enum): string =
+    match value with
+    case enum e -> e.name()
 
 fun classify_json_char(first_char: string): string =
     match first_char with

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchByType.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchByType.cfun
@@ -44,6 +44,13 @@ fun exhaustive_enum_type_match(value: enum): string =
     match value with
     case enum e -> e.name()
 
+fun merged_enum_name(flag: bool, current_enum: enum): string =
+    let v = if flag then current_enum else READY {}
+    v.name()
+
+fun merged_enum_list_names(current_enum: enum): list[string] =
+    [current_enum, READY {}] | value => value.name()
+
 fun classify_json_char(first_char: string): string =
     match first_char with
     case '{' -> "object"

--- a/capy/src/e2e-cfun/java/dev/capylang/test/MatchByTypeTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/MatchByTypeTest.java
@@ -58,6 +58,13 @@ class MatchByTypeTest {
     }
 
     @Test
+    void mergedEnumValuesPreserveEnumType() {
+        assertThat(MatchByType.mergedEnumName(true, MatchByType.MatchStatus.DONE)).isEqualTo("DONE");
+        assertThat(MatchByType.mergedEnumName(false, MatchByType.MatchStatus.DONE)).isEqualTo("READY");
+        assertThat(MatchByType.mergedEnumListNames(MatchByType.MatchStatus.DONE)).isEqualTo(List.of("DONE", "READY"));
+    }
+
+    @Test
     void matchCaseCanUseMultiplePatterns() {
         assertThat(MatchByType.classifyJsonChar("{")).isEqualTo("object");
         assertThat(MatchByType.classifyJsonChar("\"")).isEqualTo("string");

--- a/capy/src/e2e-cfun/java/dev/capylang/test/MatchByTypeTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/MatchByTypeTest.java
@@ -41,6 +41,20 @@ class MatchByTypeTest {
 
         assertThat(MatchByType.isData(new MatchByType.Person("Tom"))).isTrue();
         assertThat(MatchByType.isDataFromEntity(new MatchByType.Person("Jerry"))).isTrue();
+        assertThat(MatchByType.isData(MatchByType.MatchStatus.READY)).isTrue();
+    }
+
+    @Test
+    void enumTypeMatchesOnlyEnums() {
+        assertThat(MatchByType.classifyEnum(MatchByType.MatchStatus.READY)).isEqualTo("READY");
+        assertThat(MatchByType.classifyEnum(new MatchByType.Person("Tom"))).isEqualTo("data");
+        assertThat(MatchByType.classifyEnum("x")).isEqualTo("any");
+    }
+
+    @Test
+    void enumValuesExposeGenericNameMethod() {
+        assertThat(MatchByType.genericEnumName(MatchByType.MatchStatus.DONE)).isEqualTo("DONE");
+        assertThat(MatchByType.exhaustiveEnumTypeMatch(MatchByType.MatchStatus.READY)).isEqualTo("READY");
     }
 
     @Test

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -136,6 +136,21 @@ public class CompilationErrorTest {
     }
 
     @Test
+    void shouldRejectEnumTypePatternForNonEnumStaticType() {
+        var errors = compileProgram("""
+                        fun classify(value: int): string =
+                            match value with
+                            case enum e -> e.name()
+                            case _ -> "other"
+                        """,
+                "enum_type_pattern_for_non_enum_static_type");
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.first().message())
+                .contains("Cannot match `INT` with typed pattern `ENUM`");
+    }
+
+    @Test
     void shouldRejectConstructorStarOutsideConstructor() {
         var errors = compileProgram("""
                         fun parse(): int =

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -76,7 +76,7 @@ BOOL_LITERAL: 'true' | 'false';
 COLLECTION: 'list' | 'set' | 'dict';
 REC: 'rec';
 NAME : [_]* [a-z] [a-zA-Z0-9_]*;
-identifier: NAME | REC | COLLECTION | 'derive' | 'deriver' | 'fun' | 'type' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'string' | 'float' | 'nothing' | 'any';
+identifier: NAME | REC | COLLECTION | 'derive' | 'deriver' | 'fun' | 'type' | 'enum' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'string' | 'float' | 'nothing' | 'any';
 parameters: parameter (',' parameter)*;
 parameter: identifier ':' type;
 functionType: ':' type;
@@ -94,6 +94,7 @@ type: COLLECTION typeLbrack type RBRACK
     | 'float'
     | 'any'
     | 'data'
+    | 'enum'
     | 'nothing'
     | qualifiedType (typeLbrack type (',' type)* RBRACK)?;
 qualifiedType: TYPE (DOT TYPE)*;
@@ -235,6 +236,7 @@ patternType: COLLECTION (typeLbrack type RBRACK)?
            | 'float'
            | 'any'
            | 'data'
+           | 'enum'
            | 'nothing'
            | qualifiedType (typeLbrack type (',' type)* RBRACK)?;
 constructorPattern: TYPE '{' fieldPatternList? '}';

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -4146,7 +4146,10 @@ public class CapybaraCompiler {
             return true;
         }
         if (expected == PrimitiveLinkedType.DATA) {
-            return actual instanceof GenericDataType || actual == PrimitiveLinkedType.DATA;
+            return actual instanceof GenericDataType || actual == PrimitiveLinkedType.DATA || actual == PrimitiveLinkedType.ENUM;
+        }
+        if (expected == PrimitiveLinkedType.ENUM) {
+            return isEnumLikeType(actual, dataTypes);
         }
         if (expected instanceof PrimitiveLinkedType expectedPrimitive
             && actual instanceof PrimitiveLinkedType actualPrimitive) {
@@ -4284,6 +4287,24 @@ public class CapybaraCompiler {
                 .collect(java.util.stream.Collectors.joining(", ")) + "]";
     }
 
+    private boolean isEnumLikeType(CompiledType type, Map<String, GenericDataType> dataTypes) {
+        if (type == PrimitiveLinkedType.ENUM) {
+            return true;
+        }
+        if (type instanceof CompiledDataParentType parentType) {
+            return parentType.enumType();
+        }
+        if (!(type instanceof CompiledDataType dataType)) {
+            return false;
+        }
+        return dataTypes.values().stream()
+                .filter(CompiledDataParentType.class::isInstance)
+                .map(CompiledDataParentType.class::cast)
+                .filter(CompiledDataParentType::enumType)
+                .flatMap(parentType -> parentType.subTypes().stream())
+                .anyMatch(subType -> sameTypeName(subType.name(), dataType.name()));
+    }
+
     private boolean isAssignablePrimitiveReturnType(PrimitiveLinkedType expected, PrimitiveLinkedType actual) {
         if (expected == actual) {
             return true;
@@ -4294,7 +4315,8 @@ public class CapybaraCompiler {
         if (expected == PrimitiveLinkedType.ANY) {
             return true;
         }
-        if (expected == PrimitiveLinkedType.DATA || actual == PrimitiveLinkedType.DATA) {
+        if (expected == PrimitiveLinkedType.DATA || actual == PrimitiveLinkedType.DATA
+            || expected == PrimitiveLinkedType.ENUM || actual == PrimitiveLinkedType.ENUM) {
             return false;
         }
         if (expected == PrimitiveLinkedType.BOOL || actual == PrimitiveLinkedType.BOOL) {
@@ -4923,6 +4945,7 @@ public class CapybaraCompiler {
             case NOTHING -> PrimitiveLinkedType.NOTHING;
             case ANY -> PrimitiveLinkedType.ANY;
             case DATA -> PrimitiveLinkedType.DATA;
+            case ENUM -> PrimitiveLinkedType.ENUM;
         };
     }
 
@@ -5309,6 +5332,7 @@ public class CapybaraCompiler {
                 case ANY -> PrimitiveType.ANY;
                 case NOTHING -> PrimitiveType.NOTHING;
                 case DATA -> PrimitiveType.DATA;
+                case ENUM -> PrimitiveType.ENUM;
             };
             case CollectionLinkedType.CompiledList compiledList ->
                     new CollectionType.ListType(compiledTypeToParserType(compiledList.elementType()));
@@ -5365,6 +5389,7 @@ public class CapybaraCompiler {
                 case FLOAT -> PrimitiveLinkedType.FLOAT;
                 case ANY -> PrimitiveLinkedType.ANY;
                 case DATA -> PrimitiveLinkedType.DATA;
+                case ENUM -> PrimitiveLinkedType.ENUM;
                 case NOTHING -> PrimitiveLinkedType.NOTHING;
             });
             case CollectionType.ListType listType ->

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -894,7 +894,8 @@ public class CapybaraCompiler {
                     linkedDataType.extendedTypes(),
                     linkedDataType.comments(),
                     linkedDataType.visibility(),
-                    linkedDataType.singleton()
+                    linkedDataType.singleton(),
+                    linkedDataType.enumValue()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
@@ -1178,7 +1179,8 @@ public class CapybaraCompiler {
                     linkedDataType.extendedTypes(),
                     linkedDataType.comments(),
                     linkedDataType.visibility(),
-                    linkedDataType.singleton()
+                    linkedDataType.singleton(),
+                    linkedDataType.enumValue()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     requestedName,
@@ -5488,7 +5490,10 @@ public class CapybaraCompiler {
                             dataType.fields(),
                             mappedTypeArguments,
                             dataType.extendedTypes(),
-                            dataType.singleton()
+                            dataType.comments(),
+                            dataType.visibility(),
+                            dataType.singleton(),
+                            dataType.enumValue()
                     );
                 }
                 var substitutions = new LinkedHashMap<String, CompiledType>();
@@ -5504,7 +5509,10 @@ public class CapybaraCompiler {
                         substitutedFields,
                         mappedTypeArguments,
                         dataType.extendedTypes(),
-                        dataType.singleton()
+                        dataType.comments(),
+                        dataType.visibility(),
+                        dataType.singleton(),
+                        dataType.enumValue()
                 );
             }
             default -> linkedType;
@@ -6070,7 +6078,7 @@ public class CapybaraCompiler {
 
     private CompiledDataParentType linkEnumDeclaration(EnumDeclaration enumDeclaration) {
         var values = enumDeclaration.values().stream()
-                .map(value -> new CompiledDataType(value, List.of(), List.of(), List.of(), true))
+                .map(value -> new CompiledDataType(value, List.of(), List.of(), List.of(), List.of(), null, true, true))
                 .toList();
         return new CompiledDataParentType(
                 enumDeclaration.name(),
@@ -6190,7 +6198,8 @@ public class CapybaraCompiler {
                     dataType.extendedTypes(),
                     dataType.comments(),
                     dataType.visibility(),
-                    dataType.singleton()
+                    dataType.singleton(),
+                    dataType.enumValue()
             );
             default -> placeholder;
         };
@@ -6406,7 +6415,8 @@ public class CapybaraCompiler {
                 childType.extendedTypes(),
                 childType.comments(),
                 childType.visibility(),
-                childType.singleton()
+                childType.singleton(),
+                childType.enumValue()
         ));
     }
 

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraTypeCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraTypeCompiler.java
@@ -240,7 +240,8 @@ public class CapybaraTypeCompiler {
                             dataType.extendedTypes(),
                             dataType.comments(),
                             dataType.visibility(),
-                            dataType.singleton()
+                            dataType.singleton(),
+                            dataType.enumValue()
                     );
                 }
                 var substitutions = substitutionsFor(dataType.typeParameters(), typeArguments);
@@ -258,7 +259,8 @@ public class CapybaraTypeCompiler {
                                 .toList(),
                         dataType.comments(),
                         dataType.visibility(),
-                        dataType.singleton()
+                        dataType.singleton(),
+                        dataType.enumValue()
                 );
             }
             default -> linkedType;
@@ -328,7 +330,8 @@ public class CapybaraTypeCompiler {
                             .toList(),
                     linkedDataType.comments(),
                     linkedDataType.visibility(),
-                    linkedDataType.singleton()
+                    linkedDataType.singleton(),
+                    linkedDataType.enumValue()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
@@ -522,7 +525,8 @@ public class CapybaraTypeCompiler {
                     linkedDataType.extendedTypes(),
                     linkedDataType.comments(),
                     linkedDataType.visibility(),
-                    linkedDataType.singleton()
+                    linkedDataType.singleton(),
+                    linkedDataType.enumValue()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     requestedName,
@@ -578,7 +582,6 @@ public class CapybaraTypeCompiler {
                 .map(CompiledTupleType::new);
     }
 }
-
 
 
 

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraTypeCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraTypeCompiler.java
@@ -550,6 +550,7 @@ public class CapybaraTypeCompiler {
             case FLOAT -> PrimitiveLinkedType.FLOAT;
             case ANY -> PrimitiveLinkedType.ANY;
             case DATA -> PrimitiveLinkedType.DATA;
+            case ENUM -> PrimitiveLinkedType.ENUM;
             case NOTHING -> PrimitiveLinkedType.NOTHING;
         };
     }
@@ -577,7 +578,6 @@ public class CapybaraTypeCompiler {
                 .map(CompiledTupleType::new);
     }
 }
-
 
 
 

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledDataType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledDataType.java
@@ -8,14 +8,25 @@ public record CompiledDataType(String name,
                              List<String> extendedTypes,
                              List<String> comments,
                              Visibility visibility,
-                             boolean singleton) implements GenericDataType, Comparable<CompiledDataType> {
+                             boolean singleton,
+                             boolean enumValue) implements GenericDataType, Comparable<CompiledDataType> {
+    public CompiledDataType(String name,
+                            List<CompiledField> fields,
+                            List<String> typeParameters,
+                            List<String> extendedTypes,
+                            List<String> comments,
+                            Visibility visibility,
+                            boolean singleton) {
+        this(name, fields, typeParameters, extendedTypes, comments, visibility, singleton, false);
+    }
+
     public CompiledDataType(String name,
                             List<CompiledField> fields,
                             List<String> typeParameters,
                             List<String> extendedTypes,
                             List<String> comments,
                             boolean singleton) {
-        this(name, fields, typeParameters, extendedTypes, comments, null, singleton);
+        this(name, fields, typeParameters, extendedTypes, comments, null, singleton, false);
     }
 
     public CompiledDataType(String name,
@@ -23,7 +34,7 @@ public record CompiledDataType(String name,
                             List<String> typeParameters,
                             List<String> extendedTypes,
                             boolean singleton) {
-        this(name, fields, typeParameters, extendedTypes, List.of(), null, singleton);
+        this(name, fields, typeParameters, extendedTypes, List.of(), null, singleton, false);
     }
 
     @Override

--- a/compiler/src/main/java/dev/capylang/compiler/PrimitiveLinkedType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/PrimitiveLinkedType.java
@@ -22,7 +22,11 @@ public enum PrimitiveLinkedType implements CompiledType {
     /**
      * Super type for all user-defined data/type declarations.
      */
-    DATA;
+    DATA,
+    /**
+     * Super type for all enum declarations and enum values.
+     */
+    ENUM;
 
     public static Optional<PrimitiveLinkedType> find(String name) {
         return Arrays.stream(values()).filter(x -> x.name().equals(name)).findAny();

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -1307,7 +1307,8 @@ public class CapybaraExpressionCompiler {
                 dataType.extendedTypes(),
                 dataType.comments(),
                 dataType.visibility(),
-                dataType.singleton()
+                dataType.singleton(),
+                dataType.enumValue()
         );
     }
 
@@ -1576,7 +1577,8 @@ public class CapybaraExpressionCompiler {
         if (type instanceof CompiledDataParentType parentType) {
             return parentType.enumType();
         }
-        return type instanceof CompiledDataType dataType && findEnumParentForValue(dataType.name()) != null;
+        return type instanceof CompiledDataType dataType
+               && (dataType.enumValue() || findEnumParentForValue(dataType.name()) != null);
     }
 
     private CompiledDataParentType findEnumTypeByName(String enumName) {
@@ -2950,7 +2952,8 @@ public class CapybaraExpressionCompiler {
                 dataType.extendedTypes(),
                 dataType.comments(),
                 dataType.visibility(),
-                dataType.singleton()
+                dataType.singleton(),
+                dataType.enumValue()
         )));
     }
 
@@ -3587,7 +3590,8 @@ public class CapybaraExpressionCompiler {
                 expectedSubtype.extendedTypes(),
                 expectedSubtype.comments(),
                 expectedSubtype.visibility(),
-                expectedSubtype.singleton()
+                expectedSubtype.singleton(),
+                expectedSubtype.enumValue()
         );
     }
 
@@ -5207,7 +5211,8 @@ public class CapybaraExpressionCompiler {
                     dataType.extendedTypes(),
                     dataType.comments(),
                     dataType.visibility(),
-                    dataType.singleton()
+                    dataType.singleton(),
+                    dataType.enumValue()
             );
         }
         var substitutions = typeParameterSubstitutions(rawDataType.typeParameters(), typeParameters);
@@ -5222,7 +5227,8 @@ public class CapybaraExpressionCompiler {
                 substituted.extendedTypes(),
                 dataType.comments(),
                 dataType.visibility(),
-                substituted.singleton()
+                substituted.singleton(),
+                substituted.enumValue()
         );
     }
 
@@ -7300,7 +7306,10 @@ public class CapybaraExpressionCompiler {
                     linkedDataType.extendedTypes().stream()
                             .map(typeDescriptor -> substituteTypeDescriptor(typeDescriptor, substitutions))
                             .toList(),
-                    linkedDataType.singleton()
+                    linkedDataType.comments(),
+                    linkedDataType.visibility(),
+                    linkedDataType.singleton(),
+                    linkedDataType.enumValue()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
@@ -7436,7 +7445,10 @@ public class CapybaraExpressionCompiler {
                                 dataType.fields(),
                                 typeArgumentDescriptors,
                                 dataType.extendedTypes(),
-                                dataType.singleton()
+                                dataType.comments(),
+                                dataType.visibility(),
+                                dataType.singleton(),
+                                dataType.enumValue()
                         );
                     }
                     var substitutions = new java.util.LinkedHashMap<String, CompiledType>();
@@ -7455,7 +7467,10 @@ public class CapybaraExpressionCompiler {
                             substitutedFields,
                             typeArgumentDescriptors,
                             dataType.extendedTypes(),
-                            dataType.singleton()
+                            dataType.comments(),
+                            dataType.visibility(),
+                            dataType.singleton(),
+                            dataType.enumValue()
                     );
                 }
             });
@@ -8134,7 +8149,8 @@ public class CapybaraExpressionCompiler {
                 singleton.type().extendedTypes(),
                 singleton.type().comments(),
                 singleton.type().visibility(),
-                singleton.type().singleton()
+                singleton.type().singleton(),
+                singleton.type().enumValue()
         );
     }
 
@@ -9812,7 +9828,10 @@ public class CapybaraExpressionCompiler {
                             .toList(),
                     linkedDataType.typeParameters(),
                     linkedDataType.extendedTypes(),
-                    linkedDataType.singleton()
+                    linkedDataType.comments(),
+                    linkedDataType.visibility(),
+                    linkedDataType.singleton(),
+                    linkedDataType.enumValue()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -446,6 +446,14 @@ public class CapybaraExpressionCompiler {
         }
         return linkExpression(fieldAccess.source(), scope)
                 .flatMap(source -> {
+                    if (source.type() == PrimitiveLinkedType.ENUM) {
+                        if ("order".equals(fieldAccess.field())) {
+                            return Result.success(new CompiledFieldAccess(source, "ordinal", PrimitiveLinkedType.INT));
+                        }
+                        if ("name".equals(fieldAccess.field())) {
+                            return Result.success(new CompiledFieldAccess(source, "name", PrimitiveLinkedType.STRING));
+                        }
+                    }
                     if (source.type() instanceof CompiledDataParentType linkedDataParentType && linkedDataParentType.enumType()) {
                         if ("order".equals(fieldAccess.field())) {
                             return Result.success(new CompiledFieldAccess(source, "ordinal", PrimitiveLinkedType.INT));
@@ -1561,6 +1569,16 @@ public class CapybaraExpressionCompiler {
                 .orElse(null);
     }
 
+    private boolean isEnumLikeType(CompiledType type) {
+        if (type == PrimitiveLinkedType.ENUM) {
+            return true;
+        }
+        if (type instanceof CompiledDataParentType parentType) {
+            return parentType.enumType();
+        }
+        return type instanceof CompiledDataType dataType && findEnumParentForValue(dataType.name()) != null;
+    }
+
     private CompiledDataParentType findEnumTypeByName(String enumName) {
         var normalizedLookup = enumName.replace('/', '.');
         return dataTypes.values().stream()
@@ -2018,6 +2036,10 @@ public class CapybaraExpressionCompiler {
         if (pipeAlias.isPresent()) {
             return pipeAlias;
         }
+        var enumNameMethod = resolveBuiltinEnumNameMethodInvoke(functionCall, scope, methodName);
+        if (enumNameMethod.isPresent()) {
+            return enumNameMethod;
+        }
         var supportsBoolTwoStrings = "contains".equals(methodName)
                 || "starts_with".equals(methodName)
                 || "end_with".equals(methodName);
@@ -2166,6 +2188,28 @@ public class CapybaraExpressionCompiler {
         return Optional.of(Result.success(new CompiledFunctionCall(
                 METHOD_DECL_PREFIX + "String__trim",
                 args,
+                STRING
+        )));
+    }
+
+    private Optional<Result<CompiledExpression>> resolveBuiltinEnumNameMethodInvoke(
+            FunctionCall functionCall,
+            Scope scope,
+            String methodName
+    ) {
+        if (!"name".equals(methodName) || functionCall.arguments().size() != 1) {
+            return Optional.empty();
+        }
+        var linkedArgument = linkExpression(functionCall.arguments().getFirst(), scope);
+        if (linkedArgument instanceof Result.Error<CompiledExpression> error) {
+            return Optional.of(new Result.Error<>(error.errors()));
+        }
+        if (!(linkedArgument instanceof Result.Success<CompiledExpression> value) || !isEnumLikeType(value.value().type())) {
+            return Optional.empty();
+        }
+        return Optional.of(Result.success(new CompiledFunctionCall(
+                METHOD_DECL_PREFIX + "Enum__name",
+                List.of(value.value()),
                 STRING
         )));
     }
@@ -3357,7 +3401,10 @@ public class CapybaraExpressionCompiler {
             return new CoercedArgument(argument, 0);
         }
         if (expected == PrimitiveLinkedType.DATA
-            && argument.type() instanceof GenericDataType) {
+            && (argument.type() instanceof GenericDataType || argument.type() == PrimitiveLinkedType.ENUM)) {
+            return new CoercedArgument(argument, 1);
+        }
+        if (expected == PrimitiveLinkedType.ENUM && isEnumLikeType(argument.type())) {
             return new CoercedArgument(argument, 1);
         }
         if (expected instanceof CompiledDataParentType expectedParent
@@ -3642,6 +3689,12 @@ public class CapybaraExpressionCompiler {
         if (expected == ANY || actual == ANY || actual == NOTHING) {
             return true;
         }
+        if (expected == DATA && actual == ENUM) {
+            return true;
+        }
+        if (expected == ENUM) {
+            return isEnumLikeType(actual);
+        }
         if (expected instanceof CompiledGenericTypeParameter || actual instanceof CompiledGenericTypeParameter) {
             return true;
         }
@@ -3750,6 +3803,7 @@ public class CapybaraExpressionCompiler {
             case NOTHING -> NOTHING;
             case ANY -> ANY;
             case DATA -> DATA;
+            case ENUM -> ENUM;
         };
     }
 
@@ -4409,7 +4463,7 @@ public class CapybaraExpressionCompiler {
 
     private boolean isBroadSpecificityType(CompiledType type) {
         return switch (type) {
-            case PrimitiveLinkedType primitive -> primitive == ANY || primitive == DATA;
+            case PrimitiveLinkedType primitive -> primitive == ANY || primitive == DATA || primitive == ENUM;
             case CompiledGenericTypeParameter ignored -> true;
             case CompiledDataType ignored -> false;
             case CompiledDataParentType ignored -> false;
@@ -5890,12 +5944,14 @@ public class CapybaraExpressionCompiler {
                    || right == STRING
                    || right == BOOL
                    || right == PrimitiveLinkedType.DATA
+                   || right == PrimitiveLinkedType.ENUM
                    || right == PrimitiveLinkedType.ANY ? STRING : null;
         }
         if (right == STRING) {
             return isNumericPrimitive(left)
                    || left == BOOL
                    || left == PrimitiveLinkedType.DATA
+                   || left == PrimitiveLinkedType.ENUM
                    || left == PrimitiveLinkedType.ANY ? STRING : null;
         }
         if (left == BOOL || right == BOOL) {
@@ -5908,7 +5964,7 @@ public class CapybaraExpressionCompiler {
     }
 
     private static boolean isDataLikeType(CompiledType type) {
-        return type == PrimitiveLinkedType.DATA || type instanceof GenericDataType;
+        return type == PrimitiveLinkedType.DATA || type == PrimitiveLinkedType.ENUM || type instanceof GenericDataType;
     }
 
     private static CompiledType findMathPrimitiveType(PrimitiveLinkedType left, PrimitiveLinkedType right) {
@@ -6590,6 +6646,9 @@ public class CapybaraExpressionCompiler {
     }
 
     private boolean typedPatternCoversStaticMatchType(CompiledType matchType, CompiledType patternType) {
+        if (patternType == ENUM && isEnumLikeType(matchType)) {
+            return true;
+        }
         if (matchType instanceof CompiledList matchList && patternType instanceof CompiledList patternList) {
             return patternArgumentCoversStaticType(matchList.elementType(), patternList.elementType());
         }
@@ -6958,7 +7017,16 @@ public class CapybaraExpressionCompiler {
         if (patternType == PrimitiveLinkedType.DATA && matchType instanceof GenericDataType) {
             return true;
         }
+        if (patternType == PrimitiveLinkedType.DATA && matchType == PrimitiveLinkedType.ENUM) {
+            return true;
+        }
         if (matchType == PrimitiveLinkedType.DATA && patternType instanceof GenericDataType) {
+            return true;
+        }
+        if (patternType == PrimitiveLinkedType.ENUM && (matchType == PrimitiveLinkedType.DATA || isEnumLikeType(matchType))) {
+            return true;
+        }
+        if (matchType == PrimitiveLinkedType.ENUM && isEnumLikeType(patternType)) {
             return true;
         }
         if (matchType.equals(patternType)) {

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraTypeFinder.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraTypeFinder.java
@@ -5,6 +5,7 @@ import dev.capylang.compiler.PrimitiveLinkedType;
 
 import static dev.capylang.compiler.PrimitiveLinkedType.ANY;
 import static dev.capylang.compiler.PrimitiveLinkedType.DATA;
+import static dev.capylang.compiler.PrimitiveLinkedType.ENUM;
 import static dev.capylang.compiler.PrimitiveLinkedType.NOTHING;
 
 public class CapybaraTypeFinder {
@@ -85,7 +86,10 @@ public class CapybaraTypeFinder {
             return ANY;
         }
         if (left == DATA || right == DATA) {
-            return left == DATA && right == DATA ? DATA : ANY;
+            return ((left == DATA && right == DATA) || left == ENUM || right == ENUM) ? DATA : ANY;
+        }
+        if (left == ENUM || right == ENUM) {
+            return left == ENUM && right == ENUM ? ENUM : ANY;
         }
         if (left.ordinal() < right.ordinal()) {
             return right;

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraTypeFinder.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraTypeFinder.java
@@ -1,5 +1,7 @@
 package dev.capylang.compiler.expression;
 
+import dev.capylang.compiler.CompiledDataParentType;
+import dev.capylang.compiler.CompiledDataType;
 import dev.capylang.compiler.CompiledType;
 import dev.capylang.compiler.PrimitiveLinkedType;
 
@@ -14,6 +16,8 @@ public class CapybaraTypeFinder {
         if (left == NOTHING) return right;
         if (right == NOTHING) return left;
         if (left == ANY || right == ANY) return ANY;
+        if (left == ENUM && isEnumLikeType(right)) return ENUM;
+        if (right == ENUM && isEnumLikeType(left)) return ENUM;
         if (left == DATA && !(right instanceof PrimitiveLinkedType)) return DATA;
         if (right == DATA && !(left instanceof PrimitiveLinkedType)) return DATA;
 
@@ -35,6 +39,16 @@ public class CapybaraTypeFinder {
         // for now returning ANY
         // todo: get data types and find common types there
         return ANY;
+    }
+
+    private static boolean isEnumLikeType(CompiledType type) {
+        if (type == ENUM) {
+            return true;
+        }
+        if (type instanceof CompiledDataParentType parentType) {
+            return parentType.enumType();
+        }
+        return type instanceof CompiledDataType dataType && dataType.enumValue();
     }
 
     /// `int`:

--- a/compiler/src/main/java/dev/capylang/compiler/parser/PrimitiveType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/PrimitiveType.java
@@ -13,6 +13,7 @@ public enum PrimitiveType implements Type {
     FLOAT("float"),
     ANY("any"),
     DATA("data"),
+    ENUM("enum"),
     NOTHING("nothing");
 
     private final String name;
@@ -25,4 +26,3 @@ public enum PrimitiveType implements Type {
         return Arrays.stream(values()).filter(x -> x.name.equals(name)).findAny();
     }
 }
-

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -739,6 +739,7 @@ public class JavaAstBuilder {
             case NOTHING -> new JavaType("java.lang.Object");
             case ANY -> new JavaType("java.lang.Object");
             case DATA -> new JavaType("java.lang.Object");
+            case ENUM -> new JavaType("java.lang.Enum<?>");
         };
     }
 
@@ -763,6 +764,7 @@ public class JavaAstBuilder {
                 case NOTHING -> "java.lang.Object";
                 case ANY -> "java.lang.Object";
                 case DATA -> "java.lang.Object";
+                case ENUM -> "java.lang.Enum<?>";
             };
             case GenericDataType genericDataType -> buildGenericDataType(genericDataType).toString();
             case CollectionLinkedType collectionLinkedType -> buildCollectionLinkedType(collectionLinkedType).toString();

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -1745,6 +1745,7 @@ public class JavaExpressionEvaluator {
                 case STRING -> "java.lang.String";
                 case BOOL -> "java.lang.Boolean";
                 case FLOAT -> "java.lang.Float";
+                case ENUM -> "java.lang.Enum<?>";
                 case NOTHING, ANY, DATA -> "java.lang.Object";
             };
             case dev.capylang.compiler.CollectionLinkedType.CompiledList linkedList ->
@@ -1785,6 +1786,7 @@ public class JavaExpressionEvaluator {
                 case STRING -> "java.lang.String";
                 case BOOL -> "boolean";
                 case FLOAT -> "float";
+                case ENUM -> "java.lang.Enum<?>";
                 case NOTHING, ANY, DATA -> "java.lang.Object";
             };
             default -> javaCastType(type);
@@ -1800,7 +1802,7 @@ public class JavaExpressionEvaluator {
                 case DOUBLE -> "((double) " + expression + ")";
                 case BOOL -> "((boolean) " + expression + ")";
                 case FLOAT -> "((float) " + expression + ")";
-                case STRING, NOTHING, ANY, DATA -> expression;
+                case STRING, NOTHING, ANY, DATA, ENUM -> expression;
             };
         }
         return expression;
@@ -2239,6 +2241,7 @@ public class JavaExpressionEvaluator {
             case "double" -> "java.lang.Double";
             case "string" -> "java.lang.String";
             case "bool" -> "java.lang.Boolean";
+            case "enum" -> "java.lang.Enum<?>";
             case "any", "nothing", "data" -> "java.lang.Object";
             default -> {
                 if (normalized.matches("[A-Z]")) {
@@ -2383,6 +2386,7 @@ public class JavaExpressionEvaluator {
         if (optionMatch
             || selectorType == dev.capylang.compiler.PrimitiveLinkedType.ANY
             || selectorType == dev.capylang.compiler.PrimitiveLinkedType.DATA
+            || selectorType == dev.capylang.compiler.PrimitiveLinkedType.ENUM
             || selectorType == dev.capylang.compiler.PrimitiveLinkedType.NOTHING
             || selectorType instanceof dev.capylang.compiler.CompiledGenericTypeParameter
             || selectorType instanceof dev.capylang.compiler.CompiledDataType
@@ -2437,6 +2441,9 @@ public class JavaExpressionEvaluator {
                 var patternBindingName = caseBindingNames.getOrDefault(typedPattern.name(), typedPattern.name());
                 if (typedPattern.type() == dev.capylang.compiler.PrimitiveLinkedType.DATA) {
                     yield "case java.lang.Object " + patternBindingName + " when " + dataGuard(patternBindingName);
+                }
+                if (typedPattern.type() == dev.capylang.compiler.PrimitiveLinkedType.ENUM) {
+                    yield "case java.lang.Enum " + patternBindingName;
                 }
                 if (typedPattern.type() instanceof CompiledDataType typedDataType) {
                     var resolvedTypedType = resolveConstructorType(matchType, typedDataType.name());
@@ -2562,6 +2569,7 @@ public class JavaExpressionEvaluator {
             case dev.capylang.compiler.PrimitiveLinkedType primitiveType -> switch (primitiveType) {
                 case ANY -> "true";
                 case DATA -> dataGuard(expression);
+                case ENUM -> enumGuard(expression);
                 case NOTHING -> expression + " == null";
                 default -> expression + " instanceof " + javaPatternType(primitiveType);
             };
@@ -2619,6 +2627,7 @@ public class JavaExpressionEvaluator {
         return switch (normalized) {
             case "any" -> "true";
             case "data" -> dataGuard(expression);
+            case "enum" -> enumGuard(expression);
             case "nothing" -> expression + " == null";
             case "byte" -> expression + " instanceof java.lang.Byte";
             case "int" -> expression + " instanceof java.lang.Integer";
@@ -2869,6 +2878,7 @@ public class JavaExpressionEvaluator {
             }
             if (type == dev.capylang.compiler.PrimitiveLinkedType.ANY
                 || type == dev.capylang.compiler.PrimitiveLinkedType.DATA
+                || type == dev.capylang.compiler.PrimitiveLinkedType.ENUM
                 || type == dev.capylang.compiler.PrimitiveLinkedType.NOTHING) {
                 continue;
             }
@@ -2881,9 +2891,14 @@ public class JavaExpressionEvaluator {
         return varName + " instanceof dev.capylang.CapybaraDataValue";
     }
 
+    private static String enumGuard(String varName) {
+        return varName + " instanceof java.lang.Enum<?>";
+    }
+
     private static String castMatchCaseExpression(String expression, dev.capylang.compiler.CompiledType resultType) {
         if (resultType == dev.capylang.compiler.PrimitiveLinkedType.ANY
             || resultType == dev.capylang.compiler.PrimitiveLinkedType.DATA
+            || resultType == dev.capylang.compiler.PrimitiveLinkedType.ENUM
             || resultType == dev.capylang.compiler.PrimitiveLinkedType.NOTHING
             || resultType instanceof dev.capylang.compiler.CompiledGenericTypeParameter) {
             return expression;
@@ -2901,6 +2916,7 @@ public class JavaExpressionEvaluator {
                 case STRING -> "java.lang.String";
                 case BOOL -> "java.lang.Boolean";
                 case FLOAT -> "java.lang.Float";
+                case ENUM -> "java.lang.Enum";
                 case NOTHING, ANY, DATA -> "java.lang.Object";
             };
             case dev.capylang.compiler.CompiledDataType dataType -> normalizeJavaTypeReference(dataType.name());

--- a/compiler/src/test/java/dev/capylang/compiler/expression/CapybaraTypeFinderTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/expression/CapybaraTypeFinderTest.java
@@ -1,0 +1,28 @@
+package dev.capylang.compiler.expression;
+
+import dev.capylang.compiler.CompiledDataType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static dev.capylang.compiler.PrimitiveLinkedType.ANY;
+import static dev.capylang.compiler.PrimitiveLinkedType.ENUM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CapybaraTypeFinderTest {
+    @Test
+    void enumPrimitiveAndEnumValueMergeToEnum() {
+        var ready = new CompiledDataType("READY", List.of(), List.of(), List.of(), List.of(), null, true, true);
+
+        assertThat(CapybaraTypeFinder.findHigherType(ENUM, ready)).isEqualTo(ENUM);
+        assertThat(CapybaraTypeFinder.findHigherType(ready, ENUM)).isEqualTo(ENUM);
+    }
+
+    @Test
+    void enumPrimitiveAndRegularSingletonDoNotMergeToEnum() {
+        var singleton = new CompiledDataType("READY", List.of(), List.of(), List.of(), true);
+
+        assertThat(CapybaraTypeFinder.findHigherType(ENUM, singleton)).isEqualTo(ANY);
+        assertThat(CapybaraTypeFinder.findHigherType(singleton, ENUM)).isEqualTo(ANY);
+    }
+}

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -95,6 +95,16 @@ class CapybaraParserTest {
                                         x * 2
                                 """
                 ),
+                Arguments.of(
+                        "enum_type_pattern",
+                        """
+                                enum Status { READY, DONE }
+                                fun enum_type_pattern(value: any): string =
+                                    match value with
+                                    case enum e -> e.name()
+                                    case _ -> "other"
+                                """
+                ),
                 Arguments.of("const_usage", "const PI = 3.14\nfun const_usage(): double = PI"),
                 Arguments.of(
                         "block_comment",

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -79,6 +79,7 @@ fun to_json(obj: data): Result[JsonObject] =
             case Success { value } -> any_to_json(value)
             case Error { message } -> any_to_json(message)
         }
+        case enum e -> Success { JsonString { e.name() } }
         case data d -> to_json(d) | object => Success { object }
         case _ -> Error { "unsupported value" }
     ---

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -16,6 +16,7 @@ data JsonPrimitiveSample {
 data JsonCollectionSample { numbers: list[int], flags: dict[bool] }
 data JsonSetSample { tags: set[string] }
 data JsonInnerSample { label: string, count: int }
+enum JsonSampleStatus { PENDING, COMPLETE }
 data JsonLambdaSample { callback: () => string }
 data JsonWrapperSample {
     present: Option[string],
@@ -23,6 +24,7 @@ data JsonWrapperSample {
     success: Result[int],
     error: Result[int],
     inner: JsonInnerSample,
+    status: JsonSampleStatus,
     raw: Json
 }
 data JsonablePrimitiveSample { name: string, age: int, active: bool } derive Jsonable
@@ -39,6 +41,7 @@ fun tests(): Effect[TestFile] =
         test("should convert data with collection fields to json object", () => should_convert_data_with_collection_fields_to_json_object()),
         test("should convert data with set field to json array", () => should_convert_data_with_set_field_to_json_array()),
         test("should convert data with wrapper and nested fields to json object", () => should_convert_data_with_wrapper_and_nested_fields_to_json_object()),
+        test("should convert enum to json string", () => should_convert_enum_to_json_string()),
         test("should fail converting lambda field", () => should_fail_converting_lambda_field()),
         test("should derive Jsonable to_json for primitive fields", () => should_derive_jsonable_to_json_for_primitive_fields()),
         test("should derive Jsonable to_json for nested and collection fields", () => should_derive_jsonable_to_json_for_nested_and_collection_fields()),
@@ -132,6 +135,7 @@ fun should_convert_data_with_wrapper_and_nested_fields_to_json_object(): Assert 
         success: Success { value: 7 },
         error: Error { message: "bad" },
         inner: JsonInnerSample { label: "child", count: 2 },
+        status: COMPLETE {},
         raw: JsonArray { value: [JsonString { value: "kept" }] }
     }
     assert_that(to_json(sample)).succeeds(JsonObject {
@@ -146,11 +150,31 @@ fun should_convert_data_with_wrapper_and_nested_fields_to_json_object(): Assert 
                     "count": JsonNumberLong { value: 2 },
                 }
             },
+            "status": JsonString { value: "COMPLETE" },
             "raw": JsonArray {
                 value: [JsonString { value: "kept" }]
             },
         }
     })
+
+fun should_convert_enum_to_json_string(): Assert =
+    assert_that(to_json(JsonWrapperSample {
+        present: None {},
+        absent: None {},
+        success: Success { value: 1 },
+        error: Error { message: "ignored" },
+        inner: JsonInnerSample { label: "enum", count: 1 },
+        status: PENDING {},
+        raw: JsonNull {}
+    })).succeeds(obj =>
+        match _json_field(obj, "status") with
+        case Some { json } -> {
+            match json with
+            case JsonString { value } -> assert_that(value).is_equal_to("PENDING")
+            case _ -> assert_that(false).is_true()
+        }
+        case _ -> assert_that(false).is_true()
+    )
 
 fun should_fail_converting_lambda_field(): Assert =
     let sample = JsonLambdaSample {


### PR DESCRIPTION
## What changed
- Added `enum` as a runtime type/category for type patterns and signatures.
- Added generic enum `name()` support so `case enum e -> e.name()` works.
- Updated JSON serialization to encode enum fields as JSON strings.
- Added parser, e2e, invalid-program, and library JSON coverage.

## Why
Issue #108 asks for enum type matching analogous to `data`, enum-to-string naming, and JSON enum handling.

## Impacted modules
- `compiler` grammar, type linking, expression linking, and Java generation
- `capy` cfun e2e tests and compilation-error tests
- `lib/capybara-lib` JSON library and tests

## Validation
- `./gradlew :compiler:test :capy:e2e-cfun :lib:capybara-lib:testCapybara`
- `./gradlew clean check`

## Performance
- Fresh `master` baseline: `./gradlew clean check` elapsed 243.76s.
- This branch: `./gradlew clean check` elapsed 265.99s.
- Measured branch run is 22.23s slower on this machine; the change adds only focused tests and small enum matching paths, so no code hot path issue is apparent from the diff.

## Sample
```cfun
fun x(any: any): string =
  match any with
  case enum e -> e.name()
  case data d -> "data"
  case _ -> "any"
```

Closes #108