### PR TITLE
test(#137): cover Python review fixes

### DIFF
--- a/capy/src/test/py/capy_test.py
+++ b/capy/src/test/py/capy_test.py
@@ -102,6 +102,10 @@ class CapyPythonCliTest(unittest.TestCase):
         (source_dir / "foo" / "Main.coo").write_text(textwrap.dedent("""
             class Main {
                 def main(args: List[String]): int = args.size()
+
+                def inverted(flag: bool): bool = !flag
+
+                def not_one(value: int): bool = value != 1
             }
         """))
 
@@ -113,6 +117,91 @@ class CapyPythonCliTest(unittest.TestCase):
         python = run_python([str(generated_dir / "foo" / "Main.py"), "one", "two"])
         self.assertEqual(python.returncode, 0, python.stderr)
         self.assertEqual(python.stdout.strip(), "2")
+
+        python = run_python([
+            "-c",
+            "from foo.Main import Main; m = Main(); "
+            "print('|'.join(["
+            "str(m.inverted(False)).lower(), "
+            "str(m.not_one(2)).lower(), "
+            "str(m.not_one(1)).lower()"
+            "]))",
+        ], cwd=generated_dir)
+        self.assertEqual(python.returncode, 0, python.stderr)
+        self.assertEqual(python.stdout.strip(), "true|true|false")
+
+    def test_python_capybara_runner_applies_test_selectors(self):
+        root = self.temp_project()
+        generated_dir = root / "generated"
+        output_dir = root / "results"
+        runtime_dir = generated_dir / "capy" / "test"
+        executed_file = generated_dir / "executed.txt"
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / "CapyTestRuntime.py").write_text(textwrap.dedent(f"""
+            import pathlib
+
+            executed_file = pathlib.Path({str(executed_file)!r})
+
+            def record(name):
+                def body():
+                    with executed_file.open("a") as output:
+                        output.write(name + "\\n")
+                    return {{"result": True, "message": "", "type": "Assertion"}}
+                return body
+
+            def gatherTests():
+                return [
+                    {{
+                        "file_name": "/capy/lang/EffectTest.cfun",
+                        "test_cases": [
+                            {{"name": "selected", "body": record("selected")}},
+                            {{"name": "skipped", "body": record("skipped")}},
+                        ],
+                    }},
+                    {{
+                        "file_name": "/capy/lang/StringTest.cfun",
+                        "test_cases": [
+                            {{"name": "other", "body": record("other")}},
+                        ],
+                    }},
+                ]
+        """))
+        runner = (
+            pathlib.Path(__file__).resolve().parents[4]
+            / "lib"
+            / "capybara-lib"
+            / "src"
+            / "test"
+            / "py"
+            / "run-capybara-tests.py"
+        )
+
+        result = run_python([
+            str(runner),
+            "--generated-dir", str(generated_dir),
+            "--output-dir", str(output_dir),
+            "--tests", "/capy/lang/EffectTest.\"selected\"",
+        ])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(executed_file.read_text().splitlines(), ["selected"])
+        report = (output_dir / "TEST-capy.lang.EffectTest.cfun.xml").read_text()
+        self.assertIn('tests="1"', report)
+        self.assertIn('name="selected"', report)
+        self.assertNotIn('name="skipped"', report)
+
+        missing = run_python([
+            str(runner),
+            "--generated-dir", str(generated_dir),
+            "--output-dir", str(root / "missing-results"),
+            "--tests", "/capy/lang/EffectTest.\"missing\"",
+        ])
+
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn(
+            "Test selector `/capy/lang/EffectTest.\"missing\"` did not match any test",
+            missing.stderr,
+        )
 
     def test_generated_python_output_is_pruned_by_manifest_on_reuse(self):
         root = self.temp_project()


### PR DESCRIPTION
## What changed
- Added CLI regression coverage for OO Python unary `!` translation while preserving `!=`.
- Added a Python Capybara runner subprocess test for `--tests` filtering and missing-selector failures.

## Impacted modules
- `capy` Python CLI tests
- `lib/capybara-lib` Python test runner coverage

## Commands run
- `./gradlew :capy:pythonTests :compiler:test --tests dev.capylang.generator.PythonGeneratorTest :capy:e2e-coo-python`
- `./gradlew :lib:capybara-lib:testCapybara`
- `./gradlew :capy:pythonTests`
- `git diff --check`

Refs #137