### PR TITLE
fix(#122): allow enum values without braces

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/EnumCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/EnumCollection.cfun
@@ -1,5 +1,10 @@
 enum Color { RED, BLUE, GREEN_BLUE, YELLOW, BLACK, WHITE }
 
+data Palette {
+    primary: Color,
+    fallback: Color
+}
+
 fun color_match(c: Color): int =
     match c with
     case RED -> 1
@@ -24,3 +29,19 @@ fun color_values(): set[Color] = Color.values
 fun parse_color_name(name: string): /capy/lang/Result[Color] = Color.parse(name)
 
 fun parse_color_order(order: int): /capy/lang/Result[Color] = Color.parse(order)
+
+fun qualified_color_without_braces(): Color = Color.BLUE
+
+fun unqualified_color_without_braces(): Color = GREEN_BLUE
+
+fun inferred_color_without_braces() = RED
+
+fun color_name_without_braces(): string = YELLOW.name
+
+fun color_list_without_braces(): list[Color] = [RED, Color.BLUE, GREEN_BLUE]
+
+fun palette_without_braces(): Palette =
+    Palette {
+        primary: WHITE,
+        fallback: Color.BLACK
+    }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/EnumCollectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/EnumCollectionTest.java
@@ -53,4 +53,29 @@ class EnumCollectionTest {
         assertThat(EnumCollection.parseColorOrder(99))
                 .isInstanceOf(Result.Error.class);
     }
+
+    @Test
+    void enumValuesCanBeUsedWithoutBracesInExpressions() {
+        assertThat(EnumCollection.qualifiedColorWithoutBraces())
+                .isEqualTo(EnumCollection.Color.BLUE);
+        assertThat(EnumCollection.unqualifiedColorWithoutBraces())
+                .isEqualTo(EnumCollection.Color.GREEN_BLUE);
+        assertThat(EnumCollection.inferredColorWithoutBraces())
+                .isEqualTo(EnumCollection.Color.RED);
+        assertThat(EnumCollection.colorNameWithoutBraces())
+                .isEqualTo("YELLOW");
+    }
+
+    @Test
+    void enumValuesCanBeUsedWithoutBracesInCompoundExpressions() {
+        assertThat(EnumCollection.colorListWithoutBraces())
+                .containsExactly(
+                        EnumCollection.Color.RED,
+                        EnumCollection.Color.BLUE,
+                        EnumCollection.Color.GREEN_BLUE);
+
+        var palette = EnumCollection.paletteWithoutBraces();
+        assertThat(palette.primary()).isEqualTo(EnumCollection.Color.WHITE);
+        assertThat(palette.fallback()).isEqualTo(EnumCollection.Color.BLACK);
+    }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -974,7 +974,7 @@ public class CapybaraExpressionCompiler {
                 if (singleton.isPresent()) {
                     var singletonType = singleton.orElseThrow();
                     var enumParent = singletonType.enumParent();
-                    if (enumParent.isEmpty()) {
+                    if (enumParent.isEmpty() && singletonType.type().enumValue()) {
                         enumParent = Optional.ofNullable(findEnumParentForValue(singletonType.type().name()));
                     }
                     if (enumParent.isPresent()) {
@@ -1513,6 +1513,18 @@ public class CapybaraExpressionCompiler {
             var qualifiedEnum = findEnumSingletonDataType(constructorName, qualified);
             if (qualifiedEnum.isPresent()) {
                 return qualifiedEnum;
+            }
+        }
+        if (qualified.isEmpty()) {
+            var regularSingleton = dataTypes.values().stream()
+                    .filter(CompiledDataType.class::isInstance)
+                    .map(CompiledDataType.class::cast)
+                    .filter(CompiledDataType::singleton)
+                    .filter(dataType -> !dataType.enumValue())
+                    .filter(dataType -> typeNameMatches(dataType.name(), constructorName))
+                    .findFirst();
+            if (regularSingleton.isPresent()) {
+                return regularSingleton.map(dataType -> new SingletonDataType(dataType, Optional.empty()));
             }
         }
         var direct = dataTypes.values().stream()

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -972,6 +972,21 @@ public class CapybaraExpressionCompiler {
             if (functionCall.arguments().isEmpty()) {
                 var singleton = findSingletonDataType(functionCall.name());
                 if (singleton.isPresent()) {
+                    var singletonType = singleton.orElseThrow();
+                    var enumParent = singletonType.enumParent();
+                    if (enumParent.isEmpty()) {
+                        enumParent = Optional.ofNullable(findEnumParentForValue(singletonType.type().name()));
+                    }
+                    if (enumParent.isPresent()) {
+                        return linkNewData(new NewData(
+                                new DataType(functionCall.name()),
+                                false,
+                                List.of(),
+                                List.of(),
+                                List.of(),
+                                functionCall.position()
+                        ), scope);
+                    }
                     return withPosition(
                             Result.error("Singleton data value `" + functionCall.name() + "` must be constructed with `"
                                          + functionCall.name() + " {}`"),

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -390,6 +390,36 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldCompileEnumValuesWithoutBraces() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram("Consumer", "/foo/app", """
+                enum PathRoot { RELATIVE, ABSOLUTE }
+                fun root(): PathRoot = PathRoot.ABSOLUTE
+                fun inferred_root() = RELATIVE
+                fun root_name(): string = ABSOLUTE.name
+                """));
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated)
+                .contains("return PathRoot.ABSOLUTE;")
+                .contains("return PathRoot.RELATIVE;");
+        assertGeneratedJavaCompiles(generatedProgram);
+    }
+
+    @Test
+    void shouldStillRequireBracesForSingleValues() {
+        var programResult = CapybaraCompiler.INSTANCE.compile(List.of(new RawModule("test", "/foo/boo", """
+                single Done
+                fun done(): Done = Done
+                """)), new java.util.TreeSet<>());
+        assertThat(programResult).isInstanceOf(Result.Error.class);
+        var error = (Result.Error<CompiledProgram>) programResult;
+        assertThat(error.errors().stream().map(Result.Error.SingleError::message).collect(joining(",")))
+                .contains("Singleton data value `Done` must be constructed with `Done {}`");
+    }
+
+    @Test
     void shouldGenerateRuntimeCarrierCallForReflectionValueOnGenericData() {
         var generatedProgram = new JavaGenerator().generate(compileProgram(List.of(
                 reflectionMetadataModule(),

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -420,6 +420,23 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldStillRequireBracesForSingleValuesThatShareEnumValueNames() {
+        var libraries = compileProgram(List.of(new RawModule("Statuses", "/foo/lib", """
+                enum Status { DONE }
+                """))).modules();
+        var programResult = CapybaraCompiler.INSTANCE.compile(List.of(new RawModule("test", "/foo/boo", """
+                from /foo/lib/Statuses import { * }
+
+                single DONE
+                fun done(): DONE = DONE
+                """)), libraries);
+        assertThat(programResult).isInstanceOf(Result.Error.class);
+        var error = (Result.Error<CompiledProgram>) programResult;
+        assertThat(error.errors().stream().map(Result.Error.SingleError::message).collect(joining(",")))
+                .contains("Singleton data value `DONE` must be constructed with `DONE {}`");
+    }
+
+    @Test
     void shouldGenerateRuntimeCarrierCallForReflectionValueOnGenericData() {
         var generatedProgram = new JavaGenerator().generate(compileProgram(List.of(
                 reflectionMetadataModule(),

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -135,7 +135,7 @@ fun should_convert_data_with_wrapper_and_nested_fields_to_json_object(): Assert 
         success: Success { value: 7 },
         error: Error { message: "bad" },
         inner: JsonInnerSample { label: "child", count: 2 },
-        status: COMPLETE {},
+        status: COMPLETE,
         raw: JsonArray { value: [JsonString { value: "kept" }] }
     }
     assert_that(to_json(sample)).succeeds(JsonObject {
@@ -164,7 +164,7 @@ fun should_convert_enum_to_json_string(): Assert =
         success: Success { value: 1 },
         error: Error { message: "ignored" },
         inner: JsonInnerSample { label: "enum", count: 1 },
-        status: PENDING {},
+        status: PENDING,
         raw: JsonNull {}
     })).succeeds(obj =>
         match _json_field(obj, "status") with


### PR DESCRIPTION
## What changed
- Allows enum values to be used without `{}` in expressions, including qualified values such as `PathRoot.ABSOLUTE` and unqualified values such as `ABSOLUTE`.
- Keeps regular `single` values requiring `Single {}` and preserves the existing diagnostic.
- Updates the JSON library test sample to use bare enum values.

## Impacted modules
- `compiler`: enum singleton expression linking and unit coverage.
- `lib/capybara-lib`: JSON test source syntax coverage.

## Verification
- `./gradlew :compiler:test --tests dev.capylang.generator.java.JavaExpressionEvaluatorTest`
- `./gradlew :lib:capybara-lib:testCapybara`
- `/usr/bin/time -f 'elapsed_seconds=%e' ./gradlew clean check`

## Performance
- Fresh `master` clean check baseline: `214.45s`.
- Branch clean check: first run `229.18s`, repeat run `214.91s`.
- The repeat run is effectively flat against baseline (`+0.46s`, about `0.2%`), so I do not see a clean-check performance regression.

## Sample
```cfun
enum PathRoot { RELATIVE, ABSOLUTE }
fun root(): PathRoot = PathRoot.ABSOLUTE
fun inferred_root() = RELATIVE
```
