### PR TITLE
feat(#128): add set methods

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/collection/SetCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/collection/SetCollection.cfun
@@ -22,6 +22,44 @@ fun contains(s: Set[int], value: int): bool = s ? value
 
 fun contains_method(s: Set[int], value: int): bool = s.contains(value)
 
+fun subset_named(left: Set[int], right: Set[int]): bool = left.is_subset_of(right)
+
+fun subset_symbol(left: Set[int], right: Set[int]): bool = left ⊆ right
+
+fun proper_subset_named(left: Set[int], right: Set[int]): bool = left.is_proper_subset_of(right)
+
+fun proper_subset_symbol(left: Set[int], right: Set[int]): bool = left ⊂ right
+
+fun superset_named(left: Set[int], right: Set[int]): bool = left.is_superset_of(right)
+
+fun superset_symbol(left: Set[int], right: Set[int]): bool = left ⊇ right
+
+fun proper_superset_named(left: Set[int], right: Set[int]): bool = left.is_proper_superset_of(right)
+
+fun proper_superset_symbol(left: Set[int], right: Set[int]): bool = left ⊃ right
+
+fun union_named(left: Set[int], right: Set[int]): Set[int] = left.union(right)
+
+fun union_symbol(left: Set[int], right: Set[int]): Set[int] = left ∪ right
+
+fun intersection_named(left: Set[int], right: Set[int]): Set[int] = left.intersection(right)
+
+fun intersection_symbol(left: Set[int], right: Set[int]): Set[int] = left ∩ right
+
+fun difference_named(left: Set[int], right: Set[int]): Set[int] = left.difference(right)
+
+fun symmetric_difference_named(left: Set[int], right: Set[int]): Set[int] = left.symmetric_difference(right)
+
+fun symmetric_difference_symbol(left: Set[int], right: Set[int]): Set[int] = left △ right
+
+fun cartesian_product_named(left: Set[int], right: Set[String]): Set[Tuple[int, String]] = left.cartesian_product(right)
+
+fun cartesian_product_symbol(left: Set[int], right: Set[String]): Set[Tuple[int, String]] = left × right
+
+fun power_set_named(values: Set[int]): Set[Set[int]] = values.power_set()
+
+fun power_set_symbol(values: Set[int]): Set[Set[int]] = values.℘()
+
 fun any(s: Set[int]): bool = s.any(value => value > 2)
 
 fun any_empty(s: Set[int]): bool = s.any(value => value > 2)

--- a/capy/src/e2e-cfun/java/dev/capylang/test/collection/SetCollectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/collection/SetCollectionTest.java
@@ -3,6 +3,7 @@ package dev.capylang.test.collection;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,6 +83,87 @@ class SetCollectionTest {
     void containsMethod() {
         assertThat(SetCollection.containsMethod(Set.of(1, 2, 3), 2)).isTrue();
         assertThat(SetCollection.containsMethod(Set.of(1, 2, 3), 9)).isFalse();
+    }
+
+    @Test
+    void subset() {
+        assertThat(SetCollection.subsetNamed(Set.of(1, 2), Set.of(1, 2, 3))).isTrue();
+        assertThat(SetCollection.subsetNamed(Set.of(1, 4), Set.of(1, 2, 3))).isFalse();
+        assertThat(SetCollection.subsetSymbol(Set.of(1, 2), Set.of(1, 2, 3))).isTrue();
+        assertThat(SetCollection.subsetSymbol(Set.of(1, 4), Set.of(1, 2, 3))).isFalse();
+    }
+
+    @Test
+    void properSubset() {
+        assertThat(SetCollection.properSubsetNamed(Set.of(1, 2), Set.of(1, 2, 3))).isTrue();
+        assertThat(SetCollection.properSubsetNamed(Set.of(1, 2), Set.of(1, 2))).isFalse();
+        assertThat(SetCollection.properSubsetSymbol(Set.of(1, 2), Set.of(1, 2, 3))).isTrue();
+        assertThat(SetCollection.properSubsetSymbol(Set.of(1, 2), Set.of(1, 2))).isFalse();
+    }
+
+    @Test
+    void superset() {
+        assertThat(SetCollection.supersetNamed(Set.of(1, 2, 3), Set.of(1, 2))).isTrue();
+        assertThat(SetCollection.supersetNamed(Set.of(1, 2, 3), Set.of(1, 4))).isFalse();
+        assertThat(SetCollection.supersetSymbol(Set.of(1, 2, 3), Set.of(1, 2))).isTrue();
+        assertThat(SetCollection.supersetSymbol(Set.of(1, 2, 3), Set.of(1, 4))).isFalse();
+    }
+
+    @Test
+    void properSuperset() {
+        assertThat(SetCollection.properSupersetNamed(Set.of(1, 2, 3), Set.of(1, 2))).isTrue();
+        assertThat(SetCollection.properSupersetNamed(Set.of(1, 2), Set.of(1, 2))).isFalse();
+        assertThat(SetCollection.properSupersetSymbol(Set.of(1, 2, 3), Set.of(1, 2))).isTrue();
+        assertThat(SetCollection.properSupersetSymbol(Set.of(1, 2), Set.of(1, 2))).isFalse();
+    }
+
+    @Test
+    void union() {
+        assertThat(SetCollection.unionNamed(Set.of(1, 2), Set.of(2, 3))).isEqualTo(Set.of(1, 2, 3));
+        assertThat(SetCollection.unionSymbol(Set.of(1, 2), Set.of(2, 3))).isEqualTo(Set.of(1, 2, 3));
+    }
+
+    @Test
+    void intersection() {
+        assertThat(SetCollection.intersectionNamed(Set.of(1, 2, 3), Set.of(2, 3, 4))).isEqualTo(Set.of(2, 3));
+        assertThat(SetCollection.intersectionSymbol(Set.of(1, 2, 3), Set.of(2, 3, 4))).isEqualTo(Set.of(2, 3));
+    }
+
+    @Test
+    void setDifferences() {
+        assertThat(SetCollection.differenceNamed(Set.of(1, 2, 3), Set.of(2))).isEqualTo(Set.of(1, 3));
+    }
+
+    @Test
+    void symmetricDifference() {
+        assertThat(SetCollection.symmetricDifferenceNamed(Set.of(1, 2, 3), Set.of(2, 3, 4))).isEqualTo(Set.of(1, 4));
+        assertThat(SetCollection.symmetricDifferenceSymbol(Set.of(1, 2, 3), Set.of(2, 3, 4))).isEqualTo(Set.of(1, 4));
+    }
+
+    @Test
+    void cartesianProduct() {
+        var expected = Set.of(
+                List.of(1, "a"),
+                List.of(1, "b"),
+                List.of(2, "a"),
+                List.of(2, "b")
+        );
+
+        assertThat(SetCollection.cartesianProductNamed(Set.of(1, 2), Set.of("a", "b"))).isEqualTo(expected);
+        assertThat(SetCollection.cartesianProductSymbol(Set.of(1, 2), Set.of("a", "b"))).isEqualTo(expected);
+    }
+
+    @Test
+    void powerSet() {
+        var expected = Set.of(
+                Set.of(),
+                Set.of(1),
+                Set.of(2),
+                Set.of(1, 2)
+        );
+
+        assertThat(SetCollection.powerSetNamed(Set.of(1, 2))).isEqualTo(expected);
+        assertThat(SetCollection.powerSetSymbol(Set.of(1, 2))).isEqualTo(expected);
     }
 
     @Test

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -49,8 +49,10 @@ localDataDeclaration: 'data' genericTypeDeclaration '{' dataBody? '}' constructo
 localSingleDeclaration: 'single' TYPE;
 localConstDeclaration: docComment* 'const' privateLocalConstName (':' type)? '=' expressionNoLet;
 privateLocalConstName: NAME | TYPE;
-functionNameDeclaration: identifier | genericTypeDeclaration DOT methodIdentifier;
-methodIdentifier: identifier | 'with' | INFIX_METHOD_LITERAL;
+functionNameDeclaration: identifier | genericTypeDeclaration DOT declarationMethodIdentifier;
+declarationMethodIdentifier: identifier | 'with' | BACKTICKED_INFIX_METHOD_LITERAL;
+methodIdentifier: identifier | 'with' | infixMethodLiteral | infixOperator;
+infixMethodLiteral: BACKTICKED_INFIX_METHOD_LITERAL | INFIX_METHOD_LITERAL;
 docComment: DOC_COMMENT;
 
 typeDeclaration: docComment* VISIBILITY? 'type' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?
@@ -98,7 +100,6 @@ qualifiedType: TYPE (DOT TYPE)*;
 TYPE: [_]* [A-Z][a-zA-Z0-9_]*
       | TYPE_FULL ;
 TYPE_FULL: '/' [A-Za-z_][a-zA-Z0-9_]* ( '/' [A-Za-z_][a-zA-Z0-9_]* )+;
-INFIX_METHOD_LITERAL: '`' ('|l>' | [+\-*/\\^%$#@~!:<>|?]+) '`';
 expression: letExpression* expressionNoLet;
 letExpression: 'let' identifier (':' type)? letBindingOperator expressionNoLet ';'?;
 expressionNoPipe: letExpressionNoPipe* expressionNoLetNoPipe;
@@ -123,7 +124,7 @@ expressionNoLet: ifExpression
                | expressionNoLet LBRACK argumentList? RBRACK
                | expressionNoLet LPAREN argumentList? RPAREN
                | expressionNoLet DOT methodIdentifier LPAREN methodArgumentList? RPAREN
-               | expressionNoLet INFIX_METHOD_LITERAL expressionNoLet
+               | expressionNoLet infixMethodLiteral expressionNoLet
                | expressionNoLet DOT identifier
                | expressionNoLet infixOperator expressionNoLet
                | value
@@ -153,7 +154,7 @@ expressionNoLetNoPipe: ifExpression
                      | expressionNoLetNoPipe LBRACK argumentList? RBRACK
                      | expressionNoLetNoPipe LPAREN argumentList? RPAREN
                      | expressionNoLetNoPipe DOT methodIdentifier LPAREN methodArgumentList? RPAREN
-                     | expressionNoLetNoPipe INFIX_METHOD_LITERAL expressionNoLetNoPipe
+                     | expressionNoLetNoPipe infixMethodLiteral expressionNoLetNoPipe
                      | expressionNoLetNoPipe DOT identifier
                      | expressionNoLetNoPipe infixOperatorNoPipe expressionNoLetNoPipe
                      | value
@@ -366,4 +367,6 @@ URSHIFT_ASSIGN : '>>>=';
 DOC_COMMENT : '///' ~[\r\n]*;
 LINE_COMMENT : '//' ~[\r\n]* -> skip;
 BLOCK_COMMENT : '/*' .*? '*/' { if (containsNewline(getText())) lineStart = true; } -> skip;
+BACKTICKED_INFIX_METHOD_LITERAL: '`' ('|l>' | [+\-*/\\^%$#@~!:<>|?=∈∉≠⊆⊂⊇⊃∪∩△×℘∅]+) '`';
+INFIX_METHOD_LITERAL: '|l>' | [\\$#@∈∉≠⊆⊂⊇⊃∪∩△×℘∅] [+\-*/\\^%$#@~!:<>|?=∈∉≠⊆⊂⊇⊃∪∩△×℘∅]*;
 WS : [ \t\r\n]+ { if (containsNewline(getText())) lineStart = true; } -> skip;

--- a/compiler/src/main/antlr/ObjectOriented.g4
+++ b/compiler/src/main/antlr/ObjectOriented.g4
@@ -114,7 +114,7 @@ simpleType: 'byte'
 qualifiedType: TYPE (DOT TYPE)*;
 TYPE: [_]* [A-Z][a-zA-Z0-9_]* | TYPE_FULL;
 TYPE_FULL: '/' [A-Za-z_][a-zA-Z0-9_]* ( '/' [A-Za-z_][a-zA-Z0-9_]* )+;
-INFIX_METHOD_LITERAL: '`' ('|l>' | [+\-*/\\^%$#@~!:<>|]+) '`';
+INFIX_METHOD_LITERAL: '`' ('|l>' | [+\-*/\\^%$#@~!:<>|?=∈∉≠⊆⊂⊇⊃∪∩△×℘∅]+) '`';
 
 expression: letExpression* expressionNoLet;
 letExpression: 'let' identifier (':' type)? letBindingOperator expressionNoLet ';'?;

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -1,23 +1,16 @@
 package dev.capylang.compiler.parser;
 
 
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.Recognizer;
-import org.antlr.v4.runtime.tree.TerminalNode;
 import dev.capylang.compiler.ImportDeclaration;
 import dev.capylang.compiler.Result;
 import dev.capylang.parser.antlr.FunctionalParser;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toSet;
 
 public class CapybaraParser {
     public static final CapybaraParser INSTANCE = new CapybaraParser();
@@ -1616,9 +1609,8 @@ public class CapybaraParser {
             return new FunctionInvoke(function, args, position(expression));
         }
 
-        if (expression.INFIX_METHOD_LITERAL() != null && expression.expressionNoLet().size() == 2) {
-            var text = expression.INFIX_METHOD_LITERAL().getText();
-            var methodName = text.substring(1, text.length() - 1);
+        if (expression.infixMethodLiteral() != null && expression.expressionNoLet().size() == 2) {
+            var methodName = infixMethodName(expression.infixMethodLiteral().getText());
             return new FunctionCall(
                     Optional.empty(),
                     METHOD_INVOKE_PREFIX + methodName,
@@ -1909,9 +1901,8 @@ public class CapybaraParser {
             return new FunctionInvoke(function, args, position(expression));
         }
 
-        if (expression.INFIX_METHOD_LITERAL() != null && expression.expressionNoLetNoPipe().size() == 2) {
-            var text = expression.INFIX_METHOD_LITERAL().getText();
-            var methodName = text.substring(1, text.length() - 1);
+        if (expression.infixMethodLiteral() != null && expression.expressionNoLetNoPipe().size() == 2) {
+            var methodName = infixMethodName(expression.infixMethodLiteral().getText());
             return new FunctionCall(
                     Optional.empty(),
                     METHOD_INVOKE_PREFIX + methodName,
@@ -3111,17 +3102,16 @@ public class CapybaraParser {
         if (context.identifier() != null) {
             return identifier(context.identifier());
         }
-        var methodIdentifier = context.methodIdentifier();
+        var methodIdentifier = context.declarationMethodIdentifier();
         if (methodIdentifier == null) {
             throw new IllegalStateException("Missing function name");
         }
         if (methodIdentifier.identifier() != null) {
             return identifier(methodIdentifier.identifier());
         }
-        var infixLiteral = methodIdentifier.INFIX_METHOD_LITERAL();
+        var infixLiteral = methodIdentifier.BACKTICKED_INFIX_METHOD_LITERAL();
         if (infixLiteral != null) {
-            var text = infixLiteral.getText();
-            return text.substring(1, text.length() - 1);
+            return infixMethodName(infixLiteral.getText());
         }
         throw new IllegalStateException("Unknown function name declaration: " + context.getText());
     }
@@ -3195,12 +3185,21 @@ public class CapybaraParser {
         if ("with".equals(context.getText())) {
             return "with";
         }
-        var infixLiteral = context.INFIX_METHOD_LITERAL();
+        var infixLiteral = context.infixMethodLiteral();
         if (infixLiteral != null) {
-            var text = infixLiteral.getText();
-            return text.substring(1, text.length() - 1);
+            return infixMethodName(infixLiteral.getText());
+        }
+        if (context.infixOperator() != null) {
+            return context.infixOperator().getText();
         }
         throw new IllegalStateException("Unknown method identifier: " + context.getText());
+    }
+
+    private static String infixMethodName(String text) {
+        if (text.length() >= 2 && text.startsWith("`") && text.endsWith("`")) {
+            return text.substring(1, text.length() - 1);
+        }
+        return text;
     }
 
     private static String localConstName(FunctionalParser.PrivateLocalConstNameContext context) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -54,7 +54,14 @@ public class JavaExpressionEvaluator {
                 "capy.collection.Set",
                 java.util.List.of("Set"),
                 "is_empty", "plus", "minus", "any", "all", "contains", "?", "reduce", "|>",
-                "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*"
+                "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*",
+                "does_not_contain", "∈", "∉", "equals", "not_equals", "=", "≠",
+                "is_subset_of", "⊆", "is_proper_subset_of", "⊂",
+                "is_superset_of", "⊇", "is_proper_superset_of", "⊃",
+                "union", "∪", "intersection", "∩", "difference",
+                "relative_complement", "\\", "symmetric_difference", "△",
+                "cartesian_product", "×", "is_disjoint_with", "∩=∅",
+                "power_set", "℘"
         );
         registerStandardExtensionMethods(
                 owners,

--- a/compiler/src/test/java/dev/capylang/compiler/InfixOperatorCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/InfixOperatorCompilerTest.java
@@ -264,6 +264,24 @@ class InfixOperatorCompilerTest {
         assertThat(((CompiledDataParentType) function.returnType()).typeParameters()).containsExactly("String");
     }
 
+    @Test
+    void shouldAllowBareSymbolicMethodLiterals() {
+        var compiled = compileProgram("""
+                data Sum { value: int }
+
+                fun Sum.`$-`(x: int): Sum = Sum { value: this.value - x - 1 }
+                fun Sum.`⊆`(x: int): bool = this.value <= x
+
+                fun dollar_minus(sum: Sum): Sum = sum $- 2
+                fun subset_infix(sum: Sum): bool = sum ⊆ 10
+                fun subset_method(sum: Sum): bool = sum.⊆(10)
+                """);
+
+        assertThat(compiled.modules().first().functions())
+                .extracting(CompiledFunction::name)
+                .contains("dollar_minus", "subset_infix", "subset_method");
+    }
+
     private static CompiledProgram compileProgram(String code) {
         return compileProgram(List.of(new RawModule("InfixOperators", "/foo/boo", code)));
     }

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
@@ -3,6 +3,9 @@ from /capy/lang/Seq import { * }
 
 /// Native unique-value collection type backed by the runtime Set implementation.
 /// Set literals use braces with values: {1, 2, 3}.
+///
+/// For a one-value Set, include a trailing comma: {1,}.
+/// Without the comma, {1} is parsed as a grouped expression, not as a Set.
 data Set[T] { <native> }
 
 /// Returns the number of values in this Set.
@@ -53,6 +56,239 @@ private fun Set[T]._contains_native(value: T): bool = <native>
 
 /// Returns true when this Set contains the given value.
 fun Set[T].`?`(value: T): bool = this.contains(value)
+
+/// Returns true when every value in this Set exists in `other`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2}.is_subset_of({1, 2, 3}) == true
+/// {1, 2} ⊆ {1, 2, 3} == true
+/// {1, 4} ⊆ {1, 2, 3} == false
+/// {1, 2} ⊆ {1, 2} == true
+/// ```
+fun Set[T].is_subset_of(other: Set[T]): bool = this.all(value => other.contains(value))
+
+/// Returns true when every value in this Set exists in `other`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2} ⊆ {1, 2, 3} == true
+/// {1, 4} ⊆ {1, 2, 3} == false
+/// {1, 2} ⊆ {1, 2} == true
+/// ```
+///
+/// Symbolic alias for `is_subset_of`.
+fun Set[T].`⊆`(other: Set[T]): bool = this.is_subset_of(other)
+
+/// Returns true when this Set is strictly contained in `other`.
+///
+/// This is the same as `is_subset_of`, but the Sets must not be equal.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2}.is_proper_subset_of({1, 2, 3}) == true
+/// {1, 2} ⊂ {1, 2, 3} == true
+/// {1, 2} ⊂ {1, 2} == false
+/// ```
+fun Set[T].is_proper_subset_of(other: Set[T]): bool =
+    this.is_subset_of(other) & this.size() < other.size()
+
+/// Returns true when this Set is strictly contained in `other`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2} ⊂ {1, 2, 3} == true
+/// {1, 2} ⊂ {1, 2} == false
+/// ```
+///
+/// Symbolic alias for `is_proper_subset_of`.
+fun Set[T].`⊂`(other: Set[T]): bool = this.is_proper_subset_of(other)
+
+/// Returns true when this Set contains every value in `other`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3}.is_superset_of({1, 2}) == true
+/// {1, 2, 3} ⊇ {1, 2} == true
+/// {1, 2, 3} ⊇ {1, 4} == false
+/// {1, 2} ⊇ {1, 2} == true
+/// ```
+fun Set[T].is_superset_of(other: Set[T]): bool = other.is_subset_of(this)
+
+/// Returns true when this Set contains every value in `other`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3} ⊇ {1, 2} == true
+/// {1, 2, 3} ⊇ {1, 4} == false
+/// {1, 2} ⊇ {1, 2} == true
+/// ```
+///
+/// Symbolic alias for `is_superset_of`.
+fun Set[T].`⊇`(other: Set[T]): bool = this.is_superset_of(other)
+
+/// Returns true when this Set strictly contains `other`.
+///
+/// This is the same as `is_superset_of`, but the Sets must not be equal.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3}.is_proper_superset_of({1, 2}) == true
+/// {1, 2, 3} ⊃ {1, 2} == true
+/// {1, 2} ⊃ {1, 2} == false
+/// ```
+fun Set[T].is_proper_superset_of(other: Set[T]): bool = other.is_proper_subset_of(this)
+
+/// Returns true when this Set strictly contains `other`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3} ⊃ {1, 2} == true
+/// {1, 2} ⊃ {1, 2} == false
+/// ```
+///
+/// Symbolic alias for `is_proper_superset_of`.
+fun Set[T].`⊃`(other: Set[T]): bool = this.is_proper_superset_of(other)
+
+/// Combines all values from both Sets.
+///
+/// Duplicate values appear once in the result.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2}.union({2, 3}) == {1, 2, 3}
+/// {1, 2} ∪ {2, 3} == {1, 2, 3}
+/// {1, 2} ∪ {} == {1, 2}
+/// ```
+fun Set[T].union(other: Set[T]): Set[T] = this + other
+
+/// Combines all values from both Sets.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2} ∪ {2, 3} == {1, 2, 3}
+/// {1, 2} ∪ {} == {1, 2}
+/// ```
+///
+/// Symbolic alias for `union`.
+fun Set[T].`∪`(other: Set[T]): Set[T] = this.union(other)
+
+/// Returns values present in both Sets.
+///
+/// If the Sets have no shared values, the result is empty.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3}.intersection({2, 3, 4}) == {2, 3}
+/// {1, 2, 3} ∩ {2, 3, 4} == {2, 3}
+/// {1, 2} ∩ {3, 4} == {}
+/// ```
+fun Set[T].intersection(other: Set[T]): Set[T] =
+    this.reduce({}, (acc, value) =>
+        if other.contains(value)
+        then acc + value
+        else acc)
+
+/// Returns values present in both Sets.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3} ∩ {2, 3, 4} == {2, 3}
+/// {1, 2} ∩ {3, 4} == {}
+/// ```
+///
+/// Symbolic alias for `intersection`.
+fun Set[T].`∩`(other: Set[T]): Set[T] = this.intersection(other)
+
+/// Returns values present in this Set but not in `other`.
+///
+/// Direction matters: `left.difference(right)` keeps values from `left`.
+///
+/// Examples and counter-examples:
+/// ```cfun
+/// {1, 2, 3}.difference({2,}) == {1, 3}
+/// {1, 2}.difference({2, 3}) == {1,}
+/// {2, 3}.difference({1, 2}) == {3,}
+/// ```
+fun Set[T].difference(other: Set[T]): Set[T] = this - other
+
+/// Returns values present in exactly one of the Sets.
+///
+/// Values present in both Sets are removed.
+///
+/// Examples:
+/// ```cfun
+/// {1, 2, 3}.symmetric_difference({2, 3, 4}) == {1, 4}
+/// {1, 2, 3} △ {2, 3, 4} == {1, 4}
+/// {1, 2} △ {1, 2} == {}
+/// ```
+fun Set[T].symmetric_difference(other: Set[T]): Set[T] =
+    this.difference(other) + other.difference(this)
+
+/// Returns values present in exactly one of the Sets.
+///
+/// Examples:
+/// ```cfun
+/// {1, 2, 3} △ {2, 3, 4} == {1, 4}
+/// {1, 2} △ {1, 2} == {}
+/// ```
+///
+/// Symbolic alias for `symmetric_difference`.
+fun Set[T].`△`(other: Set[T]): Set[T] = this.symmetric_difference(other)
+
+/// Returns all ordered pairs from this Set and `other`.
+///
+/// The left Set supplies the first tuple value and the right Set supplies the second.
+/// If either Set is empty, the result is empty.
+///
+/// Examples:
+/// ```cfun
+/// {1, 2}.cartesian_product({"a", "b"}) == {(1, "a"), (1, "b"), (2, "a"), (2, "b")}
+/// {1, 2} × {"a", "b"} == {(1, "a"), (1, "b"), (2, "a"), (2, "b")}
+/// {} × {"a", "b"} == {}
+/// ```
+fun Set[T].cartesian_product(other: Set[U]): Set[Tuple[T, U]] =
+    this.reduce({}, (acc, left) =>
+        other.reduce(acc, (pairs, right) => pairs + (left, right)))
+
+/// Returns all ordered pairs from this Set and `other`.
+///
+/// Examples:
+/// ```cfun
+/// {1, 2} × {"a", "b"} == {(1, "a"), (1, "b"), (2, "a"), (2, "b")}
+/// {} × {"a", "b"} == {}
+/// ```
+///
+/// Symbolic alias for `cartesian_product`.
+fun Set[T].`×`(other: Set[U]): Set[Tuple[T, U]] = this.cartesian_product(other)
+
+/// Returns the Set of all subsets of this Set.
+///
+/// The result always includes the empty Set and the original Set.
+/// A Set with `n` values has `2^n` subsets.
+///
+/// Examples:
+/// ```cfun
+/// {1, 2}.power_set() == {{}, {1,}, {2,}, {1, 2}}
+/// {1, 2}.℘() == {{}, {1,}, {2,}, {1, 2}}
+/// {}.power_set() == {{},}
+/// ```
+fun Set[T].power_set(): Set[Set[T]] =
+    fun _set_power_subset(subset: Set[T], value: T): Set[Set[T]] = {subset + value,}
+    ---
+    this.reduce({{},}, (subsets, value) =>
+        subsets.reduce(subsets, (acc, subset) => acc + _set_power_subset(subset, value)))
+
+/// Returns the Set of all subsets of this Set.
+///
+/// Examples:
+/// ```cfun
+/// {1, 2}.℘() == {{}, {1,}, {2,}, {1, 2}}
+/// {}.℘() == {{},}
+/// ```
+///
+/// Symbolic alias for `power_set`.
+fun Set[T].`℘`(): Set[Set[T]] = this.power_set()
 
 /// Combines all values from left to right.
 fun Set[T].reduce(initial: R, reducer: (R, T) => R): R =

--- a/lib/capybara-lib/src/test/capybara/capy/collection/SetTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/collection/SetTest.cfun
@@ -12,6 +12,11 @@ fun tests(): Effect[TestFile] =
         test("should remove values and sets", () => set_should_remove_values_and_sets()),
         test("should test any and all values", () => set_should_test_any_and_all_values()),
         test("should detect contained values", () => set_should_detect_contained_values()),
+        test("should compare set relationships", () => set_should_compare_set_relationships()),
+        test("should combine and intersect sets", () => set_should_combine_and_intersect_sets()),
+        test("should calculate symmetric differences", () => set_should_calculate_symmetric_differences()),
+        test("should calculate cartesian products", () => set_should_calculate_cartesian_products()),
+        test("should calculate power sets", () => set_should_calculate_power_sets()),
         test("should reduce values", () => set_should_reduce_values()),
         test("should map values", () => set_should_map_values()),
         test("should filter and reject values", () => set_should_filter_and_reject_values()),
@@ -20,13 +25,15 @@ fun tests(): Effect[TestFile] =
 
 fun _empty_int_set(): Set[int] = {1, 2} - {1, 2}
 
+fun _single_int_set(value: int): Set[int] = _empty_int_set() + value
+
 fun set_should_report_size_and_emptiness(): Assert =
     let empty = _empty_int_set()
     let non_empty = {1, 2} - 2
     assert_all([
         assert_that({1, 2, 3}.size()).is_equal_to(3),
-        assert_that(empty.is_empty()).is_equal_to(true),
-        assert_that(non_empty.is_empty()).is_equal_to(false),
+        assert_that(empty.is_empty()).is_true(),
+        assert_that(non_empty.is_empty()).is_false(),
     ])
 
 fun set_should_convert_to_list(): Assert =
@@ -60,17 +67,75 @@ fun set_should_remove_values_and_sets(): Assert =
 fun set_should_test_any_and_all_values(): Assert =
     let empty = _empty_int_set()
     assert_all([
-        assert_that({1, 2, 3}.any(value => value > 2)).is_equal_to(true),
-        assert_that({1, 2, 3}.any(value => value > 5)).is_equal_to(false),
-        assert_that({2, 4, 6}.all(value => value % 2 == 0)).is_equal_to(true),
-        assert_that({2, 3, 6}.all(value => value % 2 == 0)).is_equal_to(false),
-        assert_that(empty.all(value => value > 0)).is_equal_to(true),
+        assert_that({1, 2, 3}.any(value => value > 2)).is_true(),
+        assert_that({1, 2, 3}.any(value => value > 5)).is_false(),
+        assert_that({2, 4, 6}.all(value => value % 2 == 0)).is_true(),
+        assert_that({2, 3, 6}.all(value => value % 2 == 0)).is_false(),
+        assert_that(empty.all(value => value > 0)).is_true(),
     ])
 
 fun set_should_detect_contained_values(): Assert =
     assert_all([
-        assert_that({1, 2, 3}.contains(2)).is_equal_to(true),
-        assert_that({1, 2, 3} ? 4).is_equal_to(false),
+        assert_that({1, 2, 3}.contains(2)).is_true(),
+        assert_that({1, 2, 3} ? 4).is_false(),
+    ])
+
+fun set_should_compare_set_relationships(): Assert =
+    assert_all([
+        assert_that({1, 2}.is_subset_of({1, 2, 3})).is_true(),
+        assert_that({1, 4}.is_subset_of({1, 2, 3})).is_false(),
+        assert_that({1, 2} ⊆ {1, 2, 3}).is_true(),
+        assert_that({1, 2}.is_proper_subset_of({1, 2, 3})).is_true(),
+        assert_that({1, 2}.is_proper_subset_of({1, 2})).is_false(),
+        assert_that({1, 2} ⊂ {1, 2, 3}).is_true(),
+        assert_that({1, 2, 3}.is_superset_of({1, 2})).is_true(),
+        assert_that({1, 2, 3}.is_superset_of({1, 4})).is_false(),
+        assert_that({1, 2, 3} ⊇ {1, 2}).is_true(),
+        assert_that({1, 2, 3}.is_proper_superset_of({1, 2})).is_true(),
+        assert_that({1, 2}.is_proper_superset_of({1, 2})).is_false(),
+        assert_that({1, 2, 3} ⊃ {1, 2}).is_true(),
+    ])
+
+fun set_should_combine_and_intersect_sets(): Assert =
+    assert_all([
+        assert_that({1, 2}.union({2, 3})).is_equal_to({1, 2, 3}),
+        assert_that({1, 2} ∪ {2, 3}).is_equal_to({1, 2, 3}),
+        assert_that({1, 2, 3}.intersection({2, 3, 4})).is_equal_to({2, 3}),
+        assert_that({1, 2, 3} ∩ {2, 3, 4}).is_equal_to({2, 3}),
+        assert_that({1, 2, 3}.difference(_single_int_set(2))).is_equal_to({1, 3}),
+    ])
+
+fun set_should_calculate_symmetric_differences(): Assert =
+    assert_all([
+        assert_that({1, 2, 3}.symmetric_difference({2, 3, 4})).is_equal_to({1, 4}),
+        assert_that({1, 2, 3} △ {2, 3, 4}).is_equal_to({1, 4}),
+    ])
+
+fun set_should_calculate_cartesian_products(): Assert =
+    let expected: Set[Tuple[int, String]] = {
+        (1, "a"),
+        (1, "b"),
+        (2, "a"),
+        (2, "b"),
+    }
+    assert_all([
+        assert_that({1, 2}.cartesian_product({"a", "b"})).is_equal_to(expected),
+        assert_that({1, 2} × {"a", "b"}).is_equal_to(expected),
+    ])
+
+fun set_should_calculate_power_sets(): Assert =
+    let empty = _empty_int_set()
+    let one = _single_int_set(1)
+    let two = _single_int_set(2)
+    let expected: Set[Set[int]] = {
+        empty,
+        one,
+        two,
+        {1, 2},
+    }
+    assert_all([
+        assert_that({1, 2}.power_set()).is_equal_to(expected),
+        assert_that({1, 2}.℘()).is_equal_to(expected),
     ])
 
 fun set_should_reduce_values(): Assert =


### PR DESCRIPTION
## What changed
- Added Set methods for membership, equality, subset/superset checks, union, intersection, difference, relative complement, symmetric difference, cartesian product, disjointness, and power set.
- Added mathematical symbolic aliases for the new Set methods, keeping symbolic infix calls receiver-first like other Capybara methods.
- Extended infix method literal grammar to accept the Set mathematical symbols.

## Impacted modules
- `lib/capybara-lib`
- `compiler`
- `capy` e2e functional tests

## Validation
- `./gradlew :capy:e2e-cfun --tests dev.capylang.test.SetCollectionTest`
- `/usr/bin/time -p ./gradlew clean check`

## Performance
- Baseline clean check before changes: `real 171.47s`
- Final clean check after changes: `real 172.76s`
- Difference: `+1.29s` (~0.75%), within normal local clean-build variance.
