### PR TITLE
fix(#122): address placeholder partial binding review notes

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
@@ -48,3 +48,11 @@ fun between(min: int, value: int, max: int): bool =
     value >= min & value <= max
 
 fun is_age_valid(): int => bool = between(0, _, 150)
+
+fun invoke_partial_contains_method(): bool =
+    let f: string => bool = "capybara".contains(_)
+    f("pyb")
+
+fun invoke_partial_replace_method(): string =
+    let f: string => string = "banana".replace("a", _)
+    f("o")

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
@@ -24,6 +24,11 @@ fun invoke_partial_add(): int =
     let f: int => int = add(10, _)
     f(5)
 
+fun invoke_partial_add_with_generated_name_collision(): int =
+    let __capybaraPartial1 = 10
+    let f: int => int = add(__capybaraPartial1, _)
+    f(5)
+
 fun concat(a: string, b: string, c: string): string = a + b + c
 
 fun invoke_partial_concat(): string =

--- a/capy/src/e2e-cfun/java/dev/capylang/test/LambdaValuesTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/LambdaValuesTest.java
@@ -28,6 +28,7 @@ class LambdaValuesTest {
     void invokesPartiallyBoundFunction() {
         assertThat(LambdaValues.add10().apply(5)).isEqualTo(15);
         assertThat(LambdaValues.invokePartialAdd()).isEqualTo(15);
+        assertThat(LambdaValues.invokePartialAddWithGeneratedNameCollision()).isEqualTo(15);
     }
 
     @Test

--- a/capy/src/e2e-cfun/java/dev/capylang/test/LambdaValuesTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/LambdaValuesTest.java
@@ -50,6 +50,12 @@ class LambdaValuesTest {
     }
 
     @Test
+    void invokesPartiallyBoundBuiltinMethods() {
+        assertThat(LambdaValues.invokePartialContainsMethod()).isTrue();
+        assertThat(LambdaValues.invokePartialReplaceMethod()).isEqualTo("bonono");
+    }
+
+    @Test
     void generatesSupplierReturnType() throws NoSuchMethodException {
         var returnType = (ParameterizedType) LambdaValues.class.getMethod("makeSupplier").getGenericReturnType();
         assertThat(returnType.getRawType().getTypeName()).isEqualTo(Supplier.class.getTypeName());

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -1695,6 +1695,12 @@ public class CapybaraExpressionCompiler {
         var methodName = functionCall.name().substring(METHOD_INVOKE_PREFIX.length());
         var candidates = methodsByNameAndArity(functionSignatures, methodName, functionCall.arguments().size());
         if (candidates.isEmpty()) {
+            if (hasPlaceholderArguments(functionCall.arguments())) {
+                var partialBuiltin = resolvePartialBuiltinMethodInvoke(functionCall, scope, methodName, expectedType);
+                if (partialBuiltin.isPresent()) {
+                    return partialBuiltin.orElseThrow();
+                }
+            }
             return resolveBuiltinMethodInvoke(functionCall, scope, methodName)
                     .orElseGet(() -> withPosition(
                             Result.error("No method `" + methodName + "` with " + functionCall.arguments().size() + " argument(s)"),
@@ -1702,13 +1708,21 @@ public class CapybaraExpressionCompiler {
                     ));
         }
         if (hasPlaceholderArguments(functionCall.arguments())) {
-            return resolvePartialFunctionCall(
+            var partialMethod = resolvePartialFunctionCall(
                     functionCall,
                     scope,
                     expectedType,
                     candidates,
                     FunctionSignature::name
             );
+            if (partialMethod instanceof Result.Success<CompiledExpression>) {
+                return partialMethod;
+            }
+            var partialBuiltin = resolvePartialBuiltinMethodInvoke(functionCall, scope, methodName, expectedType);
+            if (partialBuiltin.isPresent() && partialBuiltin.orElseThrow() instanceof Result.Success<CompiledExpression>) {
+                return partialBuiltin.orElseThrow();
+            }
+            return partialMethod;
         }
 
         ResolvedFunctionCall best = null;
@@ -2192,6 +2206,95 @@ public class CapybaraExpressionCompiler {
                 args,
                 STRING
         )));
+    }
+
+    private Optional<Result<CompiledExpression>> resolvePartialBuiltinMethodInvoke(
+            FunctionCall functionCall,
+            Scope scope,
+            String methodName,
+            Optional<CompiledType> expectedType
+    ) {
+        var candidates = builtinMethodSignatures(methodName, functionCall.arguments().size());
+        if (candidates.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(resolvePartialFunctionCall(
+                functionCall,
+                scope,
+                expectedType,
+                candidates,
+                FunctionSignature::name
+        ));
+    }
+
+    private List<FunctionSignature> builtinMethodSignatures(String methodName, int arity) {
+        var signatures = new java.util.ArrayList<FunctionSignature>();
+        if (arity == 2 && ("contains".equals(methodName)
+                           || "starts_with".equals(methodName)
+                           || "end_with".equals(methodName))) {
+            signatures.add(builtinMethodSignature("String", methodName, List.of(STRING, STRING), BOOL));
+        }
+        if (arity == 3 && "replace".equals(methodName)) {
+            signatures.add(builtinMethodSignature("String", methodName, List.of(STRING, STRING, STRING), STRING));
+        }
+        if (arity != 1) {
+            return List.copyOf(signatures);
+        }
+        if ("trim".equals(methodName)) {
+            signatures.add(builtinMethodSignature("String", "trim", List.of(STRING), STRING));
+        }
+        if ("is_empty".equals(methodName)) {
+            signatures.add(builtinMethodSignature("String", "is_empty", List.of(STRING), BOOL));
+        }
+        if ("to_int".equals(methodName)) {
+            signatures.add(builtinMethodSignature("Long", "to_int", List.of(LONG), INT));
+            signatures.add(builtinMethodSignature("Float", "to_int", List.of(FLOAT), INT));
+            signatures.add(builtinMethodSignature("Double", "to_int", List.of(DOUBLE), INT));
+            var resultType = resultTypeFor(INT);
+            if (resultType != null) {
+                signatures.add(builtinMethodSignature("String", "to_int", List.of(STRING), resultType));
+            }
+        }
+        if ("to_long".equals(methodName)) {
+            signatures.add(builtinMethodSignature("Float", "to_long", List.of(FLOAT), LONG));
+            signatures.add(builtinMethodSignature("Double", "to_long", List.of(DOUBLE), LONG));
+            var resultType = resultTypeFor(LONG);
+            if (resultType != null) {
+                signatures.add(builtinMethodSignature("String", "to_long", List.of(STRING), resultType));
+            }
+        }
+        if ("to_double".equals(methodName)) {
+            var resultType = resultTypeFor(DOUBLE);
+            if (resultType != null) {
+                signatures.add(builtinMethodSignature("String", "to_double", List.of(STRING), resultType));
+            }
+        }
+        if ("to_float".equals(methodName)) {
+            var resultType = resultTypeFor(FLOAT);
+            if (resultType != null) {
+                signatures.add(builtinMethodSignature("String", "to_float", List.of(STRING), resultType));
+            }
+        }
+        if ("to_bool".equals(methodName)) {
+            var resultType = resultTypeFor(BOOL);
+            if (resultType != null) {
+                signatures.add(builtinMethodSignature("String", "to_bool", List.of(STRING), resultType));
+            }
+        }
+        return List.copyOf(signatures);
+    }
+
+    private FunctionSignature builtinMethodSignature(
+            String receiverType,
+            String methodName,
+            List<CompiledType> parameterTypes,
+            CompiledType returnType
+    ) {
+        return new FunctionSignature(
+                METHOD_DECL_PREFIX + receiverType + "__" + methodName,
+                parameterTypes,
+                returnType
+        );
     }
 
     private Optional<Result<CompiledExpression>> resolveBuiltinEnumNameMethodInvoke(

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -19,6 +19,7 @@ public class CapybaraExpressionCompiler {
     private static final Logger LOG = Logger.getLogger(CapybaraExpressionCompiler.class.getName());
     private static final String METHOD_DECL_PREFIX = "__method__";
     private static final String METHOD_INVOKE_PREFIX = "__invoke__";
+    private static final String PARTIAL_PLACEHOLDER_PREFIX = "$capybaraPartial";
     private static final String DICT_PIPE_ARGS_SEPARATOR = "::";
     private static final String TUPLE_PIPE_ARGS_SEPARATOR = ";;";
     private static final String REFLECTION_INTRINSIC_MODULE = "capy/meta_prog/Reflection";
@@ -617,6 +618,10 @@ public class CapybaraExpressionCompiler {
         return arguments.stream().anyMatch(PlaceholderExpression.class::isInstance);
     }
 
+    private String partialPlaceholderName(int index) {
+        return PARTIAL_PLACEHOLDER_PREFIX + index;
+    }
+
     private Result<CompiledExpression> resolvePartialFunctionCall(
             FunctionCall functionCall,
             Scope scope,
@@ -692,7 +697,7 @@ public class CapybaraExpressionCompiler {
             var argument = arguments.get(i);
             var expected = expectedTypes.get(i);
             if (argument instanceof PlaceholderExpression) {
-                var name = "__capybaraPartial" + (placeholderNames.size() + 1);
+                var name = partialPlaceholderName(placeholderNames.size() + 1);
                 placeholderNames.add(name);
                 placeholderTypes.add(expected);
                 callArguments.add(new CompiledVariable(name, expected));
@@ -2674,7 +2679,7 @@ public class CapybaraExpressionCompiler {
             }
             var expected = currentFunctionType.argumentType();
             if (argument instanceof PlaceholderExpression) {
-                var name = "__capybaraPartial" + (placeholderNames.size() + 1);
+                var name = partialPlaceholderName(placeholderNames.size() + 1);
                 placeholderNames.add(name);
                 placeholderTypes.add(expected);
                 callArguments.add(new CompiledVariable(name, expected));

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -172,7 +172,7 @@ class JavaExpressionEvaluatorTest {
 
         assertThat(expression).isInstanceOf(CompiledLambdaExpression.class);
         var lambda = (CompiledLambdaExpression) expression;
-        assertThat(lambda.argumentName()).isEqualTo("__capybaraPartial1");
+        assertThat(lambda.argumentName()).isEqualTo("$capybaraPartial1");
         assertThat(lambda.functionType()).isEqualTo(new CompiledFunctionType(PrimitiveLinkedType.INT, PrimitiveLinkedType.INT));
     }
 
@@ -189,15 +189,15 @@ class JavaExpressionEvaluatorTest {
 
         assertThat(expression).isInstanceOf(CompiledLambdaExpression.class);
         var first = (CompiledLambdaExpression) expression;
-        assertThat(first.argumentName()).isEqualTo("__capybaraPartial1");
+        assertThat(first.argumentName()).isEqualTo("$capybaraPartial1");
         assertThat(first.functionType().argumentType()).isEqualTo(PrimitiveLinkedType.INT);
         assertThat(first.expression()).isInstanceOf(CompiledLambdaExpression.class);
         var second = (CompiledLambdaExpression) first.expression();
-        assertThat(second.argumentName()).isEqualTo("__capybaraPartial2");
+        assertThat(second.argumentName()).isEqualTo("$capybaraPartial2");
         assertThat(second.functionType().argumentType()).isEqualTo(PrimitiveLinkedType.DOUBLE);
         assertThat(second.expression()).isInstanceOf(CompiledLambdaExpression.class);
         var third = (CompiledLambdaExpression) second.expression();
-        assertThat(third.argumentName()).isEqualTo("__capybaraPartial3");
+        assertThat(third.argumentName()).isEqualTo("$capybaraPartial3");
         assertThat(third.functionType().argumentType()).isEqualTo(PrimitiveLinkedType.INT);
     }
 


### PR DESCRIPTION
## What changed
- Routed placeholder method calls through partial binding for built-in method signatures before falling back to normal built-in resolution.
- Added built-in partial binding coverage for cases such as `"capybara".contains(_)` and `"banana".replace("a", _)`.
- Changed generated placeholder lambda names to a `$capybaraPartialN` prefix so source locals cannot collide with them.
- Added regression coverage for `let __capybaraPartial1 = 10; let f = add(__capybaraPartial1, _)`.

## Why
Addresses the two P2 review comments from PR #121:
- Built-in method placeholders were linked as standalone `_` instead of being lowered to a partial method binding.
- Generated placeholder names could collide with user-defined locals and change runtime behavior.

## Impacted modules
- `compiler`: method invocation resolution and generated placeholder naming.
- `capy`: functional e2e coverage for partial binding behavior.

## Validation
- `./gradlew :compiler:test :capy:e2e-cfun`
- `./gradlew clean check`

## Performance
- Baseline fresh-branch `./gradlew clean check`: `239.82s`
- Final PR `./gradlew clean check`: `235.08s`
- Result: no clean-check performance regression observed.

## Sample
```cfun
fun uses_builtin(): string => bool = "capybara".contains(_)
fun add_collision_safe(): int =
    let __capybaraPartial1 = 10
    let f: int => int = add(__capybaraPartial1, _)
    f(5)
```
