### PR TITLE
feat(#126): allow selecting capybara tests

### DIFF
--- a/build-tool/gradle/src/main/java/dev.capylang/CapybaraPlugin.java
+++ b/build-tool/gradle/src/main/java/dev.capylang/CapybaraPlugin.java
@@ -246,6 +246,8 @@ public class CapybaraPlugin implements Plugin<Project> {
                         task.getOutputDir().set(capybaraTestResultsDir);
                         task.getReportType().set("JUNIT");
                         task.getLogType().set("NONE");
+                        task.getTests().convention(List.of());
+                        task.getPrintAvailableTests().convention(false);
                         task.setEnabled(hasCapybaraTestSources);
                         if (!hasCapybaraTestSources) {
                             task.setDependsOn(java.util.List.of());

--- a/build-tool/gradle/src/main/java/dev.capylang/CapybaraTestTask.java
+++ b/build-tool/gradle/src/main/java/dev.capylang/CapybaraTestTask.java
@@ -4,15 +4,18 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
 
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 
 public abstract class CapybaraTestTask extends DefaultTask {
     @Classpath
@@ -26,6 +29,22 @@ public abstract class CapybaraTestTask extends DefaultTask {
 
     @Input
     public abstract Property<String> getLogType();
+
+    @Input
+    public abstract ListProperty<String> getTests();
+
+    @Input
+    public abstract Property<Boolean> getPrintAvailableTests();
+
+    @Option(option = "tests", description = "Run only matching Capybara tests. Can be provided multiple times.")
+    public void addTest(String test) {
+        getTests().add(test);
+    }
+
+    @Option(option = "available-tests", description = "Print available Capybara tests without running them.")
+    public void setAvailableTests(boolean availableTests) {
+        getPrintAvailableTests().set(availableTests);
+    }
 
     @TaskAction
     public void runCapybaraTests() throws Exception {
@@ -51,18 +70,24 @@ public abstract class CapybaraTestTask extends DefaultTask {
             Method runTests = testRunnerClass.getMethod("runTests", argumentsClass);
 
             var logType = getLogType().getOrElse("NONE");
-            var args = logType.isBlank() || "NONE".equalsIgnoreCase(logType)
-                    ? new String[]{
-                    "-o", outputDir.getAbsolutePath(),
-                    "-rt", getReportType().get()
+            var args = new ArrayList<String>();
+            args.add("-o");
+            args.add(outputDir.getAbsolutePath());
+            args.add("-rt");
+            args.add(getReportType().get());
+            if (!logType.isBlank() && !"NONE".equalsIgnoreCase(logType)) {
+                args.add("-l");
+                args.add(logType);
             }
-                    : new String[]{
-                    "-o", outputDir.getAbsolutePath(),
-                    "-rt", getReportType().get(),
-                    "-l", logType
-            };
+            for (var test : getTests().getOrElse(java.util.List.of())) {
+                args.add("--tests");
+                args.add(test);
+            }
+            if (getPrintAvailableTests().getOrElse(false)) {
+                args.add("--available-tests");
+            }
 
-            var parsedArguments = parseArguments.invoke(null, (Object) args);
+            var parsedArguments = parseArguments.invoke(null, (Object) args.toArray(String[]::new));
             var exitCode = (Integer) runTests.invoke(null, parsedArguments);
             if (exitCode != 0) {
                 throw new GradleException("Capybara tests failed with exit code " + exitCode);

--- a/build-tool/gradle/src/test/java/dev/capylang/CapybaraPluginTest.java
+++ b/build-tool/gradle/src/test/java/dev/capylang/CapybaraPluginTest.java
@@ -617,6 +617,15 @@ class CapybaraPluginTest {
         assertEquals("NONE", testCapybara.getLogType().get());
     }
 
+    @Test
+    void shouldDefaultCapybaraTestSelectionOptions() {
+        var project = newProject(List.of("check"));
+        var testCapybara = project.getTasks().named("testCapybara", CapybaraTestTask.class).get();
+
+        assertTrue(testCapybara.getTests().get().isEmpty());
+        assertFalse(testCapybara.getPrintAvailableTests().get());
+    }
+
     @ParameterizedTest
     @MethodSource("fusedCapybaraLifecycleTasks")
     void shouldWireLifecycleBuildJavaCompilationDirectlyToFusedCompileTask(String requestedTask) {

--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -867,6 +867,9 @@ public final class JavaGenerator implements Generator {
         if (isCapyTestCurrentLogTypeMethod(ownerPackage, ownerName, method)) {
             return mapCapyTestCurrentLogTypeMethod(method, visibility, methodTypeParameters);
         }
+        if (isCapyTestSelectionMethod(ownerPackage, ownerName, method)) {
+            return mapCapyTestSelectionMethod(method, visibility, methodTypeParameters);
+        }
         if (isCapyIoConsoleMethod(ownerPackage, ownerName, method)) {
             return mapCapyIoConsoleMethod(method, visibility, methodTypeParameters);
         }
@@ -959,6 +962,33 @@ public final class JavaGenerator implements Generator {
         return mapJavaDoc(method.comments())
                + visibility + "static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "() {\n"
                + "return capy.lang.Effect.delay(dev.capylang.test.TestLog::currentLogType);\n"
+               + "}\n";
+    }
+
+    private boolean isCapyTestSelectionMethod(String ownerPackage, String ownerName, JavaMethod method) {
+        if (!"capy.test".equals(ownerPackage) || !"CapyTest".equals(ownerName) || !isEffectTypeReference(method.returnType().toString())) {
+            return false;
+        }
+        var methodName = mapMethodName(method.name());
+        return switch (methodName) {
+            case "pushTestFile", "shouldIncludeTestFile", "shouldExecuteTest", "shouldIncludeTest" ->
+                    method.parameters().size() == 1 && isNativeExpression(method);
+            case "popTestFile" -> method.parameters().isEmpty() && isNativeExpression(method);
+            default -> false;
+        };
+    }
+
+    private String mapCapyTestSelectionMethod(JavaMethod method, String visibility, String methodTypeParameters) {
+        var methodName = mapMethodName(method.name());
+        var runtimeCall = switch (methodName) {
+            case "pushTestFile", "shouldIncludeTestFile", "shouldExecuteTest", "shouldIncludeTest" ->
+                    "dev.capylang.test.TestSelection." + methodName + "(" + method.parameters().getFirst().generatedName() + ")";
+            case "popTestFile" -> "dev.capylang.test.TestSelection.popTestFile()";
+            default -> throw new IllegalStateException("Unsupported CapyTest selection method: " + methodName);
+        };
+        return mapJavaDoc(method.comments())
+               + visibility + "static " + methodTypeParameters + method.returnType() + " " + methodName + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
+               + "return capy.lang.Effect.delay(() -> " + runtimeCall + ");\n"
                + "}\n";
     }
 

--- a/lib/capybara-lib/build.gradle
+++ b/lib/capybara-lib/build.gradle
@@ -4,6 +4,7 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
@@ -19,6 +20,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.options.Option
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
@@ -136,7 +138,7 @@ class CapyRuntimeBridge implements Closeable {
         ) as Integer
     }
 
-    int runTests(Path outputPath, String reportType, String logType) {
+    int runTests(Path outputPath, String reportType, String logType, List<String> tests, boolean availableTests) {
         ensureTestRunnerLoaded()
         def originalContextClassLoader = Thread.currentThread().contextClassLoader
         try {
@@ -147,6 +149,12 @@ class CapyRuntimeBridge implements Closeable {
             ]
             if (logType != null && !logType.isBlank() && !logType.equalsIgnoreCase('NONE')) {
                 args.addAll(['-l', logType])
+            }
+            tests.each { test ->
+                args.addAll(['--tests', test])
+            }
+            if (availableTests) {
+                args.add('--available-tests')
             }
 
             def parsedArguments = parseArgumentsMethod.invoke(null, [args.toArray(new String[0])] as Object[])
@@ -294,12 +302,34 @@ abstract class InProcessCapybaraTestTask extends DefaultTask {
     @Input
     abstract Property<String> getLogType()
 
+    @Input
+    abstract ListProperty<String> getTests()
+
+    @Input
+    abstract Property<Boolean> getPrintAvailableTests()
+
+    @Option(option = 'tests', description = 'Run only matching Capybara tests. Can be provided multiple times.')
+    void addTest(String test) {
+        getTests().add(test)
+    }
+
+    @Option(option = 'available-tests', description = 'Print available Capybara tests without running them.')
+    void setAvailableTests(boolean availableTests) {
+        getPrintAvailableTests().set(availableTests)
+    }
+
     @TaskAction
     void runCapybaraTests() {
         outputDir.get().asFile.mkdirs()
 
         def bridge = runtimeService.get().bridgeFor(runtimeClasspath.files)
-        def exitCode = bridge.runTests(outputDir.get().asFile.toPath(), reportType.get(), logType.getOrElse('NONE'))
+        def exitCode = bridge.runTests(
+                outputDir.get().asFile.toPath(),
+                reportType.get(),
+                logType.getOrElse('NONE'),
+                getTests().getOrElse([]),
+                getPrintAvailableTests().getOrElse(false)
+        )
         if (exitCode != 0) {
             throw new GradleException("Capybara tests failed with exit code ${exitCode}")
         }
@@ -321,6 +351,8 @@ tasks.withType(InProcessCapybaraCompileTask).configureEach {
 tasks.withType(InProcessCapybaraTestTask).configureEach {
     runtimeService.set(capyRuntimeService)
     logType.set('TC')
+    getTests().convention([])
+    getPrintAvailableTests().convention(false)
 }
 
 def capyProject = project(':capy')

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -19,11 +19,23 @@ enum LogType { NONE, LOG, TEAM_CITY }
 
 fun test_file(file_name: string, test_cases: list[Effect[TestCase]]): Effect[TestFile] =
     let current <- now()
+    let pushed_file <- push_test_file(file_name)
+    let include_file <- should_include_test_file(file_name)
     let log_type <- current_log_type()
     let suite_name = test_suite_name(file_name)
-    let started <- print_test_suite_started(log_type, suite_name)
-    let executed_test_cases <- execute_test_cases(test_cases)
-    let finished <- print_test_suite_finished(log_type, suite_name)
+    let started <-
+        if include_file
+        then print_test_suite_started(log_type, suite_name)
+        else pure(suite_name)
+    let executed_test_cases <-
+        if include_file
+        then execute_test_cases(test_cases)
+        else pure(empty_test_cases())
+    let finished <-
+        if include_file
+        then print_test_suite_finished(log_type, suite_name)
+        else pure(suite_name)
+    let popped_file <- pop_test_file()
     TestFile {
         file_name: file_name,
         test_cases: executed_test_cases,
@@ -31,31 +43,50 @@ fun test_file(file_name: string, test_cases: list[Effect[TestCase]]): Effect[Tes
     }
 
 fun test(name: string, assert_supplier: () => Assert): Effect[TestCase] =
-    let log_type <- current_log_type()
-    let started <- print_test_started(log_type, name)
-    let start <- nano_time()
-    let assert = assert_supplier()
-    let result = execute(assert.assertions)
-    let end <- nano_time()
-    let test_case = TestCase {
+    let should_execute <- should_execute_test(name)
+    if !should_execute
+    then pure(TestCase {
         name: name,
-        result: result,
-        assertions_count: assert.assertions.size,
-        execution_time: (end - start) / 1000000000.0
-    }
-    let failed <- print_test_failed(log_type, test_case)
-    let finished <- print_test_finished(log_type, name)
-    test_case
+        result: Passed {},
+        assertions_count: 0,
+        execution_time: 0.0
+    })
+    else
+        let log_type <- current_log_type()
+        let started <- print_test_started(log_type, name)
+        let start <- nano_time()
+        let assert = assert_supplier()
+        let result = execute(assert.assertions)
+        let end <- nano_time()
+        let test_case = TestCase {
+            name: name,
+            result: result,
+            assertions_count: assert.assertions.size,
+            execution_time: (end - start) / 1000000000.0
+        }
+        let failed <- print_test_failed(log_type, test_case)
+        let finished <- print_test_finished(log_type, name)
+        test_case
 
 private fun current_log_type(): Effect[LogType] = <native>
+private fun push_test_file(file_name: string): Effect[string] = <native>
+private fun pop_test_file(): Effect[string] = <native>
+private fun should_include_test_file(file_name: string): Effect[bool] = <native>
+private fun should_execute_test(test_name: string): Effect[bool] = <native>
+private fun should_include_test(test_name: string): Effect[bool] = <native>
+
+private fun empty_test_cases(): list[TestCase] = []
 
 private fun execute_test_cases(test_cases: list[Effect[TestCase]]): Effect[list[TestCase]] =
     match test_cases[0] with
     case None -> pure([])
     case Some { test_case } ->
         let executed_test_case <- test_case
+        let include_test_case <- should_include_test(executed_test_case.name)
         let executed_test_cases <- execute_test_cases(test_cases[1:])
-        [executed_test_case] + executed_test_cases
+        if include_test_case
+        then [executed_test_case] + executed_test_cases
+        else executed_test_cases
 
 private fun execute(assertions: list[() => Assertion]): TestResult =
     let failed_assertion = to_seq(assertions)

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
@@ -9,6 +9,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -32,12 +33,22 @@ public class TestRunner {
         var capyTestRuntimeClass = loadCapyTestRuntime();
         var gatherTestsMethod = loadGatherTestsMethod(capyTestRuntimeClass);
         var previousLogType = TestLog.currentLogType();
-        TestLog.setLogType(arguments.logType());
+        var previousSelection = TestSelection.setSelection(TestSelection.Selection.from(
+                arguments.testSelectors(),
+                arguments.availableTests()
+        ));
+        TestLog.setLogType(arguments.availableTests() ? CapyTest.LogType.NONE : arguments.logType());
         try {
             var testFiles = invokeGatherTests(gatherTestsMethod);
+            if (arguments.availableTests()) {
+                availableTests(testFiles).forEach(System.out::println);
+                return 0;
+            }
+            testFiles = filterTestFiles(testFiles, arguments.testSelectors());
             var testRun = invokeRunTests(arguments.reportType(), arguments.outputDir(), testFiles);
             return testRun.failed() ? 1 : 0;
         } finally {
+            TestSelection.restoreSelection(previousSelection);
             TestLog.setLogType(previousLogType);
         }
     }
@@ -46,6 +57,8 @@ public class TestRunner {
         Path outputDir = null;
         ReportType reportType = null;
         CapyTest.LogType logType = CapyTest.LogType.NONE;
+        var testSelectors = new ArrayList<String>();
+        var availableTests = false;
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "-o", "--output-dir" -> {
@@ -66,6 +79,13 @@ public class TestRunner {
                     }
                     logType = parseLogType(args[++i]);
                 }
+                case "--tests" -> {
+                    if (i + 1 >= args.length) {
+                        throw new IllegalArgumentException("Missing value for " + args[i]);
+                    }
+                    testSelectors.add(args[++i]);
+                }
+                case "--available-tests" -> availableTests = true;
                 case "-h", "--help" -> {
                     printHelp();
                     System.exit(0);
@@ -73,29 +93,49 @@ public class TestRunner {
                 default -> throw new IllegalArgumentException("Unknown argument: " + args[i]);
             }
         }
-        return new Arguments(outputDir, reportType, logType);
+        return new Arguments(outputDir, reportType, logType, testSelectors, availableTests);
     }
 
-    public record Arguments(Path outputDir, ReportType reportType, CapyTest.LogType logType) {
+    public record Arguments(
+            Path outputDir,
+            ReportType reportType,
+            CapyTest.LogType logType,
+            List<String> testSelectors,
+            boolean availableTests
+    ) {
         public Arguments(Path outputDir, ReportType reportType) {
-            this(outputDir, reportType, CapyTest.LogType.NONE);
+            this(outputDir, reportType, CapyTest.LogType.NONE, List.of(), false);
+        }
+
+        public Arguments(Path outputDir, ReportType reportType, CapyTest.LogType logType) {
+            this(outputDir, reportType, logType, List.of(), false);
         }
 
         public Arguments {
-            if (outputDir == null) {
+            if (!availableTests && outputDir == null) {
                 throw new IllegalArgumentException("Output directory not specified");
             }
-            if (!Files.exists(outputDir)) {
+            if (outputDir != null && !Files.exists(outputDir)) {
                 throw new IllegalArgumentException("Output directory `%s` doesn't exist".formatted(outputDir));
             }
-            if (!Files.isDirectory(outputDir)) {
+            if (outputDir != null && !Files.isDirectory(outputDir)) {
                 throw new IllegalArgumentException("Output directory `%s` is not a directory".formatted(outputDir));
             }
-            if (reportType == null) {
+            if (!availableTests && reportType == null) {
                 throw new IllegalArgumentException("Report type is null");
             }
             if (logType == null) {
                 logType = CapyTest.LogType.NONE;
+            }
+            if (testSelectors == null) {
+                testSelectors = List.of();
+            } else {
+                testSelectors = List.copyOf(testSelectors);
+            }
+            for (var testSelector : testSelectors) {
+                if (testSelector == null || testSelector.isBlank()) {
+                    throw new IllegalArgumentException("Test selector must not be blank");
+                }
             }
         }
     }
@@ -111,8 +151,21 @@ public class TestRunner {
                   -o, --output-dir <dir>    Output directory for test reports (required)
                   -rt, --report-type <type> Report type (required, e.g., JUNIT)
                   -l, --log <type>          Log output type (optional, LOG, TC, TEAM_CITY)
+                  --tests <selector>        Run only tests matching selector; can be repeated
+                  --available-tests         Print available test selectors and exit
                   -h, --help                Show this help message
                 """);
+    }
+
+    static List<String> availableTests(List<CapyTest.TestFile> testFiles) {
+        return TestSelection.availableTests(testFiles);
+    }
+
+    static List<CapyTest.TestFile> filterTestFiles(
+            List<CapyTest.TestFile> testFiles,
+            List<String> testSelectors
+    ) {
+        return TestSelection.filterTestFiles(testFiles, testSelectors);
     }
 
     private static CapyTest.LogType parseLogType(String value) {

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestSelection.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestSelection.java
@@ -1,0 +1,239 @@
+package dev.capylang.test;
+
+import capy.test.CapyTest;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TestSelection {
+    private static final ThreadLocal<Selection> CURRENT_SELECTION = new ThreadLocal<>();
+    private static final ThreadLocal<ArrayDeque<String>> CURRENT_TEST_FILES = ThreadLocal.withInitial(ArrayDeque::new);
+
+    private TestSelection() {
+    }
+
+    static Selection currentSelection() {
+        var selection = CURRENT_SELECTION.get();
+        return selection == null ? Selection.all() : selection;
+    }
+
+    static Selection setSelection(Selection selection) {
+        var previousSelection = CURRENT_SELECTION.get();
+        if (selection == null || selection.isDefault()) {
+            CURRENT_SELECTION.remove();
+        } else {
+            CURRENT_SELECTION.set(selection);
+        }
+        CURRENT_TEST_FILES.remove();
+        return previousSelection;
+    }
+
+    static void restoreSelection(Selection selection) {
+        if (selection == null || selection.isDefault()) {
+            CURRENT_SELECTION.remove();
+        } else {
+            CURRENT_SELECTION.set(selection);
+        }
+        CURRENT_TEST_FILES.remove();
+    }
+
+    public static String pushTestFile(String fileName) {
+        CURRENT_TEST_FILES.get().push(normalizedTestFileName(fileName));
+        return fileName;
+    }
+
+    public static String popTestFile() {
+        var testFiles = CURRENT_TEST_FILES.get();
+        return testFiles.isEmpty() ? "" : testFiles.pop();
+    }
+
+    public static boolean shouldIncludeTestFile(String fileName) {
+        return currentSelection().shouldIncludeTestFile(fileName);
+    }
+
+    public static boolean shouldExecuteTest(String testName) {
+        return currentSelection().shouldExecuteTest(currentTestFile(), testName);
+    }
+
+    public static boolean shouldIncludeTest(String testName) {
+        return currentSelection().shouldIncludeTest(currentTestFile(), testName);
+    }
+
+    static List<String> availableTests(List<CapyTest.TestFile> testFiles) {
+        return testFiles.stream()
+                .flatMap(testFile -> testFile.test_cases().stream()
+                        .map(testCase -> testId(testFile, testCase)))
+                .toList();
+    }
+
+    static List<CapyTest.TestFile> filterTestFiles(
+            List<CapyTest.TestFile> testFiles,
+            List<String> testSelectors
+    ) {
+        if (testSelectors == null || testSelectors.isEmpty()) {
+            return testFiles;
+        }
+
+        var selectors = testSelectors.stream()
+                .map(Selector::parse)
+                .toList();
+        var matched = new boolean[selectors.size()];
+        var filteredFiles = new ArrayList<CapyTest.TestFile>();
+
+        for (var testFile : testFiles) {
+            for (int i = 0; i < selectors.size(); i++) {
+                if (!selectors.get(i).hasTestName() && selectors.get(i).matchesFile(testFile.file_name())) {
+                    matched[i] = true;
+                }
+            }
+
+            var filteredCases = new ArrayList<CapyTest.TestCase>();
+            for (var testCase : testFile.test_cases()) {
+                var include = false;
+                for (int i = 0; i < selectors.size(); i++) {
+                    if (selectors.get(i).matches(testFile.file_name(), testCase.name())) {
+                        matched[i] = true;
+                        include = true;
+                    }
+                }
+                if (include) {
+                    filteredCases.add(testCase);
+                }
+            }
+
+            if (!filteredCases.isEmpty()) {
+                filteredFiles.add(new CapyTest.TestFile(
+                        testFile.file_name(),
+                        filteredCases,
+                        testFile.timestamp()
+                ));
+            }
+        }
+
+        var missingSelectors = new ArrayList<String>();
+        for (int i = 0; i < matched.length; i++) {
+            if (!matched[i]) {
+                missingSelectors.add(selectors.get(i).raw());
+            }
+        }
+        if (missingSelectors.size() == 1) {
+            throw new IllegalArgumentException("Test selector `%s` did not match any test".formatted(missingSelectors.getFirst()));
+        }
+        if (!missingSelectors.isEmpty()) {
+            throw new IllegalArgumentException("Test selectors did not match any test: %s".formatted(
+                    String.join(", ", missingSelectors.stream()
+                            .map(selector -> "`" + selector + "`")
+                            .toList())
+            ));
+        }
+
+        return filteredFiles;
+    }
+
+    private static String currentTestFile() {
+        var testFiles = CURRENT_TEST_FILES.get();
+        return testFiles.isEmpty() ? "" : testFiles.peek();
+    }
+
+    private static String testId(CapyTest.TestFile testFile, CapyTest.TestCase testCase) {
+        return normalizedTestFileName(testFile.file_name()) + ".\"" + escapeTestName(testCase.name()) + "\"";
+    }
+
+    private static String normalizedTestFileName(String fileName) {
+        if (fileName != null && fileName.endsWith(".cfun")) {
+            return fileName.substring(0, fileName.length() - ".cfun".length());
+        }
+        return fileName;
+    }
+
+    private static String escapeTestName(String testName) {
+        return testName
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+    }
+
+    private static String unescapeTestName(String testName) {
+        var result = new StringBuilder();
+        var escaping = false;
+        for (int i = 0; i < testName.length(); i++) {
+            var current = testName.charAt(i);
+            if (escaping) {
+                result.append(current);
+                escaping = false;
+            } else if (current == '\\') {
+                escaping = true;
+            } else {
+                result.append(current);
+            }
+        }
+        if (escaping) {
+            result.append('\\');
+        }
+        return result.toString();
+    }
+
+    record Selection(List<Selector> selectors, boolean availableTests) {
+        static Selection all() {
+            return new Selection(List.of(), false);
+        }
+
+        static Selection from(List<String> testSelectors, boolean availableTests) {
+            var selectors = testSelectors == null
+                    ? List.<Selector>of()
+                    : testSelectors.stream().map(Selector::parse).toList();
+            return new Selection(selectors, availableTests);
+        }
+
+        boolean isDefault() {
+            return selectors.isEmpty() && !availableTests;
+        }
+
+        boolean shouldIncludeTestFile(String fileName) {
+            if (availableTests || selectors.isEmpty()) {
+                return true;
+            }
+            var normalizedFileName = normalizedTestFileName(fileName);
+            return selectors.stream().anyMatch(selector -> selector.fileName().equals(normalizedFileName));
+        }
+
+        boolean shouldExecuteTest(String fileName, String testName) {
+            return !availableTests && shouldIncludeTest(fileName, testName);
+        }
+
+        boolean shouldIncludeTest(String fileName, String testName) {
+            if (availableTests || selectors.isEmpty()) {
+                return true;
+            }
+            return selectors.stream().anyMatch(selector -> selector.matches(fileName, testName));
+        }
+    }
+
+    record Selector(String raw, String fileName, String testName) {
+        static Selector parse(String raw) {
+            var selector = raw.trim();
+            var testNameSeparator = selector.indexOf(".\"");
+            if (testNameSeparator < 0) {
+                return new Selector(raw, normalizedTestFileName(selector), null);
+            }
+            if (!selector.endsWith("\"")) {
+                throw new IllegalArgumentException("Invalid test selector `%s`".formatted(raw));
+            }
+            var fileName = selector.substring(0, testNameSeparator);
+            var testName = selector.substring(testNameSeparator + 2, selector.length() - 1);
+            return new Selector(raw, normalizedTestFileName(fileName), unescapeTestName(testName));
+        }
+
+        boolean hasTestName() {
+            return testName != null;
+        }
+
+        boolean matchesFile(String otherFileName) {
+            return fileName.equals(normalizedTestFileName(otherFileName));
+        }
+
+        boolean matches(String otherFileName, String otherTestName) {
+            return matchesFile(otherFileName) && (testName == null || testName.equals(otherTestName));
+        }
+    }
+}

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
@@ -16,6 +16,7 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -273,6 +274,191 @@ class TestRunnerTest {
         });
 
         assertEquals(CapyTest.LogType.NONE, arguments.logType());
+    }
+
+    @Test
+    void shouldParseRepeatedTestSelectors() {
+        var arguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "JUNIT",
+                "--tests", "/capy/lang/EffectTest",
+                "--tests", "/capy/lang/EffectTest.\"should run pure value\""
+        });
+
+        assertEquals(
+                List.of(
+                        "/capy/lang/EffectTest",
+                        "/capy/lang/EffectTest.\"should run pure value\""
+                ),
+                arguments.testSelectors()
+        );
+    }
+
+    @Test
+    void shouldParseAvailableTestsWithoutReportOutputOptions() {
+        var arguments = TestRunner.parseArguments(new String[]{"--available-tests"});
+
+        assertTrue(arguments.availableTests());
+        assertTrue(arguments.testSelectors().isEmpty());
+    }
+
+    @Test
+    void shouldListAvailableTestsAsRunnableSelectors() {
+        var testFiles = List.of(
+                testFile(
+                        "/capy/lang/EffectTest.cfun",
+                        passed("should run pure value"),
+                        passed("should map \"quoted\" value")
+                ),
+                testFile("/capy/lang/StringTest.cfun", passed("should escape \\ values"))
+        );
+
+        assertEquals(
+                List.of(
+                        "/capy/lang/EffectTest.\"should run pure value\"",
+                        "/capy/lang/EffectTest.\"should map \\\"quoted\\\" value\"",
+                        "/capy/lang/StringTest.\"should escape \\\\ values\""
+                ),
+                TestRunner.availableTests(testFiles)
+        );
+    }
+
+    @Test
+    void shouldFilterAllTestsFromSelectedFile() {
+        var testFiles = List.of(
+                testFile(
+                        "/capy/lang/EffectTest.cfun",
+                        passed("should run pure value"),
+                        passed("should map value")
+                ),
+                testFile("/capy/lang/StringTest.cfun", passed("should start with prefix"))
+        );
+
+        var filtered = TestRunner.filterTestFiles(testFiles, List.of("/capy/lang/EffectTest"));
+
+        assertEquals(1, filtered.size());
+        assertEquals("/capy/lang/EffectTest.cfun", filtered.getFirst().file_name());
+        assertEquals(
+                List.of("should run pure value", "should map value"),
+                filtered.getFirst().test_cases().stream().map(TestCase::name).toList()
+        );
+    }
+
+    @Test
+    void shouldFilterOnlySelectedTestCase() {
+        var testFiles = List.of(testFile(
+                "/capy/lang/EffectTest.cfun",
+                passed("should run pure value"),
+                passed("should map value")
+        ));
+
+        var filtered = TestRunner.filterTestFiles(
+                testFiles,
+                List.of("/capy/lang/EffectTest.\"should run pure value\"")
+        );
+
+        assertEquals(1, filtered.size());
+        assertEquals(
+                List.of("should run pure value"),
+                filtered.getFirst().test_cases().stream().map(TestCase::name).toList()
+        );
+    }
+
+    @Test
+    void shouldUnescapeSelectedTestCaseName() {
+        var testFiles = List.of(testFile(
+                "/capy/lang/EffectTest.cfun",
+                passed("should map \"quoted\" value"),
+                passed("should escape \\ values")
+        ));
+
+        var filtered = TestRunner.filterTestFiles(
+                testFiles,
+                List.of(
+                        "/capy/lang/EffectTest.\"should map \\\"quoted\\\" value\"",
+                        "/capy/lang/EffectTest.\"should escape \\\\ values\""
+                )
+        );
+
+        assertEquals(
+                List.of("should map \"quoted\" value", "should escape \\ values"),
+                filtered.getFirst().test_cases().stream().map(TestCase::name).toList()
+        );
+    }
+
+    @Test
+    void shouldFailWhenSelectedTestDoesNotExist() {
+        var testFiles = List.of(testFile("/capy/lang/EffectTest.cfun", passed("should run pure value")));
+
+        var exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> TestRunner.filterTestFiles(testFiles, List.of("/capy/lang/EffectTest.\"missing\""))
+        );
+
+        assertEquals(
+                "Test selector `/capy/lang/EffectTest.\"missing\"` did not match any test",
+                exception.getMessage()
+        );
+    }
+
+    @Test
+    void shouldNotExecuteUnselectedTestBodies() {
+        var executed = new AtomicInteger();
+        var previousSelection = TestSelection.setSelection(TestSelection.Selection.from(
+                List.of("/capy/lang/SelectionTest.\"selected\""),
+                false
+        ));
+        try {
+            var testFile = CapyTest.testFile(
+                    "/capy/lang/SelectionTest.cfun",
+                    List.of(
+                            CapyTest.test("selected", () -> {
+                                executed.incrementAndGet();
+                                return capy.test.Assert.assertThat("capybara").startsWith("capy");
+                            }),
+                            CapyTest.test("skipped", () -> {
+                                executed.addAndGet(100);
+                                return capy.test.Assert.assertThat("capybara").startsWith("capy");
+                            })
+                    )
+            ).unsafeRun();
+
+            assertEquals(1, executed.get());
+            assertEquals(
+                    List.of("selected"),
+                    testFile.test_cases().stream().map(TestCase::name).toList()
+            );
+        } finally {
+            TestSelection.restoreSelection(previousSelection);
+        }
+    }
+
+    @Test
+    void shouldListAvailableTestsWithoutExecutingBodies() {
+        var previousSelection = TestSelection.setSelection(TestSelection.Selection.from(List.of(), true));
+        try {
+            var testFile = CapyTest.testFile(
+                    "/capy/lang/SelectionTest.cfun",
+                    List.of(
+                            CapyTest.test("first", () -> {
+                                throw new AssertionError("available tests should not execute bodies");
+                            }),
+                            CapyTest.test("second", () -> {
+                                throw new AssertionError("available tests should not execute bodies");
+                            })
+                    )
+            ).unsafeRun();
+
+            assertEquals(
+                    List.of(
+                            "/capy/lang/SelectionTest.\"first\"",
+                            "/capy/lang/SelectionTest.\"second\""
+                    ),
+                    TestRunner.availableTests(List.of(testFile))
+            );
+        } finally {
+            TestSelection.restoreSelection(previousSelection);
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #126.

## Summary
- Added repeated `--tests` selectors and `--available-tests` to `TestRunner`.
- Added runner-controlled test selection so unselected Capy test bodies are not executed.
- Exposed the same options through `testCapybara` Gradle tasks.

## Tests
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :lib:capybara-lib:test --tests dev.capylang.test.TestRunnerTest --console=plain`
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew :build-tool:gradle:test --tests dev.capylang.CapybaraPluginTest --console=plain`
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew -q :lib:capybara-lib:testCapybara --available-tests --console=plain`
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew -q :lib:capybara-lib:testCapybara --tests '/capy/lang/ResultTest."should map success"' --console=plain`\n- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew clean check --console=plain`\n\n## Performance\n- Baseline `clean check`: 211.50s on fresh `master`.\n- This branch `clean check`: 213.10s.\n- Difference: +1.60s, about +0.8%, within normal local run-to-run noise.