### PR TITLE
feat(#139): generate Jest test reports

### DIFF
--- a/lib/capybara-lib/build.gradle
+++ b/lib/capybara-lib/build.gradle
@@ -615,7 +615,7 @@ def testCapybaraJava = tasks.register('testCapybaraJava', InProcessCapybaraTestT
                     : capybaraTestRuntimeClasspath
     )
     outputDir.set(capybaraTestResultsDir)
-    reportType.set('JUNIT_CTRF')
+    reportType.set('JUNIT_CTRF_JEST')
 }
 
 def testCapybaraJavaScript = tasks.register('testCapybaraJavaScript', NodeTask) {
@@ -629,7 +629,7 @@ def testCapybaraJavaScript = tasks.register('testCapybaraJavaScript', NodeTask) 
     args.set([
             '--generated-dir', capybaraGeneratedTestJsDir.get().asFile.absolutePath,
             '--output-dir', capybaraJsTestResultsDir.get().asFile.absolutePath,
-            '--report-type', 'JUNIT_CTRF',
+            '--report-type', 'JUNIT_CTRF_JEST',
             '--log', 'TC'
     ])
     inputs.file(capybaraJsTestRunner)

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -112,8 +112,8 @@ fun TestCase.failed(): bool =
     case Passed -> false
     case Failed -> true
 
-enum ReportType { JUNIT, CTRF, JUNIT_CTRF }
-type Report = JUnitReport | CtrfReport
+enum ReportType { JUNIT, CTRF, JEST, JUNIT_CTRF, JUNIT_JEST, CTRF_JEST, JUNIT_CTRF_JEST }
+type Report = JUnitReport | CtrfReport | JestReport
 
 /// See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml)
 data JUnitReport { suites: List[JUnitTestSuite] }
@@ -152,6 +152,7 @@ fun JUnitFailure.`+`(other_message: String): JUnitFailure =
     }
 
 data CtrfReport { report: String }
+data JestReport { report: String }
 
 data TestOutput { path: Path, content: String, failed: bool }
 data TestRun { outputs: List[TestOutput], written_files: List[Path], failure_summary: String, failed: bool }
@@ -160,7 +161,11 @@ fun run_tests(rtype: ReportType, test_files: List[TestFile]): List[TestOutput] =
     match rtype with
     case JUNIT -> junit_run_tests(test_files)
     case CTRF -> ctrf_run_tests(test_files)
+    case JEST -> jest_run_tests(test_files)
     case JUNIT_CTRF -> junit_run_tests(test_files) + ctrf_run_tests(test_files)
+    case JUNIT_JEST -> junit_run_tests(test_files) + jest_run_tests(test_files)
+    case CTRF_JEST -> ctrf_run_tests(test_files) + jest_run_tests(test_files)
+    case JUNIT_CTRF_JEST -> junit_run_tests(test_files) + ctrf_run_tests(test_files) + jest_run_tests(test_files)
 
 fun run_tests(rtype: ReportType, output_dir: Path, test_files: List[TestFile]): Effect[Result[TestRun]] =
     let outputs = run_tests(rtype, test_files)
@@ -541,6 +546,7 @@ private fun has_failures(test_outputs: List[TestOutput]): bool = test_outputs.an
 
 const JUNIT_PREFIX = 'TEST-'
 const CTRF_REPORT_FILE = 'ctrf-report.json'
+const JEST_REPORT_FILE = 'jest-report.json'
 const CTRF_SPEC_VERSION = '0.0.0'
 
 private fun junit_run_tests(test_files: List[TestFile]): List[TestOutput] = (test_files | :junit_run_test).as_list()
@@ -690,3 +696,83 @@ private fun ctrf_json_string(value: String): String =
     '"' + ctrf_json_escape(value) + '"'
 
 private fun ctrf_json_escape(value: String): String = <native>
