### PR TITLE
feat(#138): generate CTRF test reports

### DIFF
--- a/build-tool/gradle/src/main/java/dev.capylang/CapybaraPlugin.java
+++ b/build-tool/gradle/src/main/java/dev.capylang/CapybaraPlugin.java
@@ -244,7 +244,7 @@ public class CapybaraPlugin implements Plugin<Project> {
                                 : mainSourceSet.getRuntimeClasspath();
                         task.getRuntimeClasspath().from(mainRuntimeClasspath, testSourceSet.getOutput().getClassesDirs());
                         task.getOutputDir().set(capybaraTestResultsDir);
-                        task.getReportType().set("JUNIT");
+                        task.getReportType().set("JUNIT_CTRF");
                         task.getLogType().set("NONE");
                         task.getTests().convention(List.of());
                         task.getPrintAvailableTests().convention(false);

--- a/build-tool/gradle/src/test/java/dev/capylang/CapybaraPluginTest.java
+++ b/build-tool/gradle/src/test/java/dev/capylang/CapybaraPluginTest.java
@@ -618,6 +618,14 @@ class CapybaraPluginTest {
     }
 
     @Test
+    void shouldDefaultCapybaraTestReportTypeToJUnitAndCtrf() {
+        var project = newProject(List.of("check"));
+        var testCapybara = project.getTasks().named("testCapybara", CapybaraTestTask.class).get();
+
+        assertEquals("JUNIT_CTRF", testCapybara.getReportType().get());
+    }
+
+    @Test
     void shouldDefaultCapybaraTestSelectionOptions() {
         var project = newProject(List.of("check"));
         var testCapybara = project.getTasks().named("testCapybara", CapybaraTestTask.class).get();

--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -963,6 +963,9 @@ public final class JavaGenerator implements Generator {
         if (isCapyTestCurrentLogTypeMethod(ownerPackage, ownerName, method)) {
             return mapCapyTestCurrentLogTypeMethod(method, visibility, methodTypeParameters);
         }
+        if (isCapyTestCtrfJsonEscapeMethod(ownerPackage, ownerName, method)) {
+            return mapCapyTestCtrfJsonEscapeMethod(method, visibility, methodTypeParameters);
+        }
         if (isCapyTestSelectionMethod(ownerPackage, ownerName, method)) {
             return mapCapyTestSelectionMethod(method, visibility, methodTypeParameters);
         }
@@ -1084,6 +1087,24 @@ public final class JavaGenerator implements Generator {
         return mapJavaDoc(method.comments())
                + visibility + "static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "() {\n"
                + "return capy.lang.Effect.delay(dev.capylang.test.TestLog::currentLogType);\n"
+               + "}\n";
+    }
+
+    private boolean isCapyTestCtrfJsonEscapeMethod(String ownerPackage, String ownerName, JavaMethod method) {
+        return "capy.test".equals(ownerPackage)
+               && "CapyTest".equals(ownerName)
+               && "ctrf_json_escape".equals(method.sourceName())
+               && method.parameters().size() == 1
+               && method.sourceParameterTypes().size() == 1
+               && method.sourceParameterTypes().getFirst() == PrimitiveLinkedType.STRING
+               && method.sourceReturnType() == PrimitiveLinkedType.STRING
+               && isNativeExpression(method);
+    }
+
+    private String mapCapyTestCtrfJsonEscapeMethod(JavaMethod method, String visibility, String methodTypeParameters) {
+        return mapJavaDoc(method.comments())
+               + visibility + "static " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
+               + "return dev.capylang.test.CtrfJson.escape(" + method.parameters().getFirst().generatedName() + ");\n"
                + "}\n";
     }
 

--- a/lib/capybara-lib/build.gradle
+++ b/lib/capybara-lib/build.gradle
@@ -615,7 +615,7 @@ def testCapybaraJava = tasks.register('testCapybaraJava', InProcessCapybaraTestT
                     : capybaraTestRuntimeClasspath
     )
     outputDir.set(capybaraTestResultsDir)
-    reportType.set('JUNIT')
+    reportType.set('JUNIT_CTRF')
 }
 
 def testCapybaraJavaScript = tasks.register('testCapybaraJavaScript', NodeTask) {
@@ -629,7 +629,7 @@ def testCapybaraJavaScript = tasks.register('testCapybaraJavaScript', NodeTask) 
     args.set([
             '--generated-dir', capybaraGeneratedTestJsDir.get().asFile.absolutePath,
             '--output-dir', capybaraJsTestResultsDir.get().asFile.absolutePath,
-            '--report-type', 'JUNIT',
+            '--report-type', 'JUNIT_CTRF',
             '--log', 'TC'
     ])
     inputs.file(capybaraJsTestRunner)

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -14,7 +14,7 @@ from /capy/date_time/Clock import { now }
 from /capy/date_time/DateTime import { * }
 from /capy/lang/System import { nano_time }
 
-data TestFile { file_name: String, test_cases: List[TestCase], timestamp: String }
+data TestFile { file_name: String, test_cases: List[TestCase], timestamp: String, timestamp_millis: long }
 data TestCase { name: String, result: TestResult, assertions_count: int, execution_time: double }
 type TestResult = Passed | Failed
 single Passed
@@ -43,7 +43,8 @@ fun test_file(file_name: String, test_cases: List[Effect[TestCase]]): Effect[Tes
     TestFile {
         file_name: file_name,
         test_cases: executed_test_cases,
-        timestamp: current.to_iso_8601()
+        timestamp: current.to_iso_8601(),
+        timestamp_millis: current.timestamp() * 1000L
     }
 
 fun test(name: String, assert_supplier: () => Assert): Effect[TestCase] =
@@ -111,8 +112,8 @@ fun TestCase.failed(): bool =
     case Passed -> false
     case Failed -> true
 
-enum ReportType { JUNIT }
-type Report = JUnitReport
+enum ReportType { JUNIT, CTRF, JUNIT_CTRF }
+type Report = JUnitReport | CtrfReport
 
 /// See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml)
 data JUnitReport { suites: List[JUnitTestSuite] }
@@ -150,12 +151,16 @@ fun JUnitFailure.`+`(other_message: String): JUnitFailure =
         call_stack: this.call_stack
     }
 
+data CtrfReport { report: String }
+
 data TestOutput { path: Path, content: String, failed: bool }
 data TestRun { outputs: List[TestOutput], written_files: List[Path], failure_summary: String, failed: bool }
 
 fun run_tests(rtype: ReportType, test_files: List[TestFile]): List[TestOutput] =
     match rtype with
     case JUNIT -> junit_run_tests(test_files)
+    case CTRF -> ctrf_run_tests(test_files)
+    case JUNIT_CTRF -> junit_run_tests(test_files) + ctrf_run_tests(test_files)
 
 fun run_tests(rtype: ReportType, output_dir: Path, test_files: List[TestFile]): Effect[Result[TestRun]] =
     let outputs = run_tests(rtype, test_files)
@@ -535,6 +540,8 @@ private fun path_segments_to_string(segments: List[String]): String =
 private fun has_failures(test_outputs: List[TestOutput]): bool = test_outputs.any(output => output.failed)
 
 const JUNIT_PREFIX = 'TEST-'
+const CTRF_REPORT_FILE = 'ctrf-report.json'
+const CTRF_SPEC_VERSION = '0.0.0'
 
 private fun junit_run_tests(test_files: List[TestFile]): List[TestOutput] = (test_files | :junit_run_test).as_list()
 
@@ -578,3 +585,108 @@ private fun junit_escape_xml_attribute(value: String): String =
         .replace('>', '&gt;')
         .replace('"', '&quot;')
         .replace("'", '&apos;')
+
+private fun ctrf_run_tests(test_files: List[TestFile]): List[TestOutput] = [
+    TestOutput {
+        path: from_string(CTRF_REPORT_FILE),
+        content: ctrf_report(test_files),
+        failed: ctrf_failed_count(test_files) > 0
+    }
+]
+
+fun ctrf_report(test_files: List[TestFile]): String =
+    let start = ctrf_start_millis(test_files)
+    let duration = ctrf_total_duration_millis(test_files)
+    "{"
+    + '"reportFormat":"CTRF",'
+    + '"specVersion":' + ctrf_json_string(CTRF_SPEC_VERSION) + ','
+    + '"timestamp":' + ctrf_json_string(ctrf_timestamp(test_files)) + ','
+    + '"generatedBy":"Capybara",'
+    + '"results":{'
+    + '"tool":{"name":"Capybara"},'
+    + '"summary":{'
+    + '"tests":' + ctrf_tests_count(test_files) + ','
+    + '"passed":' + ctrf_passed_count(test_files) + ','
+    + '"failed":' + ctrf_failed_count(test_files) + ','
+    + '"skipped":0,'
+    + '"pending":0,'
+    + '"other":0,'
+    + '"suites":' + test_files.size() + ','
+    + '"start":' + start + ','
+    + '"stop":' + (start + duration) + ','
+    + '"duration":' + duration
+    + '},'
+    + '"tests":[' + ctrf_test_cases(test_files) + ']'
+    + '}'
+    + '}'
+
+private fun ctrf_test_cases(test_files: List[TestFile]): String =
+    test_files |> '', (acc, test_file) =>
+        let cases = ctrf_test_cases_for_file(test_file)
+        if cases.is_empty()
+        then acc
+        else acc + ctrf_comma(acc) + cases
+
+private fun ctrf_test_cases_for_file(test_file: TestFile): String =
+    test_file.test_cases |> '', (acc, test_case) =>
+        acc + ctrf_comma(acc) + ctrf_test_case(test_file, test_case)
+
+private fun ctrf_test_case(test_file: TestFile, test_case: TestCase): String =
+    let duration = ctrf_duration_millis(test_case)
+    "{"
+    + '"name":' + ctrf_json_string(test_case.name) + ','
+    + '"status":' + ctrf_json_string(ctrf_status(test_case)) + ','
+    + '"duration":' + duration + ','
+    + '"suite":[' + ctrf_json_string(test_file.file_name) + '],'
+    + '"filePath":' + ctrf_json_string(test_file.file_name)
+    + ctrf_failure_fields(test_case)
+    + '}'
+
+private fun ctrf_failure_fields(test_case: TestCase): String =
+    match test_case.result with
+    case Passed -> ''
+    case Failed { message, type } ->
+        let normalized_message = normalize_failure_message(message)
+        ',"message":' + ctrf_json_string(normalized_message)
+        + ',"trace":' + ctrf_json_string(normalized_message)
+        + ',"extra":{"failureType":' + ctrf_json_string(type) + '}'
+
+private fun ctrf_status(test_case: TestCase): String =
+    if test_case.failed()
+    then 'failed'
+    else 'passed'
+
+private fun ctrf_timestamp(test_files: List[TestFile]): String =
+    match test_files[0] with
+    case None -> '1970-01-01T00:00:00Z'
+    case Some { test_file } -> test_file.timestamp
+
+private fun ctrf_start_millis(test_files: List[TestFile]): long =
+    match test_files[0] with
+    case None -> 0L
+    case Some { test_file } -> test_file.timestamp_millis
+
+private fun ctrf_total_duration_millis(test_files: List[TestFile]): long =
+    test_files |> 0L, (acc, test_file) =>
+        acc + (test_file.test_cases |> 0L, (test_acc, test_case) => test_acc + ctrf_duration_millis(test_case))
+
+private fun ctrf_duration_millis(test_case: TestCase): long =
+    (test_case.execution_time * 1000.0).to_long()
+
+private fun ctrf_tests_count(test_files: List[TestFile]): int =
+    test_files |> 0, (acc, test_file) => acc + test_file.test_cases.size()
+
+private fun ctrf_passed_count(test_files: List[TestFile]): int =
+    test_files |> 0, (acc, test_file) =>
+        acc + (test_file.test_cases |> 0, (test_acc, test_case) => if test_case.succeeded() then test_acc + 1 else test_acc)
+
+private fun ctrf_failed_count(test_files: List[TestFile]): int =
+    test_files |> 0, (acc, test_file) =>
+        acc + (test_file.test_cases |> 0, (test_acc, test_case) => if test_case.failed() then test_acc + 1 else test_acc)
+
+private fun ctrf_comma(value: String): String = if value.is_empty() then '' else ','
+
+private fun ctrf_json_string(value: String): String =
+    '"' + ctrf_json_escape(value) + '"'
+
+private fun ctrf_json_escape(value: String): String = <native>

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/CtrfJson.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/CtrfJson.java
@@ -1,0 +1,41 @@
+package dev.capylang.test;
+
+public final class CtrfJson {
+    private CtrfJson() {
+    }
+
+    public static String escape(String value) {
+        var escaped = new StringBuilder(value.length());
+        for (var i = 0; i < value.length(); ) {
+            var codePoint = value.codePointAt(i);
+            appendEscaped(escaped, codePoint);
+            i += Character.charCount(codePoint);
+        }
+        return escaped.toString();
+    }
+
+    private static void appendEscaped(StringBuilder escaped, int codePoint) {
+        switch (codePoint) {
+            case '"' -> escaped.append("\\\"");
+            case '\\' -> escaped.append("\\\\");
+            case '\b' -> escaped.append("\\b");
+            case '\f' -> escaped.append("\\f");
+            case '\n' -> escaped.append("\\n");
+            case '\r' -> escaped.append("\\r");
+            case '\t' -> escaped.append("\\t");
+            default -> {
+                if (codePoint < 0x20) {
+                    appendUnicodeEscape(escaped, codePoint);
+                } else {
+                    escaped.appendCodePoint(codePoint);
+                }
+            }
+        }
+    }
+
+    private static void appendUnicodeEscape(StringBuilder escaped, int codePoint) {
+        escaped.append("\\u00");
+        escaped.append(Character.forDigit(codePoint / 0x10, 16));
+        escaped.append(Character.forDigit(codePoint % 0x10, 16));
+    }
+}

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
@@ -141,7 +141,9 @@ public class TestRunner {
     }
 
     public enum ReportType {
-        JUNIT
+        JUNIT,
+        CTRF,
+        JUNIT_CTRF
     }
 
     private static void printHelp() {
@@ -149,7 +151,7 @@ public class TestRunner {
                 Usage: java -jar test-runner.jar [options]
                 Options:
                   -o, --output-dir <dir>    Output directory for test reports (required)
-                  -rt, --report-type <type> Report type (required, e.g., JUNIT)
+                  -rt, --report-type <type> Report type (required, JUNIT, CTRF, JUNIT_CTRF)
                   -l, --log <type>          Log output type (optional, LOG, TC, TEAM_CITY)
                   --tests <selector>        Run only tests matching selector; can be repeated
                   --available-tests         Print available test selectors and exit

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestSelection.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestSelection.java
@@ -106,7 +106,8 @@ public final class TestSelection {
                 filteredFiles.add(new CapyTest.TestFile(
                         testFile.file_name(),
                         filteredCases,
-                        testFile.timestamp()
+                        testFile.timestamp(),
+                        testFile.timestamp_millis()
                 ));
             }
         }

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
@@ -277,6 +277,21 @@ class TestRunnerTest {
     }
 
     @Test
+    void shouldParseCtrfReportOutputTypes() {
+        var ctrfArguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "CTRF"
+        });
+        var junitCtrfArguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "JUNIT_CTRF"
+        });
+
+        assertEquals(TestRunner.ReportType.CTRF, ctrfArguments.reportType());
+        assertEquals(TestRunner.ReportType.JUNIT_CTRF, junitCtrfArguments.reportType());
+    }
+
+    @Test
     void shouldParseRepeatedTestSelectors() {
         var arguments = TestRunner.parseArguments(new String[]{
                 "-o", tempDir.toString(),
@@ -509,6 +524,55 @@ class TestRunnerTest {
     }
 
     @Test
+    void shouldRenderCtrfReportForTestRun() {
+        var report = CapyTest.ctrfReport(List.of(testFile(
+                "/capy/lang/StringTest.cfun",
+                passed("starts_with should pass"),
+                failed("starts_with should fail", "Expected string:\ncapybara\nto start with:\nbara", "assertion failed")
+        )));
+
+        assertTrue(report.contains("\"reportFormat\":\"CTRF\""));
+        assertTrue(report.contains("\"specVersion\":\"0.0.0\""));
+        assertTrue(report.contains("\"tool\":{\"name\":\"Capybara\"}"));
+        assertTrue(report.contains("\"summary\":{\"tests\":2,\"passed\":1,\"failed\":1,\"skipped\":0,\"pending\":0,\"other\":0,\"suites\":1,\"start\":0,\"stop\":0,\"duration\":0}"));
+        assertTrue(report.contains("\"name\":\"starts_with should pass\",\"status\":\"passed\",\"duration\":0,\"suite\":[\"/capy/lang/StringTest.cfun\"],\"filePath\":\"/capy/lang/StringTest.cfun\""));
+        assertTrue(report.contains("\"name\":\"starts_with should fail\",\"status\":\"failed\",\"duration\":0,\"suite\":[\"/capy/lang/StringTest.cfun\"],\"filePath\":\"/capy/lang/StringTest.cfun\",\"message\":\"Expected string:\\ncapybara\\nto start with:\\nbara\",\"trace\":\"Expected string:\\ncapybara\\nto start with:\\nbara\",\"extra\":{\"failureType\":\"assertion failed\"}"));
+    }
+
+    @Test
+    void shouldEscapeJsonControlCharactersInCtrfReport() {
+        var controlCharacters = controlCharacters();
+        var escapedControlCharacters = escapedControlCharacters();
+        var message = "line" + (char) 0 + "\b\fbreak";
+        var report = CapyTest.ctrfReport(List.of(testFile(
+                "/capy/lang/StringTest.cfun",
+                failed("control" + controlCharacters + "name", message, "assertion failed")
+        )));
+
+        assertFalse(report.chars().anyMatch(character -> character < 0x20));
+        assertTrue(report.contains("\"name\":\"control" + escapedControlCharacters + "name\""));
+        assertTrue(report.contains("\"message\":\"line\\u0000\\b\\fbreak\""));
+        assertTrue(report.contains("\"trace\":\"line\\u0000\\b\\fbreak\""));
+    }
+
+    @Test
+    void shouldWriteJUnitAndCtrfReportsTogether() throws Exception {
+        var run = successValue(CapyTest.runTests(
+                CapyTest.ReportType.JUNIT_CTRF,
+                PathUtil.fromJavaPath(tempDir),
+                List.of(testFile("/capy/lang/MathTest", passed("should_pass")))
+        ).unsafeRun());
+
+        assertEquals(
+                List.of(relativePath("TEST-capy.lang.MathTest.xml"), relativePath("ctrf-report.json")),
+                run.written_files()
+        );
+        assertTrue(Files.exists(tempDir.resolve("TEST-capy.lang.MathTest.xml")));
+        assertTrue(Files.readString(tempDir.resolve("ctrf-report.json")).contains("\"reportFormat\":\"CTRF\""));
+        assertEquals("TEST-capy.lang.MathTest.xml\nctrf-report.json\n", Files.readString(tempDir.resolve(OUTPUT_MANIFEST_FILE)));
+    }
+
+    @Test
     void shouldPrintTeamCityMessagesWhileExecutingTestFile() {
         var originalOut = System.out;
         var previousLogType = TestLog.currentLogType();
@@ -554,7 +618,7 @@ class TestRunnerTest {
     }
 
     private static TestFile testFile(String fileName, TestCase... testCases) {
-        return new TestFile(fileName, List.of(testCases), "1970-01-01T00:00:00Z");
+        return new TestFile(fileName, List.of(testCases), "1970-01-01T00:00:00Z", 0L);
     }
 
     private static TestCase passed(String name) {
@@ -567,6 +631,21 @@ class TestRunnerTest {
 
     private static TestCase failed(String name, String message, String type) {
         return new TestCase(name, new CapyTest.Failed(message, type), 1, 0.0);
+    }
+
+    private static String controlCharacters() {
+        var controlCharacters = new StringBuilder();
+        for (var character = 0; character < 0x20; character++) {
+            controlCharacters.append((char) character);
+        }
+        return controlCharacters.toString();
+    }
+
+    private static String escapedControlCharacters() {
+        return "\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007"
+               + "\\b\\t\\n\\u000b\\f\\r\\u000e\\u000f"
+               + "\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017"
+               + "\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f";
     }
 
     private static Path relativePath(String... segments) {

--- a/lib/capybara-lib/src/test/js/run-capybara-tests.js
+++ b/lib/capybara-lib/src/test/js/run-capybara-tests.js
@@ -40,8 +40,8 @@ function parseArgs(argv) {
     if (!options.availableTests && !options.outputDir) {
         throw new Error('Missing --output-dir');
     }
-    if (!options.availableTests && options.reportType !== 'JUNIT') {
-        throw new Error('Only JUNIT report type is supported');
+    if (!options.availableTests && !['JUNIT', 'CTRF', 'JUNIT_CTRF'].includes(options.reportType)) {
+        throw new Error('Supported report types are JUNIT, CTRF, and JUNIT_CTRF');
     }
     return options;
 }
@@ -199,25 +199,34 @@ function evaluateAssertions(value) {
 }
 
 function runCase(testCase) {
+    const start = Date.now();
     const startedAt = process.hrtime.bigint();
     try {
         const bodyResult = typeof testCase.body === 'function' ? testCase.body() : testCase.result;
         const assertions = evaluateAssertions(bodyResult);
         const failed = assertions.find(assertion => !assertion.result);
+        const durationMs = Math.max(0, Math.round(Number(process.hrtime.bigint() - startedAt) / 1_000_000));
         return {
             name: testCase.name,
             assertions,
             failed,
             error: null,
-            time: Number(process.hrtime.bigint() - startedAt) / 1_000_000_000,
+            time: durationMs / 1000,
+            durationMs,
+            start,
+            stop: start + durationMs,
         };
     } catch (error) {
+        const durationMs = Math.max(0, Math.round(Number(process.hrtime.bigint() - startedAt) / 1_000_000));
         return {
             name: testCase.name,
             assertions: [],
             failed: { result: false, message: error && error.stack ? error.stack : String(error), type: 'Error' },
             error,
-            time: Number(process.hrtime.bigint() - startedAt) / 1_000_000_000,
+            time: durationMs / 1000,
+            durationMs,
+            start,
+            stop: start + durationMs,
         };
     }
 }
@@ -291,6 +300,62 @@ function reportPath(outputDir, fileName) {
     return path.join(outputDir, `TEST-${normalized}.xml`);
 }
 
+function shouldWriteJUnit(reportType) {
+    return reportType === 'JUNIT' || reportType === 'JUNIT_CTRF';
+}
+
+function shouldWriteCtrf(reportType) {
+    return reportType === 'CTRF' || reportType === 'JUNIT_CTRF';
+}
+
+function ctrfReport(suites, start, stop) {
+    const tests = suites.flatMap(suite => suite.results.map(result => {
+        const test = {
+            name: result.name,
+            status: result.failed ? 'failed' : 'passed',
+            duration: result.durationMs,
+            start: result.start,
+            stop: result.stop,
+            suite: [suite.fileName],
+            filePath: suite.fileName,
+        };
+        if (result.failed) {
+            test.message = String(result.failed.message ?? '');
+            test.trace = String(result.failed.message ?? '');
+            test.extra = { failureType: String(result.failed.type ?? 'Assertion') };
+        }
+        return test;
+    }));
+    const failed = tests.filter(test => test.status === 'failed').length;
+    const report = {
+        reportFormat: 'CTRF',
+        specVersion: '0.0.0',
+        timestamp: new Date(stop).toISOString(),
+        generatedBy: 'Capybara',
+        results: {
+            tool: { name: 'Capybara' },
+            summary: {
+                tests: tests.length,
+                passed: tests.length - failed,
+                failed,
+                skipped: 0,
+                pending: 0,
+                other: 0,
+                suites: suites.length,
+                start,
+                stop,
+                duration: Math.max(0, stop - start),
+            },
+            tests,
+        },
+    };
+    return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+function ctrfReportPath(outputDir) {
+    return path.join(outputDir, 'ctrf-report.json');
+}
+
 function run(options) {
     const runtimePath = path.resolve(options.generatedDir, 'capy', 'test', 'CapyTestRuntime.js');
     const runtime = require(runtimePath);
@@ -305,6 +370,8 @@ function run(options) {
     fs.mkdirSync(options.outputDir, { recursive: true });
 
     let failed = false;
+    const suites = [];
+    const runStartedAt = Date.now();
     for (const testFile of files) {
         const fileName = testFileName(testFile);
         logSuiteStarted(options.log, fileName);
@@ -320,7 +387,13 @@ function run(options) {
             results.push(result);
         }
         logSuiteFinished(options.log, fileName);
-        fs.writeFileSync(reportPath(options.outputDir, fileName), suiteReport(testFile, results));
+        suites.push({ testFile, fileName, results });
+        if (shouldWriteJUnit(options.reportType)) {
+            fs.writeFileSync(reportPath(options.outputDir, fileName), suiteReport(testFile, results));
+        }
+    }
+    if (shouldWriteCtrf(options.reportType)) {
+        fs.writeFileSync(ctrfReportPath(options.outputDir), ctrfReport(suites, runStartedAt, Date.now()));
     }
     return failed ? 1 : 0;
 }


### PR DESCRIPTION
## What changed
- Added CTRF and JUNIT_CTRF report modes to the Capybara test runtime.
- Generate ctrf-report.json alongside existing JUnit XML for Java and JavaScript Capybara test tasks by default.
- Preserved JUnit XML output and test selection metadata while adding CTRF summary/test entries.
- Escaped all JSON control characters in Java CTRF string values; JavaScript keeps using JSON.stringify.

## Impacted modules
- lib/capybara-lib
- build-tool/gradle
- compiler

## Verification
- ./gradlew :lib:capybara-lib:test --no-daemon
- ./gradlew :build-tool:gradle:test --no-daemon
- ./gradlew :compiler:test --tests 'dev.capylang.generator.java.JavaExpressionEvaluatorTest.shouldPreserveTypedLambdaArgumentsForResultAssertChains' --no-daemon
- ./gradlew clean check --no-daemon
- node JSON.parse check for generated Java and JavaScript ctrf-report.json outputs

## Performance
- Fresh master baseline clean check: 316.04s
- Final branch clean check: 236.38s
- No local clean-check slowdown observed.

## Sample CTRF output
```json
{
  "reportFormat": "CTRF",
  "specVersion": "0.0.0",
  "results": {
    "tool": { "name": "Capybara" },
    "summary": { "tests": 497, "failed": 0 }
  }
}
```