### PR TITLE
chore(#140): add git policy hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${hook_dir}/lib/capybara-git-policy.sh"
+
+capybara_validate_commit_message_file "$1"

--- a/.githooks/lib/capybara-git-policy.sh
+++ b/.githooks/lib/capybara-git-policy.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+CAPYBARA_BRANCH_PATTERN='^((feature|bug|chore)/#[0-9]+.+|release/[0-9]+\.[0-9]+\.x)$'
+CAPYBARA_COMMIT_PATTERN='^(feat|fix|bug|chore|test|docs|refactor|style|perf|build|ci|release|merge|revert)(\(#?[0-9]+\))?: .+'
+
+capybara_default_branch_name() {
+    local default_ref=""
+
+    default_ref="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+
+    if [[ "${default_ref}" == */* ]]; then
+        printf '%s\n' "${default_ref#*/}"
+        return 0
+    fi
+
+    printf 'master\n'
+}
+
+capybara_print_branch_policy() {
+    local default_branch
+
+    default_branch="$(capybara_default_branch_name)"
+
+    {
+        cat <<'EOF'
+Allowed branch names:
+EOF
+        cat <<EOF
+- ${default_branch}
+EOF
+        cat <<'EOF'
+- {feature|bug|chore}/#{issue-number}{description}
+- release/{major}.{minor}.x
+EOF
+    } >&2
+}
+
+capybara_print_commit_policy() {
+    cat >&2 <<'EOF'
+Commit subjects must start with a conventional type, optionally followed by an issue number.
+Examples:
+- feat: add parser support
+- feat(#111): add parser support
+EOF
+}
+
+capybara_is_zero_oid() {
+    [[ "${1:-}" =~ ^0+$ ]]
+}
+
+capybara_is_valid_branch_name() {
+    local branch_name="${1:-}"
+
+    [[ "${branch_name}" == "$(capybara_default_branch_name)" || "${branch_name}" =~ ${CAPYBARA_BRANCH_PATTERN} ]]
+}
+
+capybara_validate_branch_name() {
+    local branch_name="${1:-}"
+
+    if capybara_is_valid_branch_name "${branch_name}"; then
+        return 0
+    fi
+
+    echo "Invalid branch name: ${branch_name}" >&2
+    capybara_print_branch_policy
+    return 1
+}
+
+capybara_commit_subject_from_file() {
+    local message_file="$1"
+    local subject=""
+
+    IFS= read -r subject < "${message_file}" || true
+    subject="${subject%$'\r'}"
+    printf '%s\n' "${subject}"
+}
+
+capybara_is_valid_commit_subject() {
+    [[ "${1:-}" =~ ${CAPYBARA_COMMIT_PATTERN} ]]
+}
+
+capybara_validate_commit_subject() {
+    local subject="${1:-}"
+    local source="${2:-commit}"
+
+    if capybara_is_valid_commit_subject "${subject}"; then
+        return 0
+    fi
+
+    echo "Invalid ${source} subject: ${subject}" >&2
+    capybara_print_commit_policy
+    return 1
+}
+
+capybara_validate_commit_message_file() {
+    local message_file="$1"
+    local subject
+
+    subject="$(capybara_commit_subject_from_file "${message_file}")"
+    capybara_validate_commit_subject "${subject}" "commit message"
+}
+
+capybara_validate_commit_oid() {
+    local oid="$1"
+    local subject
+
+    subject="$(git log -1 --format=%s "${oid}")"
+    capybara_validate_commit_subject "${subject}" "commit ${oid:0:12}"
+}
+
+capybara_pushed_commits() {
+    local local_oid="$1"
+    local remote_oid="$2"
+
+    if capybara_is_zero_oid "${local_oid}"; then
+        return 0
+    fi
+
+    if capybara_is_zero_oid "${remote_oid}"; then
+        git rev-list --reverse "${local_oid}" --not --remotes
+    else
+        git rev-list --reverse "${remote_oid}..${local_oid}"
+    fi
+}
+
+capybara_validate_pushed_commits() {
+    local local_oid="$1"
+    local remote_oid="$2"
+    local pushed_commits
+    local failed=0
+    local oid
+
+    if ! pushed_commits="$(capybara_pushed_commits "${local_oid}" "${remote_oid}")"; then
+        echo "Unable to determine pushed commits for ${local_oid:0:12} against ${remote_oid:0:12}." >&2
+        return 1
+    fi
+
+    while IFS= read -r oid; do
+        if [[ -z "${oid}" ]]; then
+            continue
+        fi
+
+        if ! capybara_validate_commit_oid "${oid}"; then
+            failed=1
+        fi
+    done <<< "${pushed_commits}"
+
+    return "${failed}"
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${hook_dir}/lib/capybara-git-policy.sh"
+
+branch_name="$(git symbolic-ref --quiet --short HEAD || true)"
+
+if [[ -z "${branch_name}" ]]; then
+    echo "Skipping branch name validation for detached HEAD." >&2
+    exit 0
+fi
+
+capybara_validate_branch_name "${branch_name}"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${hook_dir}/lib/capybara-git-policy.sh"
+
+failed=0
+
+while IFS=' ' read -r local_ref local_oid remote_ref remote_oid; do
+    if [[ -z "${local_ref:-}" ]]; then
+        continue
+    fi
+
+    if capybara_is_zero_oid "${local_oid}"; then
+        continue
+    fi
+
+    if [[ "${remote_ref}" == refs/heads/* ]]; then
+        branch_name="${remote_ref#refs/heads/}"
+
+        if ! capybara_validate_branch_name "${branch_name}"; then
+            failed=1
+        fi
+
+        if ! capybara_validate_pushed_commits "${local_oid}" "${remote_oid}"; then
+            failed=1
+        fi
+    fi
+done
+
+exit "${failed}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Capybara
 
+## Development
+
+Enable the repository Git hooks after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hooks validate branch names and commit subjects before commits and pushes. Branch names must be the repository default branch, `{feature|bug|chore}/#{issue-number}{description}`, or `release/{major}.{minor}.x`. Commit subjects must start with a conventional type, optionally followed by an issue number, for example `feat: add parser support` or `feat(#111): add parser support`.
+
 ## Language
 
 ### Functional part


### PR DESCRIPTION
## What changed
- Add versioned Git hooks for branch-name and commit-subject policy.
- Validate current branch names in `pre-commit`, commit subjects in `commit-msg`, and pushed branch/commit ranges in `pre-push`.
- Document enabling hooks with `git config core.hooksPath .githooks`.

## Impacted modules
- Repository tooling (`.githooks`)
- README development setup

## Commands run
- `bash -n .githooks/lib/capybara-git-policy.sh .githooks/commit-msg .githooks/pre-commit .githooks/pre-push`
- Hook behavior checks for valid/invalid branch names and commit subjects
- `.githooks/pre-commit`
- `git diff --check`
- `./gradlew clean check`

## Performance
- Baseline on unchanged `master`: Gradle reported `BUILD SUCCESSFUL in 5m 17s`, then the local daemon failed during shutdown with cache I/O errors.
- Isolated Gradle-home baseline on unchanged `master`: failed in `:compiler:test`, so it was not a usable timing baseline.
- This branch: `./gradlew clean check` passed in 8m 23s (`real 503.86`).
- The change is not wired into Gradle, so it adds no work to the `clean check` task graph; the local timing difference appears environmental/noisy rather than caused by these hooks.

CLOSE #140