+
+private fun jest_run_tests(test_files: List[TestFile]): List[TestOutput] = [
+    TestOutput {
+        path: from_string(JEST_REPORT_FILE),
+        content: jest_report(test_files),
+        failed: ctrf_failed_count(test_files) > 0
+    }
+]
+
+fun jest_report(test_files: List[TestFile]): String =
+    let failed_count = ctrf_failed_count(test_files)
+    "{"
+    + '"success":' + jest_json_bool(failed_count == 0) + ','
+    + '"numTotalTestSuites":' + test_files.size() + ','
+    + '"numPassedTestSuites":' + jest_passed_suite_count(test_files) + ','
+    + '"numFailedTestSuites":' + jest_failed_suite_count(test_files) + ','
+    + '"numPendingTestSuites":0,'
+    + '"numTotalTests":' + ctrf_tests_count(test_files) + ','
+    + '"numPassedTests":' + ctrf_passed_count(test_files) + ','
+    + '"numFailedTests":' + failed_count + ','
+    + '"numPendingTests":0,'
+    + '"numTodoTests":0,'
+    + '"startTime":' + ctrf_start_millis(test_files) + ','
+    + '"testResults":[' + jest_test_results(test_files) + ']'
+    + '}'
+
+private fun jest_test_results(test_files: List[TestFile]): String =
+    test_files |> '', (acc, test_file) =>
+        acc + ctrf_comma(acc) + jest_test_result(test_file)
+
+private fun jest_test_result(test_file: TestFile): String =
+    let failed_count = jest_failed_count(test_file)
+    let start = test_file.timestamp_millis
+    let duration = jest_duration_millis(test_file)
+    "{"
+    + '"name":' + ctrf_json_string(test_file.file_name) + ','
+    + '"status":' + ctrf_json_string(jest_status(failed_count > 0)) + ','
+    + '"startTime":' + start + ','
+    + '"endTime":' + (start + duration) + ','
+    + '"assertionResults":[' + jest_assertion_results(test_file) + ']'
+    + '}'
+
+private fun jest_assertion_results(test_file: TestFile): String =
+    test_file.test_cases |> '', (acc, test_case) =>
+        acc + ctrf_comma(acc) + jest_assertion_result(test_file, test_case)
+
+private fun jest_assertion_result(test_file: TestFile, test_case: TestCase): String =
+    "{"
+    + '"ancestorTitles":[' + ctrf_json_string(test_file.file_name) + '],'
+    + '"title":' + ctrf_json_string(test_case.name) + ','
+    + '"status":' + ctrf_json_string(jest_status(test_case.failed())) + ','
+    + '"duration":' + ctrf_duration_millis(test_case) + ','
+    + '"failureMessages":' + jest_failure_messages(test_case) + ','
+    + '"location":null'
+    + '}'
+
+private fun jest_failure_messages(test_case: TestCase): String =
+    match test_case.result with
+    case Passed -> '[]'
+    case Failed { message, type } -> '[' + ctrf_json_string(normalize_failure_message(message)) + ']'
+
+private fun jest_status(failed: bool): String =
+    if failed then 'failed' else 'passed'
+
+private fun jest_json_bool(value: bool): String =
+    if value then 'true' else 'false'
+
+private fun jest_passed_suite_count(test_files: List[TestFile]): int =
+    test_files |> 0, (acc, test_file) =>
+        if jest_failed_count(test_file) > 0 then acc else acc + 1
+
+private fun jest_failed_suite_count(test_files: List[TestFile]): int =
+    test_files |> 0, (acc, test_file) =>
+        if jest_failed_count(test_file) > 0 then acc + 1 else acc
+
+private fun jest_failed_count(test_file: TestFile): int =
+    test_file.test_cases |> 0, (acc, test_case) => if test_case.failed() then acc + 1 else acc
+
+private fun jest_duration_millis(test_file: TestFile): long =
+    test_file.test_cases |> 0L, (acc, test_case) => acc + ctrf_duration_millis(test_case)

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
@@ -143,7 +143,11 @@ public class TestRunner {
     public enum ReportType {
         JUNIT,
         CTRF,
-        JUNIT_CTRF
+        JEST,
+        JUNIT_CTRF,
+        JUNIT_JEST,
+        CTRF_JEST,
+        JUNIT_CTRF_JEST
     }
 
     private static void printHelp() {
@@ -151,7 +155,7 @@ public class TestRunner {
                 Usage: java -jar test-runner.jar [options]
                 Options:
                   -o, --output-dir <dir>    Output directory for test reports (required)
-                  -rt, --report-type <type> Report type (required, JUNIT, CTRF, JUNIT_CTRF)
+                  -rt, --report-type <type> Report type (required, JUNIT, CTRF, JEST, JUNIT_CTRF, JUNIT_JEST, CTRF_JEST, JUNIT_CTRF_JEST)
                   -l, --log <type>          Log output type (optional, LOG, TC, TEAM_CITY)
                   --tests <selector>        Run only tests matching selector; can be repeated
                   --available-tests         Print available test selectors and exit

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
@@ -286,9 +286,19 @@ class TestRunnerTest {
                 "-o", tempDir.toString(),
                 "-rt", "JUNIT_CTRF"
         });
+        var jestArguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "JEST"
+        });
+        var junitCtrfJestArguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "JUNIT_CTRF_JEST"
+        });
 
         assertEquals(TestRunner.ReportType.CTRF, ctrfArguments.reportType());
         assertEquals(TestRunner.ReportType.JUNIT_CTRF, junitCtrfArguments.reportType());
