### PR TITLE
feat(#127): add Iterator

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/DictCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/DictCollection.cfun
@@ -1,6 +1,8 @@
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/lang/Collections import { * }
+from /capy/lang/Option import { * }
 from /capy/lang/String import { * }
 
 fun static_dict(): Dict[int] = {
@@ -68,3 +70,8 @@ fun dict_to_string(d: Dict[int]): String =
 fun let_named_dict(): int =
     let dict: Dict[int] = { "one": 1, "two": 2 }
     dict.size()
+
+fun iterator_value_sum(d: Dict[int]): int =
+    match d.iterator() with
+    case None -> 0
+    case Some { iterator } -> iterator.reduce(0, (acc, entry) => acc + entry[1])

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ListCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ListCollection.cfun
@@ -1,6 +1,8 @@
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/lang/Collections import { * }
+from /capy/lang/Option import { * }
 
 fun static_list(): List[int] = [1,2,3]
 
@@ -39,3 +41,18 @@ fun size(l: List[int]): int = l.size()
 fun let_named_list(): int =
     let list: List[int] = [1, 2, 3, 4]
     list.size()
+
+fun iterator_sum(l: List[int]): int =
+    match l.iterator() with
+    case None -> 0
+    case Some { iterator } -> iterator.reduce(0, (acc, value) => acc + value)
+
+fun iterator_empty(l: List[int]): bool =
+    match l.iterator() with
+    case None -> true
+    case Some { _ } -> false
+
+fun iterator_map_sum(l: List[int]): int =
+    match l.iterator() with
+    case None -> 0
+    case Some { iterator } -> iterator.map(value => value * 2).reduce(0, (acc, value) => acc + value)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SetCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SetCollection.cfun
@@ -1,6 +1,8 @@
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/lang/Collections import { * }
+from /capy/lang/Option import { * }
 
 fun static_set(): Set[int] = {1,2,3}
 
@@ -43,3 +45,8 @@ fun size(s: Set[int]): int = s.size()
 fun let_named_set(): int =
     let set: Set[int] = {1, 2, 3}
     set.size()
+
+fun iterator_sum(s: Set[int]): int =
+    match s.iterator() with
+    case None -> 0
+    case Some { iterator } -> iterator.reduce(0, (acc, value) => acc + value)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/StringCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/StringCollection.cfun
@@ -1,4 +1,6 @@
 from /capy/lang/Result import { * }
+from /capy/lang/Collections import { * }
+from /capy/lang/Option import { * }
 from /capy/lang/String import { * }
 
 fun contains(s: String, part: String): bool = s ? part
@@ -42,3 +44,13 @@ fun to_double_method(s: String): Result[double] = s.to_double()
 fun to_float_method(s: String): Result[float] = s.to_float()
 
 fun to_bool_method(s: String): Result[bool] = s.to_bool()
+
+fun iterator_copy(s: String): String =
+    match s.iterator() with
+    case None -> ""
+    case Some { iterator } -> iterator.reduce("", (acc, ch) => acc + ch)
+
+fun iterator_empty(s: String): bool =
+    match s.iterator() with
+    case None -> true
+    case Some { _ } -> false

--- a/capy/src/e2e-cfun/java/dev/capylang/test/DictCollectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/DictCollectionTest.java
@@ -199,4 +199,10 @@ class DictCollectionTest {
         var result = DictCollection.dictToString(EXPECTED);
         assertThat(result).isEqualTo("one 1, two 2, three 3");
     }
+
+    @Test
+    void iteratorValueSum() {
+        assertThat(DictCollection.iteratorValueSum(EXPECTED)).isEqualTo(6);
+        assertThat(DictCollection.iteratorValueSum(Map.of())).isZero();
+    }
 }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/ListCollectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/ListCollectionTest.java
@@ -123,4 +123,21 @@ class ListCollectionTest {
     void letNamedList() {
         assertThat(ListCollection.letNamedList()).isEqualTo(4);
     }
+
+    @Test
+    void iteratorSum() {
+        assertThat(ListCollection.iteratorSum(List.of(1, 2, 3))).isEqualTo(6);
+        assertThat(ListCollection.iteratorSum(List.of())).isZero();
+    }
+
+    @Test
+    void iteratorEmpty() {
+        assertThat(ListCollection.iteratorEmpty(List.of())).isTrue();
+        assertThat(ListCollection.iteratorEmpty(List.of(1))).isFalse();
+    }
+
+    @Test
+    void iteratorMapSum() {
+        assertThat(ListCollection.iteratorMapSum(List.of(1, 2, 3))).isEqualTo(12);
+    }
 }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/SetCollectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/SetCollectionTest.java
@@ -134,4 +134,10 @@ class SetCollectionTest {
     void letNamedSet() {
         assertThat(SetCollection.letNamedSet()).isEqualTo(3);
     }
+
+    @Test
+    void iteratorSum() {
+        assertThat(SetCollection.iteratorSum(Set.of(1, 2, 3))).isEqualTo(6);
+        assertThat(SetCollection.iteratorSum(Set.of())).isZero();
+    }
 }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/StringCollectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/StringCollectionTest.java
@@ -173,4 +173,16 @@ class StringCollectionTest {
                 .isInstanceOf(CapybaraException.class)
                 .hasMessage("Cannot parse string to bool: abc");
     }
+
+    @Test
+    void iteratorCopy() {
+        assertThat(StringCollection.iteratorCopy("capybara")).isEqualTo("capybara");
+        assertThat(StringCollection.iteratorCopy("")).isEmpty();
+    }
+
+    @Test
+    void iteratorEmpty() {
+        assertThat(StringCollection.iteratorEmpty("")).isTrue();
+        assertThat(StringCollection.iteratorEmpty("capybara")).isFalse();
+    }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -7478,7 +7478,7 @@ public class CapybaraExpressionCompiler {
             return substitutions.getOrDefault(genericTypeParameter.name(), type);
         }
         if (substitutions.isEmpty()
-            || !containsSubstitutionTarget(type, substitutions.keySet(), Collections.newSetFromMap(new IdentityHashMap<>()))) {
+            || !containsSubstitutionTarget(type, substitutions.keySet(), new HashSet<>())) {
             return type;
         }
         return switch (type) {
@@ -7595,6 +7595,9 @@ public class CapybaraExpressionCompiler {
         if (targetNames.contains(normalized)) {
             return true;
         }
+        if (descriptorReferencesTargetName(normalized, targetNames)) {
+            return true;
+        }
         return parseLinkedTypeDescriptor(normalized)
                 .map(parsed -> containsSubstitutionTarget(parsed, targetNames, visited))
                 .orElse(false);
@@ -7604,15 +7607,68 @@ public class CapybaraExpressionCompiler {
         if (descriptor == null || descriptor.isBlank()) {
             return descriptor;
         }
-        var direct = substitutions.get(descriptor.trim());
+        var normalized = descriptor.trim();
+        var direct = substitutions.get(normalized);
         if (direct != null) {
             return linkedTypeDescriptor(direct);
         }
-        var parsed = parseLinkedTypeDescriptor(descriptor.trim());
-        if (parsed.isPresent()) {
-            return linkedTypeDescriptor(substituteTypeParameters(parsed.get(), substitutions));
+        if (!descriptorReferencesTargetName(normalized, substitutions.keySet())) {
+            return normalized;
         }
-        return descriptor;
+        return substituteDescriptorReferences(normalized, substitutions);
+    }
+
+    private boolean descriptorReferencesTargetName(String descriptor, Set<String> targetNames) {
+        return targetNames.stream().anyMatch(targetName -> descriptorContainsTypeToken(descriptor, targetName));
+    }
+
+    private String substituteDescriptorReferences(String descriptor, Map<String, CompiledType> substitutions) {
+        var substituted = descriptor;
+        for (var entry : substitutions.entrySet()) {
+            substituted = replaceTypeToken(substituted, entry.getKey(), linkedTypeDescriptor(entry.getValue()));
+        }
+        return substituted;
+    }
+
+    private String replaceTypeToken(String descriptor, String targetName, String replacement) {
+        var result = new StringBuilder();
+        var offset = 0;
+        var index = descriptor.indexOf(targetName);
+        while (index >= 0) {
+            if (isTypeTokenBoundary(descriptor, index, targetName.length())) {
+                result.append(descriptor, offset, index);
+                result.append(replacement);
+                offset = index + targetName.length();
+            }
+            index = descriptor.indexOf(targetName, index + targetName.length());
+        }
+        if (offset == 0) {
+            return descriptor;
+        }
+        result.append(descriptor, offset, descriptor.length());
+        return result.toString();
+    }
+
+    private boolean descriptorContainsTypeToken(String descriptor, String targetName) {
+        var index = descriptor.indexOf(targetName);
+        while (index >= 0) {
+            if (isTypeTokenBoundary(descriptor, index, targetName.length())) {
+                return true;
+            }
+            index = descriptor.indexOf(targetName, index + targetName.length());
+        }
+        return false;
+    }
+
+    private boolean isTypeTokenBoundary(String descriptor, int index, int length) {
+        var before = index == 0 || !isTypeNamePart(descriptor.charAt(index - 1));
+        var afterIndex = index + length;
+        var after = afterIndex >= descriptor.length() || !isTypeNamePart(descriptor.charAt(afterIndex));
+        return before && after;
+    }
+
+    private boolean isTypeNamePart(char ch) {
+        return Character.isLetterOrDigit(ch) || ch == '_';
     }
 
     private Optional<CompiledType> parseLinkedTypeDescriptor(String descriptor) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -46,28 +46,28 @@ public class JavaExpressionEvaluator {
                 owners,
                 "capy.collection.List",
                 java.util.List.of("List"),
-                "is_empty", "plus", "minus", "any", "all", "contains", "?", "reduce", "|>",
+                "is_empty", "iterator", "plus", "minus", "any", "all", "contains", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*"
         );
         registerStandardExtensionMethods(
                 owners,
                 "capy.collection.Set",
                 java.util.List.of("Set"),
-                "is_empty", "plus", "minus", "any", "all", "contains", "?", "reduce", "|>",
+                "is_empty", "iterator", "plus", "minus", "any", "all", "contains", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*"
         );
         registerStandardExtensionMethods(
                 owners,
                 "capy.collection.Dict",
                 java.util.List.of("Dict"),
-                "is_empty", "plus", "minus", "any", "all", "contains_key", "?", "reduce", "|>",
+                "is_empty", "iterator", "plus", "minus", "any", "all", "contains_key", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*"
         );
         registerStandardExtensionMethods(
                 owners,
                 "capy.lang.String",
                 java.util.List.of("String"),
-                "is_empty", "plus", "any", "all", "contains", "?", "reduce", "|>",
+                "is_empty", "iterator", "plus", "any", "all", "contains", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*",
                 "starts_with", "end_with", "trim"
         );
@@ -2365,7 +2365,64 @@ public class JavaExpressionEvaluator {
         if (!normalized.endsWith("/Option") && !normalized.endsWith(".Option") && !"Option".equals(parentType.name())) {
             return null;
         }
-        return sanitizePatternCastType(javaCastTypeFromDescriptor(parentType.typeParameters().getFirst()));
+        var castType = optionPayloadJavaCastTypeFromDescriptor(parentType.typeParameters().getFirst());
+        return "java.lang.Object".equals(castType) ? null : castType;
+    }
+
+    private static String optionPayloadJavaCastTypeFromDescriptor(String descriptor) {
+        var normalized = descriptor == null ? "" : descriptor.trim();
+        if (normalized.isEmpty()) {
+            return "java.lang.Object";
+        }
+        return switch (normalized) {
+            case "byte" -> "java.lang.Byte";
+            case "int" -> "java.lang.Integer";
+            case "long" -> "java.lang.Long";
+            case "float" -> "java.lang.Float";
+            case "double" -> "java.lang.Double";
+            case "String" -> "java.lang.String";
+            case "bool" -> "java.lang.Boolean";
+            case "enum" -> "java.lang.Enum<?>";
+            case "any", "nothing", "data" -> "java.lang.Object";
+            default -> {
+                if (normalized.matches("[A-Z]")) {
+                    yield normalized;
+                }
+                if (normalized.startsWith("List[") && normalized.endsWith("]")) {
+                    var inner = normalized.substring("List[".length(), normalized.length() - 1);
+                    yield "java.util.List<" + optionPayloadJavaCastTypeFromDescriptor(inner) + ">";
+                }
+                if (normalized.startsWith("Set[") && normalized.endsWith("]")) {
+                    var inner = normalized.substring("Set[".length(), normalized.length() - 1);
+                    yield "java.util.Set<" + optionPayloadJavaCastTypeFromDescriptor(inner) + ">";
+                }
+                if (normalized.startsWith("Dict[") && normalized.endsWith("]")) {
+                    var inner = normalized.substring("Dict[".length(), normalized.length() - 1);
+                    yield "java.util.Map<java.lang.String, " + optionPayloadJavaCastTypeFromDescriptor(inner) + ">";
+                }
+                if (normalized.startsWith("Tuple[") && normalized.endsWith("]")) {
+                    yield "java.util.List<?>";
+                }
+                var genericStart = normalized.indexOf('[');
+                if (genericStart > 0 && normalized.endsWith("]")) {
+                    var rawType = normalized.substring(0, genericStart).trim();
+                    var argsDescriptor = normalized.substring(genericStart + 1, normalized.length() - 1);
+                    var javaArgs = splitTopLevelDescriptors(argsDescriptor).stream()
+                            .map(JavaExpressionEvaluator::optionPayloadJavaCastTypeFromDescriptor)
+                            .toList();
+                    if (isOptionSomeTypeName(rawType) || isOptionNoneTypeName(rawType)) {
+                        var optionalElementType = javaArgs.isEmpty() ? "java.lang.Object" : javaArgs.getFirst();
+                        yield "java.util.Optional<" + optionalElementType + ">";
+                    }
+                    yield normalizeJavaTypeReference(rawType) + "<" + String.join(", ", javaArgs) + ">";
+                }
+                if ("Error".equals(normalized)
+                    || normalizeQualifiedTypeName(normalized).endsWith("/Result.Error")) {
+                    yield resultErrorJavaTypeReference(normalized);
+                }
+                yield normalizeJavaTypeReference(normalized);
+            }
+        };
     }
 
     private static java.util.Map<String, String> resolveGenericTypeCasts(

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -789,6 +789,45 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldGenerateRecursiveGenericOptionPayloadCasts() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram("IteratorMatch", "/foo/bar", """
+                from /capy/lang/Option import { * }
+
+                type Iterator[T] = IteratorValue[T]
+                data IteratorValue[T] { element: T, next: () => Option[Iterator[T]] }
+
+                fun Iterator[T].reduce(initial: R, reducer: (R, T) => R): R =
+                    fun rec __reduce(iterator: Iterator[T], acc: R, reducer: (R, T) => R): R =
+                        match iterator with
+                        case IteratorValue { element, next } ->
+                            let next_acc = reducer(acc, element)
+                            match next() with
+                            case None -> next_acc
+                            case Some { value } -> __reduce(value, next_acc, reducer)
+                    ---
+                    __reduce(this, initial, reducer)
+
+                fun Iterator[T].map(map: T => Y): Iterator[Y] =
+                    match this with
+                    case IteratorValue { element, next } ->
+                        IteratorValue { map(element), () =>
+                            match next() with
+                            case None -> None {}
+                            case Some { value } -> Some { value.map(map) }
+                        }
+
+                fun sum(iterator: Iterator[int]): int =
+                    iterator.map(value => value * 2).reduce(0, (acc, value) => acc + value)
+                """));
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated).contains("((Iterator<T>)");
+        assertThat(generated).doesNotContain("((Iterator<java.lang.Object>)");
+    }
+
+    @Test
     void shouldGenerateBooleanLiteralMatchCasesUsingBooleanPatternGuards() {
         var generated = new JavaGenerator().generate(compileProgram("BoolMatch", "/foo/bar", """
                 fun mood(value: bool): String =

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Dict.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Dict.cfun
@@ -1,5 +1,6 @@
 from /capy/collection/List import { * }
 from /capy/lang/Option import { * }
+from /capy/lang/Collections import { * }
 
 /// Native String-keyed map type backed by the runtime Dict implementation.
 /// Dict literals use braces with String keys: {"one": 1, "two": 2}.
@@ -13,6 +14,15 @@ fun Dict[T].is_empty(): bool = this.size() == 0
 
 /// Returns this Dict as a List of `(key, value)` tuples.
 fun Dict[T].entries(): List[Tuple[String, T]] = <native>
+
+/// Returns an iterator over this Dict's `(key, value)` entries, or `None` when the Dict is empty.
+fun Dict[T].iterator(): Option[/capy/lang/Collections.Iterator[Tuple[String, T]]] =
+    fun __iterator(dict: Dict[T], idx: int): Option[/capy/lang/Collections.Iterator[Tuple[String, T]]] =
+        match dict.entries()[idx] with
+        case None -> None {}
+        case Some { value } -> Some { /capy/lang/Collections.IteratorValue { value, () => __iterator(dict, idx + 1) } }
+    ---
+    __iterator(this, 0)
 
 /// Returns a new Dict with `entry` added or replaced.
 fun Dict[T].`+`(entry: Tuple[String, T]): Dict[T] = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
@@ -1,5 +1,6 @@
 from /capy/lang/Option import { * }
 from /capy/lang/Seq import { * }
+from /capy/lang/Collections import { * }
 
 /// Native ordered collection type backed by the runtime List implementation.
 /// List literals use square brackets: [1, 2, 3].
@@ -16,6 +17,15 @@ fun List[T].size(): int = <native>
 
 /// Returns true when this List has no values.
 fun List[T].is_empty(): bool = this.size() == 0
+
+/// Returns an iterator over this List, or `None` when the List is empty.
+fun List[T].iterator(): Option[/capy/lang/Collections.Iterator[T]] =
+    fun __iterator(list: List[T], idx: int): Option[/capy/lang/Collections.Iterator[T]] =
+        match list[idx] with
+        case None -> None {}
+        case Some { value } -> Some { /capy/lang/Collections.IteratorValue { value, () => __iterator(list, idx + 1) } }
+    ---
+    __iterator(this, 0)
 
 /// Returns a new List with `value` appended.
 fun List[T].`+`(value: T): List[T] = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
@@ -1,5 +1,7 @@
 from /capy/collection/List import { * }
 from /capy/lang/Seq import { * }
+from /capy/lang/Collections import { * }
+from /capy/lang/Option import { * }
 
 /// Native unique-value collection type backed by the runtime Set implementation.
 /// Set literals use braces with values: {1, 2, 3}.
@@ -13,6 +15,9 @@ fun Set[T].is_empty(): bool = this.size() == 0
 
 /// Returns the Set values as a List.
 fun Set[T].to_list(): List[T] = <native>
+
+/// Returns an iterator over this Set, or `None` when the Set is empty.
+fun Set[T].iterator(): Option[/capy/lang/Collections.Iterator[T]] = this.to_list().iterator()
 
 /// Returns a new Set with `value` included.
 fun Set[T].`+`(value: T): Set[T] = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Collections.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Collections.cfun
@@ -6,25 +6,31 @@ data IteratorValue[T] { element: T, next: () => Option[Iterator[T]] }
 
 /// Returns true when at least one value satisfies `predicate`.
 fun Iterator[T].any(predicate: T => bool): bool =
-    match this with
-    case IteratorValue { element, next } ->
-        if predicate(element)
-        then true
-        else
-            match next() with
-            case None -> false
-            case Some { value } -> value.any(predicate)
+    fun rec __any(iterator: Iterator[T], predicate: T => bool): bool =
+        match iterator with
+        case IteratorValue { element, next } ->
+            if predicate(element)
+            then true
+            else
+                match next() with
+                case None -> false
+                case Some { value } -> __any(value, predicate)
+    ---
+    __any(this, predicate)
 
 /// Returns true when every value satisfies `predicate`.
 fun Iterator[T].all(predicate: T => bool): bool =
-    match this with
-    case IteratorValue { element, next } ->
-        if !predicate(element)
-        then false
-        else
-            match next() with
-            case None -> true
-            case Some { value } -> value.all(predicate)
+    fun rec __all(iterator: Iterator[T], predicate: T => bool): bool =
+        match iterator with
+        case IteratorValue { element, next } ->
+            if !predicate(element)
+            then false
+            else
+                match next() with
+                case None -> true
+                case Some { value } -> __all(value, predicate)
+    ---
+    __all(this, predicate)
 
 /// Combines all values from left to right.
 fun Iterator[T].reduce(initial: R, reducer: (R, T) => R): R =

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Collections.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Collections.cfun
@@ -1,3 +1,53 @@
+from /capy/lang/Option import { * }
+
+/// Non-empty lazy iterator over values of type `T`.
+type Iterator[T] = IteratorValue[T]
+data IteratorValue[T] { element: T, next: () => Option[Iterator[T]] }
+
+/// Returns true when at least one value satisfies `predicate`.
+fun Iterator[T].any(predicate: T => bool): bool =
+    match this with
+    case IteratorValue { element, next } ->
+        if predicate(element)
+        then true
+        else
+            match next() with
+            case None -> false
+            case Some { value } -> value.any(predicate)
+
+/// Returns true when every value satisfies `predicate`.
+fun Iterator[T].all(predicate: T => bool): bool =
+    match this with
+    case IteratorValue { element, next } ->
+        if !predicate(element)
+        then false
+        else
+            match next() with
+            case None -> true
+            case Some { value } -> value.all(predicate)
+
+/// Combines all values from left to right.
+fun Iterator[T].reduce(initial: R, reducer: (R, T) => R): R =
+    fun rec __reduce(iterator: Iterator[T], acc: R, reducer: (R, T) => R): R =
+        match iterator with
+        case IteratorValue { element, next } ->
+            let next_acc = reducer(acc, element)
+            match next() with
+            case None -> next_acc
+            case Some { value } -> __reduce(value, next_acc, reducer)
+    ---
+    __reduce(this, initial, reducer)
+
+/// Transforms each value lazily using `map`.
+fun Iterator[T].map(map: T => Y): Iterator[Y] =
+    match this with
+    case IteratorValue { element, next } ->
+        IteratorValue { map(element), () =>
+            match next() with
+            case None -> None {}
+            case Some { value } -> Some { value.map(map) }
+        }
+
 /// Native fixed-size ordered collection type backed by the runtime Tuple implementation.
 /// Tuple literals use parentheses with at least two values: (1, "two").
 data Tuple { <native> }

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -1,10 +1,18 @@
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/lang/Collections import { * }
+from /capy/lang/Option import { * }
 
 type Seq[T] = Cons[T] | End
 data Cons[T] { value: T, rest: () => Seq[T] }
 single End
+
+/// Returns an iterator over this Seq, or `None` when the Seq is empty.
+fun Seq[T].iterator(): Option[/capy/lang/Collections.Iterator[T]] =
+    match this with
+    case End -> None {}
+    case Cons { value, rest } -> Some { /capy/lang/Collections.IteratorValue { value, () => rest().iterator() } }
 
 /// Returns an infinite sequence of natural numbers starting at `0`.
 ///

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -20,6 +20,15 @@ fun String.get(from: int, to: int): String = <native>
 /// Returns true when this String has no characters.
 fun String.is_empty(): bool = this.length() == 0
 
+/// Returns an iterator over this String's characters, or `None` when the String is empty.
+fun String.iterator(): Option[/capy/lang/Collections.Iterator[String]] =
+    fun __iterator(value: String, idx: int): Option[/capy/lang/Collections.Iterator[String]] =
+        match value[idx] with
+        case None -> None {}
+        case Some { char } -> Some { /capy/lang/Collections.IteratorValue { char, () => __iterator(value, idx + 1) } }
+    ---
+    __iterator(this, 0)
+
 /// Returns this String with `value` appended.
 fun String.`+`(value: any): String = <native>
 

--- a/lib/capybara-lib/src/test/capybara/capy/lang/SeqTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/SeqTest.cfun
@@ -20,6 +20,8 @@ fun tests(): Effect[TestFile] =
         test("should return empty when first match missing", () => should_return_empty_when_first_match_missing()),
         test("should detect any matching element", () => should_detect_any_matching_element()),
         test("should detect no matching element", () => should_detect_no_matching_element()),
+        test("iterator any should scan deeply without stack overflow", () => iterator_any_should_scan_deeply_without_stack_overflow()),
+        test("iterator all should scan deeply without stack overflow", () => iterator_all_should_scan_deeply_without_stack_overflow()),
         test("should iterate sequence", () => should_iterate_sequence()),
     ])
 
@@ -88,6 +90,16 @@ fun should_detect_any_matching_element(): Assert =
 fun should_detect_no_matching_element(): Assert =
     let seq = to_seq([1, 2, 3])
     assert_that(seq.any(x => x > 10)).is_equal_to(false)
+
+fun iterator_any_should_scan_deeply_without_stack_overflow(): Assert =
+    match natural_seq().iterator() with
+    case None -> assert_that(false).is_equal_to(true)
+    case Some { iterator } -> assert_that(iterator.any(x => x == 50_000)).is_equal_to(true)
+
+fun iterator_all_should_scan_deeply_without_stack_overflow(): Assert =
+    match natural_seq().iterator() with
+    case None -> assert_that(false).is_equal_to(true)
+    case Some { iterator } -> assert_that(iterator.all(x => x < 50_000)).is_equal_to(false)
 
 fun should_iterate_sequence(): Assert =
     let seq = to_seq([1, 2, 3])

--- a/lib/capybara-lib/src/test/capybara/capy/lang/SeqTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/SeqTest.cfun
@@ -1,4 +1,5 @@
 from /capy/test/Assert import { * }
+from /capy/lang/Collections import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Seq import { * }
 from /capy/test/CapyTest import { * }
@@ -19,6 +20,7 @@ fun tests(): Effect[TestFile] =
         test("should return empty when first match missing", () => should_return_empty_when_first_match_missing()),
         test("should detect any matching element", () => should_detect_any_matching_element()),
         test("should detect no matching element", () => should_detect_no_matching_element()),
+        test("should iterate sequence", () => should_iterate_sequence()),
     ])
 
 fun should_assert_finite_sequence(): Assert =
@@ -86,3 +88,11 @@ fun should_detect_any_matching_element(): Assert =
 fun should_detect_no_matching_element(): Assert =
     let seq = to_seq([1, 2, 3])
     assert_that(seq.any(x => x > 10)).is_equal_to(false)
+
+fun should_iterate_sequence(): Assert =
+    let seq = to_seq([1, 2, 3])
+    let sum =
+        match seq.iterator() with
+        case None -> 0
+        case Some { iterator } -> iterator.reduce(0, (acc, value) => acc + value)
+    assert_that(sum).is_equal_to(6)


### PR DESCRIPTION
## Summary
- add a lazy `Iterator[T]` abstraction with `any`, `all`, `reduce`, and lazy `map`
- add iterator methods for `List`, `Set`, `Dict`, `String`, and `Seq`
- route set traversal through iterators and fix recursive generic option payload Java generation

## Impacted modules
- `compiler`
- `lib/capybara-lib`
- `capy` e2e functional tests

## Testing
- `./gradlew :compiler:test --tests dev.capylang.generator.java.JavaExpressionEvaluatorTest.shouldGenerateRecursiveGenericOptionPayloadCasts`
- `./gradlew :lib:capybara-lib:testCapybara :capy:e2e-cfun`
- `/usr/bin/time -p ./gradlew clean check` -> `real 169.89`

## Performance
Baseline `clean check` on `codex/109-native-proper-types`: `real 168.65`. Final run: `real 169.89`, about 1.24s slower (~0.7%), with no material regression observed.

CLOSE #127