+        assertEquals(TestRunner.ReportType.JEST, jestArguments.reportType());
+        assertEquals(TestRunner.ReportType.JUNIT_CTRF_JEST, junitCtrfJestArguments.reportType());
     }
 
     @Test
@@ -556,20 +566,61 @@ class TestRunnerTest {
     }
 
     @Test
-    void shouldWriteJUnitAndCtrfReportsTogether() throws Exception {
+    void shouldRenderJestReportForTestRun() {
+        var report = CapyTest.jestReport(List.of(testFile(
+                "/capy/lang/StringTest.cfun",
+                passed("starts_with should pass"),
+                failed("starts_with should fail", "Expected string:\ncapybara\nto start with:\nbara", "assertion failed")
+        )));
+
+        assertTrue(report.contains("\"success\":false"));
+        assertTrue(report.contains("\"numTotalTestSuites\":1"));
+        assertTrue(report.contains("\"numPassedTestSuites\":0"));
+        assertTrue(report.contains("\"numFailedTestSuites\":1"));
+        assertTrue(report.contains("\"numTotalTests\":2"));
+        assertTrue(report.contains("\"numPassedTests\":1"));
+        assertTrue(report.contains("\"numFailedTests\":1"));
+        assertTrue(report.contains("\"startTime\":0"));
+        assertTrue(report.contains("\"name\":\"/capy/lang/StringTest.cfun\",\"status\":\"failed\",\"startTime\":0,\"endTime\":0,\"assertionResults\""));
+        assertTrue(report.contains("\"ancestorTitles\":[\"/capy/lang/StringTest.cfun\"],\"title\":\"starts_with should pass\",\"status\":\"passed\",\"duration\":0,\"failureMessages\":[],\"location\":null"));
+        assertTrue(report.contains("\"title\":\"starts_with should fail\",\"status\":\"failed\",\"duration\":0,\"failureMessages\":[\"Expected string:\\ncapybara\\nto start with:\\nbara\"],\"location\":null"));
+    }
+
+    @Test
+    void shouldEscapeJsonControlCharactersInJestReport() {
+        var controlCharacters = controlCharacters();
+        var escapedControlCharacters = escapedControlCharacters();
+        var message = "line" + (char) 0 + "\b\fbreak";
+        var report = CapyTest.jestReport(List.of(testFile(
+                "/capy/lang/StringTest.cfun",
+                failed("control" + controlCharacters + "name", message, "assertion failed")
+        )));
+
+        assertFalse(report.chars().anyMatch(character -> character < 0x20));
+        assertTrue(report.contains("\"title\":\"control" + escapedControlCharacters + "name\""));
+        assertTrue(report.contains("\"failureMessages\":[\"line\\u0000\\b\\fbreak\"]"));
+    }
+
+    @Test
+    void shouldWriteJUnitCtrfAndJestReportsTogether() throws Exception {
         var run = successValue(CapyTest.runTests(
-                CapyTest.ReportType.JUNIT_CTRF,
+                CapyTest.ReportType.JUNIT_CTRF_JEST,
                 PathUtil.fromJavaPath(tempDir),
                 List.of(testFile("/capy/lang/MathTest", passed("should_pass")))
         ).unsafeRun());
 
         assertEquals(
-                List.of(relativePath("TEST-capy.lang.MathTest.xml"), relativePath("ctrf-report.json")),
+                List.of(
+                        relativePath("TEST-capy.lang.MathTest.xml"),
+                        relativePath("ctrf-report.json"),
+                        relativePath("jest-report.json")
+                ),
                 run.written_files()
         );
         assertTrue(Files.exists(tempDir.resolve("TEST-capy.lang.MathTest.xml")));
         assertTrue(Files.readString(tempDir.resolve("ctrf-report.json")).contains("\"reportFormat\":\"CTRF\""));
-        assertEquals("TEST-capy.lang.MathTest.xml\nctrf-report.json\n", Files.readString(tempDir.resolve(OUTPUT_MANIFEST_FILE)));
+        assertTrue(Files.readString(tempDir.resolve("jest-report.json")).contains("\"success\":true"));
+        assertEquals("TEST-capy.lang.MathTest.xml\nctrf-report.json\njest-report.json\n", Files.readString(tempDir.resolve(OUTPUT_MANIFEST_FILE)));
     }
 
     @Test

--- a/lib/capybara-lib/src/test/js/run-capybara-tests.js
+++ b/lib/capybara-lib/src/test/js/run-capybara-tests.js
@@ -40,10 +40,14 @@ function parseArgs(argv) {
     if (!options.availableTests && !options.outputDir) {
         throw new Error('Missing --output-dir');
     }
-    if (!options.availableTests && !['JUNIT', 'CTRF', 'JUNIT_CTRF'].includes(options.reportType)) {
-        throw new Error('Supported report types are JUNIT, CTRF, and JUNIT_CTRF');
+    if (!options.availableTests && !supportedReportTypes().includes(options.reportType)) {
+        throw new Error(`Supported report types are ${supportedReportTypes().join(', ')}`);
     }
     return options;
+}
+
+function supportedReportTypes() {
+    return ['JUNIT', 'CTRF', 'JEST', 'JUNIT_CTRF', 'JUNIT_JEST', 'CTRF_JEST', 'JUNIT_CTRF_JEST'];
 }
 
 function requireValue(argv, index, option) {
@@ -301,11 +305,15 @@ function reportPath(outputDir, fileName) {
 }
 
 function shouldWriteJUnit(reportType) {
-    return reportType === 'JUNIT' || reportType === 'JUNIT_CTRF';
+    return reportType.split('_').includes('JUNIT');
 }
 
 function shouldWriteCtrf(reportType) {
-    return reportType === 'CTRF' || reportType === 'JUNIT_CTRF';
+    return reportType.split('_').includes('CTRF');
+}
+
+function shouldWriteJest(reportType) {
+    return reportType.split('_').includes('JEST');
 }
 
 function ctrfReport(suites, start, stop) {
@@ -356,6 +364,51 @@ function ctrfReportPath(outputDir) {
     return path.join(outputDir, 'ctrf-report.json');
 }
 
+function jestReport(suites, start) {
+    const failedSuites = suites.filter(suite => suite.results.some(result => result.failed)).length;
+    const results = suites.flatMap(suite => suite.results);
+    const failedTests = results.filter(result => result.failed).length;
+    const report = {
+        success: failedTests === 0,
+        numTotalTestSuites: suites.length,
+        numPassedTestSuites: suites.length - failedSuites,
+        numFailedTestSuites: failedSuites,
+        numPendingTestSuites: 0,
+        numTotalTests: results.length,
+        numPassedTests: results.length - failedTests,
+        numFailedTests: failedTests,
+        numPendingTests: 0,
+        numTodoTests: 0,
+        startTime: start,
+        testResults: suites.map(suite => {
+            const suiteFailed = suite.results.some(result => result.failed);
+            const suiteStart = suite.results[0]?.start ?? start;
+            const suiteEnd = suite.results.length === 0
+                ? suiteStart
+                : Math.max(...suite.results.map(result => result.stop));
+            return {
+                name: suite.fileName,
+                status: suiteFailed ? 'failed' : 'passed',
+                startTime: suiteStart,
+                endTime: suiteEnd,
+                assertionResults: suite.results.map(result => ({
+                    ancestorTitles: [suite.fileName],
+                    title: result.name,
+                    status: result.failed ? 'failed' : 'passed',
+                    duration: result.durationMs,
+                    failureMessages: result.failed ? [String(result.failed.message ?? '')] : [],
+                    location: null,
+                })),
+            };
+        }),
+    };
+    return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+function jestReportPath(outputDir) {
+    return path.join(outputDir, 'jest-report.json');
+}
+
 function run(options) {
     const runtimePath = path.resolve(options.generatedDir, 'capy', 'test', 'CapyTestRuntime.js');
     const runtime = require(runtimePath);
@@ -394,6 +447,9 @@ function run(options) {
     }
     if (shouldWriteCtrf(options.reportType)) {
         fs.writeFileSync(ctrfReportPath(options.outputDir), ctrfReport(suites, runStartedAt, Date.now()));
+    }
+    if (shouldWriteJest(options.reportType)) {
+        fs.writeFileSync(jestReportPath(options.outputDir), jestReport(suites, runStartedAt));
     }
     return failed ? 1 : 0;
 }


### PR DESCRIPTION
Closes #139.

## What changed
- Added Jest JSON report generation to the Capybara test library and generated JavaScript test runner.
- Added `JEST`, `JUNIT_JEST`, `CTRF_JEST`, and `JUNIT_CTRF_JEST` report type support.
- Switched Capybara library Gradle test tasks to emit JUnit, CTRF, and Jest reports together.
- Added Java-side coverage for Jest report rendering, escaping, parsing, and combined output manifests.

## Impacted modules
- `lib/capybara-lib`: Capybara test stdlib, Java test runner wrapper, JavaScript test runner, Gradle test task configuration.

## Sample output
`jest-report.json` now includes Jest-style top-level counts such as `success`, `numTotalTests`, `numPassedTests`, `numFailedTests`, and per-suite `testResults[].assertionResults`.

## Commands run
- `./gradlew :lib:capybara-lib:test --no-daemon` succeeded in 1:31.37.
- `./gradlew clean check --no-daemon` hit a local `OutOfMemoryError` in unrelated parallel `:compiler:test` generated-Java compilation after 4:25.37.
- `./gradlew clean check --no-daemon --max-workers=2` succeeded in 5:47.95.
- `git diff --check`.

## Performance note
Recent `master` `check.yml` runs took 172s, 193s, 154s, 145s, and 151s. This change adds one linear JSON serialization pass over the already-collected test results for Java and JavaScript Capybara test runs; the PR CI run is the apples-to-apples check for default `./gradlew clean check` timing.
