### PR TITLE
feat(#148): rename cfun union syntax

### DIFF
--- a/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
+++ b/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
@@ -60,7 +60,7 @@
         <dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict>
       </array>
     </dict>
-    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|type|enum|data|single|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
+    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|union|enum|data|single|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
     <dict><key>name</key><string>keyword.operator.constructor.capybara</string><key>match</key><string>(?&lt;=\bconstructor\s*\{[^\n]*)\*(?=\s*\{)</string></dict>
     <dict><key>name</key><string>keyword.other.capybara</string><key>match</key><string>\\b(is_empty|size|to_int|to_long|to_double|to_float|to_bool|reflection)\\b</string></dict>
     <dict><key>name</key><string>support.type.primitive.capybara</string><key>match</key><string>\b(byte|int|long|float|double|bool|string|any|data|void|list|set|dict|tuple)(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
@@ -89,7 +89,7 @@
         <key>5</key><dict><key>name</key><string>entity.name.function.capybara</string></dict>
       </dict>
     </dict>
-    <dict><key>name</key><string>meta.type.constructor.capybara</string><key>match</key><string>\b(type)\s+(_*[A-Z][A-Za-z0-9_]*(?:\[[^\]]+\])?)(?:\s*\{[^{}\n]*\})?\s+(with)\s+(constructor)\s*\{</string></dict>
+    <dict><key>name</key><string>meta.type.constructor.capybara</string><key>match</key><string>\b(union)\s+(_*[A-Z][A-Za-z0-9_]*(?:\[[^\]]+\])?)(?:\s*\{[^{}\n]*\})?\s+(with)\s+(constructor)\s*\{</string></dict>
     <dict>
       <key>name</key><string>meta.data.constructor-bypass.capybara</string>
       <key>match</key><string>(_*[A-Z][A-Za-z0-9_]*(?:\[[^\]]+\])?)(!)(?=\s*\{)</string>
@@ -100,7 +100,7 @@
       </dict>
     </dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
-    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(type|enum|data|single|deriver|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(union|enum|data|single|deriver|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b(class|trait|interface)\s+(_*[A-Z][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+(__[A-Za-z0-9_]+)</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>

--- a/Intellij/syntaxes/Capybara.tmLanguage
+++ b/Intellij/syntaxes/Capybara.tmLanguage
@@ -60,7 +60,7 @@
         <dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict>
       </array>
     </dict>
-    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|type|enum|data|single|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
+    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|union|enum|data|single|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
     <dict><key>name</key><string>keyword.operator.constructor.capybara</string><key>match</key><string>(?&lt;=\bconstructor\s*\{[^\n]*)\*(?=\s*\{)</string></dict>
     <dict><key>name</key><string>keyword.other.capybara</string><key>match</key><string>\\b(is_empty|size|to_int|to_long|to_double|to_float|to_bool|reflection)\\b</string></dict>
     <dict><key>name</key><string>support.type.primitive.capybara</string><key>match</key><string>\b(byte|int|long|float|double|bool|String|any|data|void|List|Set|Dict|Tuple)(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
@@ -89,7 +89,7 @@
         <key>5</key><dict><key>name</key><string>entity.name.function.capybara</string></dict>
       </dict>
     </dict>
-    <dict><key>name</key><string>meta.type.constructor.capybara</string><key>match</key><string>\b(type)\s+(_*[A-Z][A-Za-z0-9_]*(?:\[[^\]]+\])?)(?:\s*\{[^{}\n]*\})?\s+(with)\s+(constructor)\s*\{</string></dict>
+    <dict><key>name</key><string>meta.type.constructor.capybara</string><key>match</key><string>\b(union)\s+(_*[A-Z][A-Za-z0-9_]*(?:\[[^\]]+\])?)(?:\s*\{[^{}\n]*\})?\s+(with)\s+(constructor)\s*\{</string></dict>
     <dict>
       <key>name</key><string>meta.data.constructor-bypass.capybara</string>
       <key>match</key><string>(_*[A-Z][A-Za-z0-9_]*(?:\[[^\]]+\])?)(!)(?=\s*\{)</string>
@@ -100,7 +100,7 @@
       </dict>
     </dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
-    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(type|enum|data|single|deriver|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(union|enum|data|single|deriver|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b(class|trait|interface)\s+(_*[A-Z][A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+(__[A-Za-z0-9_]+)</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>

--- a/Intellij/syntaxes/capybara.tmLanguage.json
+++ b/Intellij/syntaxes/capybara.tmLanguage.json
@@ -130,7 +130,7 @@
       "patterns": [
         {
           "name": "keyword.control.capybara",
-          "match": "\\b(fun|rec|def|type|enum|data|single|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\\b"
+          "match": "\\b(fun|rec|def|union|enum|data|single|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\\b"
         },
         {
           "name": "keyword.operator.constructor.capybara",
@@ -196,7 +196,7 @@
         },
         {
           "name": "meta.type.constructor.capybara",
-          "match": "\\b(type)\\s+(_*[A-Z][A-Za-z0-9_]*(?:\\[[^\\]]+\\])?)(?:\\s*\\{[^{}\\n]*\\})?\\s+(with)\\s+(constructor)\\s*\\{"
+          "match": "\\b(union)\\s+(_*[A-Z][A-Za-z0-9_]*(?:\\[[^\\]]+\\])?)(?:\\s*\\{[^{}\\n]*\\})?\\s+(with)\\s+(constructor)\\s*\\{"
         },
         {
           "name": "meta.data.constructor-bypass.capybara",
@@ -216,7 +216,7 @@
         },
         {
           "name": "entity.name.type.private.capybara",
-          "match": "\\b(type|enum|data|single|deriver|class|trait|interface)\\s+(__[A-Za-z0-9_]*)"
+          "match": "\\b(union|enum|data|single|deriver|class|trait|interface)\\s+(__[A-Za-z0-9_]*)"
         },
         {
           "name": "entity.name.type.capybara",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fun rectangle_area(width: float, height: float): float =
     let area = width * height
     yield area
  
-type ProgramResult = Success { result: Option[String] } | Failure { errorCode: int }
+union ProgramResult = Success { result: Option[String] } | Failure { errorCode: int }
  
 fun test_if(x: int): String =
     if x > 0 then "positive"
@@ -97,7 +97,7 @@ fun test_new_static_dictonary(): Dict[int] =
     }
 
 // algebraic type
-type Shape = Circle | Rectangle
+union Shape = Circle | Rectangle
 data Circle { radius: float }
 data Rectangle { width: float, height: float }
 
@@ -109,7 +109,7 @@ fun area(shape: Shape): float =
 fun circle(radius: float): Circle = Circle { "radius": radius }
 fun rectangle(width: float, height: float): Rectangle = Rectangle { "width": width, "height": height }
 
-type Option[T] = Some(T) | None
+union Option[T] = Some(T) | None
 data Some[T] { value: T }
 single None
 
@@ -118,7 +118,7 @@ fun positive_or_none(x: int): Option[int] =
     else None
 
 // type with common value
-type Person { name: String, age: int } = Student | Teacher
+union Person { name: String, age: int } = Student | Teacher
 data Student { grade: int }
 data Teacher { subject: String }
 fun ppl_in_school(persons: Person): List[String] = persons | p => p.name + " is age of " + p.age
@@ -139,11 +139,11 @@ fun apply_twice(f: (int) => int, x: int): int = x | f | f
 
 fun compose(f: (int) => int, g: (int) => int): (int) => int = x => x | f | g
 
-type BuildIn = Primitive | Collection | Tuple
-type Primitive = Number | String | bool
-type Number = int | long | float | double
-type Collection[T] = List[T] | Set[T] | Dict[T]
-type List[T] = Cons[T] | None
+union BuildIn = Primitive | Collection | Tuple
+union Primitive = Number | String | bool
+union Number = int | long | float | double
+union Collection[T] = List[T] | Set[T] | Dict[T]
+union List[T] = Cons[T] | None
 data Cons[T] { head: T, tail: List[T] }
 
 // method on types

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/Consts.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/Consts.cfun
@@ -16,7 +16,7 @@ const LIST_V: List[int] = [1, 2, 3]
 const SET_V: Set[String] = {"a", "b"}
 const DICT_V: Dict[int] = {"one": 1, "two": 2}
 
-type Animal = Dog | Cat
+union Animal = Dog | Cat
 data Dog { name: String }
 data Cat { age: int }
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/Data.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/Data.cfun
@@ -1,6 +1,6 @@
 // algebraic type
 
-type Shape = Circle | Rectangle
+union Shape = Circle | Rectangle
 data Circle { radius: double }
 data Rectangle { width: double, "height": double }
 
@@ -14,11 +14,11 @@ fun da_vinci(shape: Shape): Shape =
     case Circle { radius } -> Rectangle { width : radius * 2, "height" : radius * 2 }
     case Rectangle { width, height } -> Circle { radius : (width + height) / 4 }
 
-type Typed[T] = Foo[T] | Boo[T]
+union Typed[T] = Foo[T] | Boo[T]
 data Foo[T] { foo: T }
 data Boo[T] { boo: T }
 
-type Knight = EnglishKnight | Tom
+union Knight = EnglishKnight | Tom
 data EnglishKnight { power: double }
 single Tom
 
@@ -29,7 +29,7 @@ fun is_tom(knight: Knight): bool =
     case Tom -> true
     case EnglishKnight { power } -> power > 10.0
 
-type King[T] = FrenchKing[T] | Jerry
+union King[T] = FrenchKing[T] | Jerry
 data FrenchKing[T] { head: bool, foo: T }
 single Jerry
 
@@ -40,7 +40,7 @@ fun jerry_or_french(king: King[int]): String =
     case Jerry -> "jerry"
     case FrenchKing { head, foo } -> head + ":" + foo
 
-type Worker {name: String, surname: String } = BlueCollar | WhiteCollar
+union Worker {name: String, surname: String } = BlueCollar | WhiteCollar
 data BlueCollar { strength: double }
 data WhiteCollar { intelligence: double }
 
@@ -76,7 +76,7 @@ fun read_data_type(foo: FooWithType): String = foo.type
 
 data Box[T] { value: T }
 
-type BoxResult[T] = BoxSuccess[T] | BoxError
+union BoxResult[T] = BoxSuccess[T] | BoxError
 data BoxSuccess[T] { value: T }
 data BoxError { message: String }
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/DataConstructor.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/DataConstructor.cfun
@@ -26,7 +26,7 @@ fun validated_user_age(age: int): String =
 fun validated_user_age_or_default(age: int): int =
     (User { age: age }).or_else(User! { age: 1 }).age
 
-type ValidatedName { name: String } with constructor {
+union ValidatedName { name: String } with constructor {
    if name.length() == 0 then
        Error { "Name was empty" }
    else
@@ -42,14 +42,14 @@ data NamedUser { name: String, role: String } with constructor {
 
 data NamedGuest { name: String, badge: String }
 
-type ValidatedProfileName { name: String } with constructor {
+union ValidatedProfileName { name: String } with constructor {
    if name.length() == 0 then
        Error { "Profile name was empty" }
    else
        Success { * { name: name } }
 } = Profile
 
-type ValidatedProfileRole { role: String } with constructor {
+union ValidatedProfileRole { role: String } with constructor {
    if role.length() == 0 then
        Error { "Profile role was empty" }
    else

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/DeriveFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/DeriveFeature.cfun
@@ -34,7 +34,7 @@ data DerivedUser { name: String, age: int } derive Show, AgeComparable, FieldVal
 single Empty
 data Entity { id: String }
 data Employee { department: String, ...Entity } derive Show
-type Named { id: String } = DerivedEntity derive Show
+union Named { id: String } = DerivedEntity derive Show
 data DerivedEntity { id: String, rank: int }
 
 fun show_user(): String =

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/EmptyLiteralInference.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/EmptyLiteralInference.cfun
@@ -91,11 +91,11 @@ fun reduce_list_to_box_values(values: List[int]): Box[List[int]] =
     let initial: Box[List[int]] = Box { [] }
     values |> initial, (acc_box, item) => Box { acc_box.value + item }
 
-type SeqEnd[T] = ConsEnd[T] | EndEnd
+union SeqEnd[T] = ConsEnd[T] | EndEnd
 data ConsEnd[T] { value: T, rest: () => SeqEnd[T] }
 single EndEnd
 
-type Outcome = ParseSucceeded | ParseFailed
+union Outcome = ParseSucceeded | ParseFailed
 data ParseSucceeded { source: String }
 data ParseFailed { source: String }
 data OutcomeBatch { outcomes: List[Outcome] }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -1,7 +1,7 @@
 from /capy/lang/Result import { * }
 
 fun foo_me(name: String): String =
-    type __Name = __Foo | __Boo | __Unknown
+    union __Name = __Foo | __Boo | __Unknown
     data __Foo { foo: String }
     data __Boo { boo: String }
     data __Unknown { unkn: String }
@@ -43,7 +43,7 @@ fun local_generic_data_used_in_local_function_return_type(v: int): String =
     case Error { message } -> "error:" + message
 
 fun local_single_used_in_local_type_and_function(use_stop: bool): String =
-    type __Token = __Value | Stop
+    union __Token = __Value | Stop
     data __Value { value: int }
     single Stop
     fun describe(token: __Token): String =

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchByType.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchByType.cfun
@@ -23,7 +23,7 @@ fun match_int_ignore_binding(value: any): int =
     case _ -> 0
 
 data Person { name: String }
-type Entity = Person
+union Entity = Person
 enum MatchStatus { READY, DONE }
 
 fun is_data(value: any): bool =

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchCaseAlternatives.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchCaseAlternatives.cfun
@@ -18,7 +18,7 @@ fun long_bucket(value: long): String =
     case 100L | 200L | 300L -> 'hundreds'
     case _ -> 'other'
 
-type Sign = Plus | Minus | Zero
+union Sign = Plus | Minus | Zero
 data Plus { value: String }
 data Minus { value: String }
 data Zero { value: String }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchWhen.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/MatchWhen.cfun
@@ -22,7 +22,7 @@ fun nested_guard(option: Option[int]): String =
 
 data Sign { value: String, weight: int, enabled: bool }
 
-type Letter = Vowel | Consonant
+union Letter = Vowel | Consonant
 single Vowel
 single Consonant
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/Pipe.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/Pipe.cfun
@@ -109,7 +109,7 @@ fun data_pipe(a: int, b: int, c: int): /capy/lang/Option[Value] =
     then None {}
     else Some { add(add(value, b), c) }
 
-type Boxed = IntBox | LongBox
+union Boxed = IntBox | LongBox
 data IntBox { value: int }
 data LongBox { value: long }
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
@@ -3,7 +3,7 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 
-type Letter { name: String } = A | B
+union Letter { name: String } = A | B
 data A { a: int }
 data B { b: List[String] }
 single ReflectedEmpty
@@ -13,7 +13,7 @@ single ReflectedSingleton
 enum ReflectedStatus { REFLECTED_READY, REFLECTED_DONE }
 data ReflectedEnvelope { label: String, payload: A }
 
-type ReflectedJson = ReflectedJsonObject | ReflectedJsonString | ReflectedJsonNumber | ReflectedJsonBool | ReflectedJsonNull
+union ReflectedJson = ReflectedJsonObject | ReflectedJsonString | ReflectedJsonNumber | ReflectedJsonBool | ReflectedJsonNull
 data ReflectedJsonObject { value: Dict[ReflectedJson] }
 data ReflectedJsonString { value: String }
 data ReflectedJsonNumber { value: int }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ResultInfixGeneric.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ResultInfixGeneric.cfun
@@ -1,4 +1,4 @@
-type MyResult[T] = Ok[T] | Fail
+union MyResult[T] = Ok[T] | Fail
 data Ok[T] { value: T }
 data Fail { message: String }
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SeqCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SeqCollection.cfun
@@ -1,4 +1,4 @@
-type Seq[T] = Cons[T] | End
+union Seq[T] = Cons[T] | End
 data Cons[T] { value: T, rest: Seq[T] }
 single End
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/Temporary.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/Temporary.cfun
@@ -1,3 +1,3 @@
-type Temporary { name: String } = Foo | Boo
+union Temporary { name: String } = Foo | Boo
 data Foo { fooishnes: int }
 data Boo { booishnes: int }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/With.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/With.cfun
@@ -9,7 +9,7 @@ data Foo {
     c: double,
 }
 
-type Letter { x: int, } = A | B | C
+union Letter { x: int, } = A | B | C
 
 data A { a: String, }
 data B { b: int, }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/WithExpression.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/WithExpression.cfun
@@ -4,7 +4,7 @@ data Foo {
     c: double
 }
 
-type Letter { x: int } = A | B | C
+union Letter { x: int } = A | B | C
 data A { a: String }
 data B { b: int }
 data C { c: double }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/Types1.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/Types1.cfun
@@ -1,4 +1,4 @@
-type T1 = D1 | D2
+union T1 = D1 | D2
 data D1 { foo: int }
 data D2 { boo: int }
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/Types2.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/Types2.cfun
@@ -1,4 +1,4 @@
-type T1 = TD1 | TD2
+union T1 = TD1 | TD2
 data TD1 { x: String }
 data TD2 { y: String }
 

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/imports2/Types3.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/imports2/Types3.cfun
@@ -1,3 +1,3 @@
-type T5 = D5_1 | D5_2
+union T5 = D5_1 | D5_2
 data D5_1 { x: int }
 data D5_2 { y: int }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/local_visibility/PackageLocalSupport.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/local_visibility/PackageLocalSupport.cfun
@@ -1,6 +1,6 @@
 local const LOCAL_OFFSET: int = 5
 
-local type LocalValue = LocalNumber
+local union LocalValue = LocalNumber
 local data LocalNumber { value: int }
 
 local fun add_local_offset(x: int): int = x + LOCAL_OFFSET

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -63,7 +63,7 @@ public class CompilationErrorTest {
     void shouldNormalizeLocalTypeNamesInMatchExhaustivenessErrors() {
         var errors = compileProgram("""
                         fun parse(value: int): int =
-                            type __Token = __Number | Stop
+                            union __Token = __Number | Stop
                             data __Number { value: int }
                             single Stop
                             ---
@@ -225,7 +225,7 @@ public class CompilationErrorTest {
                 var errors = compileProgram("""
                         from /capy/lang/Result import { * }
                         from /capy/lang/String import { * }
-                        type Parent { foo: String } with constructor {
+                        union Parent { foo: String } with constructor {
                            if foo.length() == 0 then
                                Error { message: "missing" }
                            else
@@ -604,7 +604,7 @@ public class CompilationErrorTest {
     void shouldRejectNestedResultPipeBeforeJavaGeneration() {
         var result = CapybaraCompiler.INSTANCE.compile(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
 
@@ -746,7 +746,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "match_not_exhaustive",
                         """
-                                type Letter = A | B | C | D
+                                union Letter = A | B | C | D
                                 data A { a: int }
                                 data B { b: int }
                                 data C { c: int }
@@ -804,7 +804,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "match_guard_does_not_make_case_exhaustive",
                         """
-                                type Letter = A | B
+                                union Letter = A | B
                                 data A { a: int }
                                 data B { b: int }
                                 fun foo(letter: Letter): int =
@@ -957,7 +957,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "infix_plus_data_parent_and_subtype",
                         """
-                                type Json = JsonArray | JsonNull
+                                union Json = JsonArray | JsonNull
                                 data JsonArray { value: List[Json] }
                                 single JsonNull
                                 fun foo(left: JsonArray, right: Json): Json =
@@ -1118,7 +1118,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "parser_syntax_error_missing_brace_in_then_branch",
                         """
-                                type Seq[T] = Cons[T] | End
+                                union Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Seq[T] }
                                 single End
                                 fun to_seq(list: List[int]): Seq[int] =
@@ -1130,7 +1130,6 @@ public class CompilationErrorTest {
                         """
                                 error: mismatched types
                                  --> /foo/boo/parser_syntax_error_missing_brace_in_then_branch.cfun:%d:%d
-                                type Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Seq[T] }
                                 single End
                                 fun to_seq(list: List[int]): Seq[int] =
@@ -1173,7 +1172,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "seq_match_case_wrong_arrow",
                         """
-                                type Seq[T] = Cons[T] | End
+                                union Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Seq[T] }
                                 single End
                                 fun Seq[T].take(n: int): List[T] =
@@ -1185,7 +1184,6 @@ public class CompilationErrorTest {
                         """
                                 error: mismatched types
                                  --> /foo/boo/seq_match_case_wrong_arrow.cfun:%d:%d
-                                type Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Seq[T] }
                                 single End
                                 fun Seq[T].take(n: int): List[T] =
@@ -1215,7 +1213,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "data_type_not_found_sqe",
                         """
-                                type Seq[T] = Cons[T] | End
+                                union Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Sqe[T] }
                                 single End
                                 """,
@@ -1301,7 +1299,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "function_json_null_wrong_generic_return_type",
                         """
-                                type Result[T] = Success[T] | Error
+                                union Result[T] = Success[T] | Error
                                 data Success[T] { value: T }
                                 data Error { message: String }
                                 data _Parse[T] { value: T, parsing_string: String }
@@ -1323,7 +1321,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "empty_dict_result_not_compatible_with_list_result",
                         """
-                                type Result[T] = Success[T] | Error
+                                union Result[T] = Success[T] | Error
                                 data Success[T] { value: T }
                                 data Error { message: String }
                                 fun accepts_list(value: Result[List[int]]): int = 1
@@ -1342,7 +1340,7 @@ public class CompilationErrorTest {
                 Arguments.of(
                         "any_list_result_not_compatible_with_list_result",
                         """
-                                type Result[T] = Success[T] | Error
+                                union Result[T] = Success[T] | Error
                                 data Success[T] { value: T }
                                 data Error { message: String }
                                 fun accepts_list(value: Result[List[int]]): int = 1
@@ -1616,7 +1614,7 @@ public class CompilationErrorTest {
                         "function_private_type_escapes_signature",
                         """
                                 fun foo_me(name: String): __Name =
-                                    type __Name = __Foo | __Boo | __Unknown
+                                    union __Name = __Foo | __Boo | __Unknown
                                     data __Foo { foo: String }
                                     data __Boo { boo: String }
                                     data __Unknown { unkn: String }
@@ -1767,7 +1765,7 @@ public class CompilationErrorTest {
                     fun String.length(): int = <native>
                     """),
             new RawModule("Name", "/capy/compilation_test", """
-                    type Name[T] = Foo[T] | Boo
+                    union Name[T] = Foo[T] | Boo
                     data Foo[T] { value: T }
                     data Boo { message: String }
                     """)

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/LocalVisibilityCompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/LocalVisibilityCompilationErrorTest.java
@@ -26,7 +26,7 @@ class LocalVisibilityCompilationErrorTest {
             """
                     local fun local_add(x: int): int = x + 1
                     local const LOCAL_OFFSET: int = 5
-                    local type LocalValue = LocalNumber
+                    local union LocalValue = LocalNumber
                     local data LocalNumber { value: int }
                     private fun private_add(x: int): int = x + 2
                     fun public_value(x: int): int = local_add(x) + LOCAL_OFFSET

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/WithCompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/WithCompilationErrorTest.java
@@ -61,7 +61,7 @@ class WithCompilationErrorTest {
                 Arguments.of(
                         "parent cannot update subtype field",
                         """
-                                type Letter { x: int } = A | B
+                                union Letter { x: int } = A | B
                                 data A { a: String }
                                 data B { b: int }
                                 fun foo(letter: Letter): Letter = letter.with(a: \"x\")

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedFpInterop.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedFpInterop.cfun
@@ -1,4 +1,4 @@
-type InteropPet = InteropDog | InteropCat
+union InteropPet = InteropDog | InteropCat
 data InteropDog { name: String }
 data InteropCat { age: int }
 data RecInteropValue { value: int }

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/SharedInterop.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/SharedInterop.cfun
@@ -1,4 +1,4 @@
-type SharedPet = SharedDog | SharedCat
+union SharedPet = SharedDog | SharedCat
 data SharedDog { name: String }
 data SharedCat { age: int }
 

--- a/compiler/src/integrationTest/java/dev/capylang/CompilationTest.java
+++ b/compiler/src/integrationTest/java/dev/capylang/CompilationTest.java
@@ -47,7 +47,7 @@ class CompilationTest {
         return Stream.of(
                 Arguments.of("""
                                 // algebraic type
-                                type Shape = Circle | Rectangle
+                                union Shape = Circle | Rectangle
                                 data Circle { radius: double }
                                 data Rectangle { width: double, height: double }
                                 
@@ -62,7 +62,7 @@ class CompilationTest {
                                     case Rectangle { width, height } -> Circle { radius : (width + height) / 4 }
                                 
                                 // type with common value
-                                type Person { name: String, age: int } = Student | Teacher
+                                union Person { name: String, age: int } = Student | Teacher
                                 data Student { grade: int }
                                 data Teacher { subject: String }
                                 """,
@@ -73,7 +73,7 @@ class CompilationTest {
                                 fun always_true(): bool = true
                                 
                                 // algebraic type
-                                type Shape = Circle | Rectangle
+                                union Shape = Circle | Rectangle
                                 data Circle { radius: double }
                                 data Rectangle { width: double, height: double }
                                 
@@ -89,7 +89,7 @@ class CompilationTest {
                                 """,
                         """
                                 // algebraic type
-                                type Shape = Circle | Rectangle
+                                union Shape = Circle | Rectangle
                                 data Circle { radius: double }
                                 data Rectangle { width: double, height: double }
                                 
@@ -105,12 +105,12 @@ class CompilationTest {
                                 """,
                         """
                                 // type with common value
-                                type Person { name: String, age: int } = Student | Teacher
+                                union Person { name: String, age: int } = Student | Teacher
                                 data Student { grade: int }
                                 data Teacher { subject: String }
                                 """,
                         """
-                                type Option[T] = Some[T] | None
+                                union Option[T] = Some[T] | None
                                 data Some[T] { value: T }
                                 single None
 

--- a/compiler/src/integrationTest/java/dev/capylang/compiler/CapybaraCompilerLibrariesIntegrationTest.java
+++ b/compiler/src/integrationTest/java/dev/capylang/compiler/CapybaraCompilerLibrariesIntegrationTest.java
@@ -115,7 +115,7 @@ class CapybaraCompilerLibrariesIntegrationTest {
 
     private static RawModule optionModule() {
         return new RawModule("Option", "/capy/lang", """
-                type Option[T] = Some[T] | None
+                union Option[T] = Some[T] | None
                 data Some[T] { value: T }
                 single None
                 """);

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -42,8 +42,8 @@ localDefinition: localFunctionDeclaration
 localFunctionDeclaration: docComment* 'fun' recFunctionMarker localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression
                         | docComment* 'fun' localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression;
 localFunctionNameDeclaration: NAME | REC;
-localTypeDeclaration: 'type' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*
-                    | 'type' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*;
+localTypeDeclaration: 'union' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*
+                    | 'union' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*;
 localDataDeclaration: 'data' genericTypeDeclaration '{' dataBody? '}' constructorClause?
                     | 'data' genericTypeDeclaration '=' '{' dataBody? '}' constructorClause?;
 localSingleDeclaration: 'single' TYPE;
@@ -55,8 +55,8 @@ methodIdentifier: identifier | 'with' | infixMethodLiteral | infixOperator;
 infixMethodLiteral: BACKTICKED_INFIX_METHOD_LITERAL | INFIX_METHOD_LITERAL;
 docComment: DOC_COMMENT;
 
-typeDeclaration: docComment* VISIBILITY? 'type' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?
-               | docComment* VISIBILITY? 'type' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?;
+typeDeclaration: docComment* VISIBILITY? 'union' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?
+               | docComment* VISIBILITY? 'union' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?;
 enumDeclaration: 'enum' TYPE '{' TYPE (COMMA TYPE)* COMMA? '}';
 dataDeclaration: docComment* VISIBILITY? 'data' genericTypeDeclaration '{' dataBody? '}' constructorClause? deriveClause?
                | docComment* VISIBILITY? 'data' genericTypeDeclaration '=' '{' dataBody? '}' constructorClause? deriveClause?;
@@ -78,7 +78,7 @@ VISIBILITY: 'local' | 'private';
 BOOL_LITERAL: 'true' | 'false';
 REC: 'rec';
 NAME : [_]* [a-z] [a-zA-Z0-9_]*;
-identifier: NAME | REC | 'derive' | 'deriver' | 'fun' | 'type' | 'enum' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'float' | 'nothing' | 'any';
+identifier: NAME | REC | 'derive' | 'deriver' | 'fun' | 'type' | 'union' | 'enum' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'float' | 'nothing' | 'any';
 parameters: parameter (',' parameter)*;
 parameter: identifier ':' type;
 functionType: ':' type;
@@ -172,6 +172,7 @@ functionCall: NAME '(' argumentList? ')'
             | 'derive' '(' argumentList? ')'
             | 'deriver' '(' argumentList? ')'
             | 'fun' '(' argumentList? ')'
+            | 'union' '(' argumentList? ')'
             | 'byte' '(' argumentList? ')'
             | 'int' '(' argumentList? ')'
             | 'long' '(' argumentList? ')'

--- a/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
@@ -66,7 +66,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldCompileStringParseFunctionsInPrimitivesModule() {
         var compiled = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -171,7 +171,7 @@ class CapybaraCompilerLibrariesTest {
                 }
 
                 data User { name: String, age: int } derive Show, AgeComparable
-                type Named { id: String } = Person derive Show
+                union Named { id: String } = Person derive Show
                 data Person { id: String, name: String }
 
                 fun render(): String = User { name: "Ada", age: 42 }.show()
@@ -567,7 +567,7 @@ class CapybaraCompilerLibrariesTest {
                 from /capy/lang/Result import { * }
                 from /capy/lang/String import { * }
 
-                type ValidatedName { name: String } with constructor {
+                union ValidatedName { name: String } with constructor {
                    if name.length() == 0 then
                        Error { message: "Name was empty" }
                    else
@@ -596,14 +596,14 @@ class CapybaraCompilerLibrariesTest {
                 from /capy/lang/Result import { * }
                 from /capy/lang/String import { * }
 
-                type ValidatedName { name: String } with constructor {
+                union ValidatedName { name: String } with constructor {
                    if name.length() == 0 then
                        Error { message: "Name was empty" }
                    else
                        Success { value: * { name: name } }
                 } = NamedEntity
 
-                type NamedEntity { name: String } = NamedUser
+                union NamedEntity { name: String } = NamedUser
 
                 data NamedUser { name: String, role: String }
                 """;
@@ -653,7 +653,7 @@ class CapybaraCompilerLibrariesTest {
                 collectionsModule(),
                 new RawModule("Assert", "/capy/test", """
                         data Assertion { result: bool, message: String }
-                        type Assert { assertions: List[Assertion] } = StringAssert
+                        union Assert { assertions: List[Assertion] } = StringAssert
                         data StringAssert { value: String }
                         """),
                 new RawModule("CapyTest", "/capy/test", """
@@ -735,7 +735,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldCompileParentWithExpression() {
         var compiled = compileProgram(List.of(
                 new RawModule("WithParent", "/foo/with", """
-                        type Letter { x: int } = A | B
+                        union Letter { x: int } = A | B
                         data A { a: String }
                         data B { b: int }
                         fun update(letter: Letter): Letter = letter.with(x: letter.x + 1)
@@ -802,7 +802,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldPreferResultOverDataOverloadForConstructorExpressionsInMethodChains() {
         var compiled = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -841,7 +841,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldPreferResultOverDataOverloadForConstructorExpressionsAgainstLinkedLibraries() {
         var libraries = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -882,7 +882,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldPreferDirectOverloadsOverWrappingPlainValuesIntoResult() {
         var compiled = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -933,7 +933,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldResolveAbsoluteImportsAgainstRelativeModulePaths() {
         var compiled = compileProgram(List.of(
                 new RawModule("Result", "capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -956,7 +956,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldRejectNestedResultWhenResultAssertExpectsSingleResult() {
         var error = compileFailure(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -996,7 +996,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldPreferLocalConstructorOverUnimportedLinkedLibraryConstructorWithSameName() {
         var libraries = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
@@ -1051,14 +1051,14 @@ class CapybaraCompilerLibrariesTest {
     void shouldCompileTypedAssertLetsForResultAssertLambdaChains() {
         var compiled = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
                 new RawModule("Assert", "/capy/test", """
                         from /capy/lang/Result import { * }
 
-                        type Assert = TechnicalAssert | DataAssert | IntAssert | ResultAssert
+                        union Assert = TechnicalAssert | DataAssert | IntAssert | ResultAssert
                         data TechnicalAssert { assertions: List[bool] }
                         data DataAssert { value: data }
                         data IntAssert { value: int }
@@ -1110,14 +1110,14 @@ class CapybaraCompilerLibrariesTest {
     void shouldWrapParentSubtypesIntoExpectedResultWithoutRecursiveCoercion() {
         var compiled = compileProgram(List.of(
                 new RawModule("Result", "/capy/lang", """
-                        type Result[T] = Success[T] | Error
+                        union Result[T] = Success[T] | Error
                         data Success[T] { value: T }
                         data Error { message: String }
                         """),
                 new RawModule("Json", "/capy/serialization", """
                         from /capy/lang/Result import { * }
 
-                        type Json = JsonObject | JsonBool
+                        union Json = JsonObject | JsonBool
                         data JsonObject { value: Dict[Json] }
                         data JsonBool { value: bool }
 
@@ -1202,7 +1202,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldRejectSubtypeFieldTypeThatDoesNotMatchParentMemberType() {
         var error = compileFailure(List.of(
                 new RawModule("Consumer", "/foo/app", """
-                        type Duration { seconds: long } = DateDuration
+                        union Duration { seconds: long } = DateDuration
                         data DateDuration { seconds: int }
                         """)
         ));
@@ -1218,7 +1218,7 @@ class CapybaraCompilerLibrariesTest {
     void shouldRejectTypeMethodThatConflictsWithSubtypeFieldGetterType() {
         var error = compileFailure(List.of(
                 new RawModule("Consumer", "/foo/app", """
-                        type Duration = DateDuration | WeekDuration
+                        union Duration = DateDuration | WeekDuration
                         data DateDuration { seconds: int }
                         data WeekDuration { weeks: int }
 
@@ -1272,7 +1272,7 @@ class CapybaraCompilerLibrariesTest {
 
     private static RawModule reflectionMetadataModule() {
         return new RawModule("Reflection", "/capy/meta_prog", """
-                type AnyInfo { name: String, pkg: PackageInfo } =
+                union AnyInfo { name: String, pkg: PackageInfo } =
                     DataInfo
                     | InterfaceInfo
                     | ObjectInfo

--- a/compiler/src/test/java/dev/capylang/compiler/InfixOperatorCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/InfixOperatorCompilerTest.java
@@ -13,7 +13,7 @@ class InfixOperatorCompilerTest {
     @Test
     void shouldFailPlusForDataParentAndSubtype() {
         var error = compileFailure("""
-                type Json = JsonArray | JsonNull
+                union Json = JsonArray | JsonNull
                 data JsonArray { value: List[Json] }
                 single JsonNull
 
@@ -31,7 +31,7 @@ class InfixOperatorCompilerTest {
                 from /capy/collection/Set import { * }
                 from /capy/collection/Dict import { * }
 
-                type Json = JsonArray | JsonNull
+                union Json = JsonArray | JsonNull
                 data JsonArray { value: List[Json] }
                 single JsonNull
 
@@ -55,7 +55,7 @@ class InfixOperatorCompilerTest {
                 from /capy/collection/Set import { * }
                 from /capy/collection/Dict import { * }
 
-                type Assert = ResultAssert | StringAssert
+                union Assert = ResultAssert | StringAssert
                 data ResultAssert { value: bool }
                 data StringAssert { value: String }
 
@@ -80,11 +80,11 @@ class InfixOperatorCompilerTest {
                 from /capy/collection/Set import { * }
                 from /capy/collection/Dict import { * }
 
-                type Result[T] = Success[T] | Error
+                union Result[T] = Success[T] | Error
                 data Success[T] { value: T }
                 data Error { message: String }
 
-                type Assert[T] = ResultAssert[T] | StringAssert
+                union Assert[T] = ResultAssert[T] | StringAssert
                 data ResultAssert[T] { value: Result[T] }
                 data StringAssert { value: String }
 
@@ -111,7 +111,7 @@ class InfixOperatorCompilerTest {
                 from /capy/collection/Dict import { * }
                 from /capy/lang/Seq import { * }
 
-                type Assert = ResultAssert | StringAssert
+                union Assert = ResultAssert | StringAssert
                 data ResultAssert { value: bool }
                 data StringAssert { value: String }
 
@@ -137,11 +137,11 @@ class InfixOperatorCompilerTest {
                 from /capy/collection/Dict import { * }
                 from /capy/lang/Seq import { * }
 
-                type Result[T] = Success[T] | Error
+                union Result[T] = Success[T] | Error
                 data Success[T] { value: T }
                 data Error { message: String }
 
-                type Assert[T] = ResultAssert[T] | StringAssert
+                union Assert[T] = ResultAssert[T] | StringAssert
                 data ResultAssert[T] { value: Result[T] }
                 data StringAssert { value: String }
 
@@ -163,10 +163,10 @@ class InfixOperatorCompilerTest {
     void shouldInferConcreteElementTypeForImportedGenericMethodCallAgainstCompiledLibraries() {
         var libraries = compileProgram(List.of(
                 new RawModule("Seq", "/capy/lang", """
-                        type Seq[T] = Cons[T] | End
+                        union Seq[T] = Cons[T] | End
                         data Cons[T] { value: T, rest: () => Seq[T] }
                         single End
-                        type Option[T] = Some[T] | None
+                        union Option[T] = Some[T] | None
                         data Some[T] { value: T }
                         single None
 
@@ -193,7 +193,7 @@ class InfixOperatorCompilerTest {
     void shouldInferConcreteReturnTypeForImportedGenericFunctionAgainstCompiledLibraries() {
         var libraries = compileProgram(List.of(
                 new RawModule("Seq", "/capy/lang", """
-                        type Seq[T] = Cons[T] | End
+                        union Seq[T] = Cons[T] | End
                         data Cons[T] { value: T, rest: () => Seq[T] }
                         single End
 

--- a/compiler/src/test/java/dev/capylang/generator/JavaScriptGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/JavaScriptGeneratorTest.java
@@ -182,7 +182,7 @@ class JavaScriptGeneratorTest {
                         "ObjectOrientedFpInterop",
                         "/foo",
                         """
-                                type InteropPet = InteropDog | InteropCat
+                                union InteropPet = InteropDog | InteropCat
                                 data InteropDog { name: String }
                                 data InteropCat { age: int }
 

--- a/compiler/src/test/java/dev/capylang/generator/ObjectOrientedJavaGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/ObjectOrientedJavaGeneratorTest.java
@@ -349,7 +349,7 @@ class ObjectOrientedJavaGeneratorTest {
                         "ObjectOrientedFpInterop",
                         "/foo/boo",
                         """
-                                type InteropPet = InteropDog | InteropCat
+                                union InteropPet = InteropDog | InteropCat
                                 data InteropDog { name: String }
                                 data InteropCat { age: int }
 
@@ -422,7 +422,7 @@ class ObjectOrientedJavaGeneratorTest {
                         "SharedInterop",
                         "/foo/boo",
                         """
-                                type SharedPet = SharedDog | SharedCat
+                                union SharedPet = SharedDog | SharedCat
                                 data SharedDog { name: String }
                                 data SharedCat { age: int }
 
@@ -494,7 +494,7 @@ class ObjectOrientedJavaGeneratorTest {
                         "SharedInterop",
                         "",
                         """
-                                type SharedPet = SharedDog | SharedCat
+                                union SharedPet = SharedDog | SharedCat
                                 data SharedDog { name: String }
                                 data SharedCat { age: int }
 

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -261,7 +261,7 @@ class JavaExpressionEvaluatorTest {
                 data JUnitReport { suites: List[JUnitTestSuite] }
 
                 /// Node type
-                type JUnitNode = JUnitReport
+                union JUnitNode = JUnitReport
                 """);
 
         var generated = new JavaGenerator().generate(program).modules().stream()
@@ -309,9 +309,9 @@ class JavaExpressionEvaluatorTest {
 
                 data Assertion { result: bool, message: String, type: String }
                 data StringAssert { value: String, assertions: List[Assertion] }
-                type Assert { assertions: List[Assertion] } = StringAssert
+                union Assert { assertions: List[Assertion] } = StringAssert
                 single Passed
-                type TestResult = Passed
+                union TestResult = Passed
                 data TestCase { name: String, result: TestResult, assertions_count: int, execution_time: long }
 
                 private fun execute(assertions: List[Assertion]): TestResult = Passed {}
@@ -342,9 +342,9 @@ class JavaExpressionEvaluatorTest {
 
                 data Assertion { result: bool, message: String, type: String }
                 data StringAssert { value: String, assertions: List[Assertion] }
-                type Assert { assertions: List[Assertion] } = StringAssert
+                union Assert { assertions: List[Assertion] } = StringAssert
                 single Passed
-                type TestResult = Passed
+                union TestResult = Passed
                 data TestCase { name: String, result: TestResult, assertions_count: int, execution_time: long }
 
                 private fun execute(assertions: List[Assertion]): TestResult = Passed {}
@@ -837,7 +837,7 @@ class JavaExpressionEvaluatorTest {
                 from /capy/collection/Dict import { * }
                 from /capy/lang/Seq import { * }
 
-                type Outcome = ParseSucceeded | ParseFailed
+                union Outcome = ParseSucceeded | ParseFailed
                 data ParseSucceeded { source: String }
                 data ParseFailed { source: String }
 
@@ -863,7 +863,7 @@ class JavaExpressionEvaluatorTest {
                 from /capy/collection/Set import { * }
                 from /capy/collection/Dict import { * }
 
-                type Outcome = ParseSucceeded | ParseFailed
+                union Outcome = ParseSucceeded | ParseFailed
                 data ParseSucceeded { source: String }
                 data ParseFailed { source: String }
                 data OutcomeBatch { outcomes: List[Outcome] }
@@ -952,7 +952,7 @@ class JavaExpressionEvaluatorTest {
         var generated = new JavaGenerator().generate(compileProgram("GenericResultBinding", "/foo/bar", """
                 from /capy/lang/Result import { * }
 
-                type Assert { assertions: List[() => String] } = StringAssert
+                union Assert { assertions: List[() => String] } = StringAssert
                 data StringAssert { assertions: List[() => String] }
                 data ResultAssert[T] { value: Result[T] }
 
@@ -1039,7 +1039,7 @@ class JavaExpressionEvaluatorTest {
                 from /capy/collection/Set import { * }
                 from /capy/collection/Dict import { * }
 
-                type Item = Text | Count
+                union Item = Text | Count
                 data Text { value: String }
                 data Count { value: int }
 
@@ -1103,7 +1103,7 @@ class JavaExpressionEvaluatorTest {
         var generatedProgram = new JavaGenerator().generate(compileProgram("TextFlatMapExpectedType", "/foo/bar", """
                 from /capy/collection/List import { * }
 
-                type TestSeq[T] = TestSeqEnd
+                union TestSeq[T] = TestSeqEnd
                 single TestSeqEnd
 
                 data Text { chars: List[String] }
@@ -1270,7 +1270,7 @@ class JavaExpressionEvaluatorTest {
                 Arguments.of(
                         "summon_tom",
                         """
-                                type Knight = EnglishKnight | Tom
+                                union Knight = EnglishKnight | Tom
                                 data EnglishKnight { power: float }
                                 single Tom
                                 fun summon_tom(): Knight = Tom {}
@@ -1347,7 +1347,7 @@ class JavaExpressionEvaluatorTest {
 
     private static RawModule reflectionMetadataModule() {
         return new RawModule("Reflection", "/capy/meta_prog", """
-                type AnyInfo { name: String, pkg: PackageInfo } =
+                union AnyInfo { name: String, pkg: PackageInfo } =
                     DataInfo
                     | InterfaceInfo
                     | ObjectInfo

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -127,7 +127,7 @@ class CapybaraParserTest {
                 Arguments.of(
                         "seq_first_wildcard",
                         """
-                                type Seq[T] = Cons[T] | End
+                                union Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Seq[T] }
                                 single End
 
@@ -140,7 +140,7 @@ class CapybaraParserTest {
                 Arguments.of(
                         "seq_first_wildcard_fq_singleton",
                         """
-                                type Seq[T] = Cons[T] | End
+                                union Seq[T] = Cons[T] | End
                                 data Cons[T] { value: T, rest: Seq[T] }
                                 single End
 
@@ -182,6 +182,21 @@ class CapybaraParserTest {
         assertThat(call.arguments().get(0)).isInstanceOf(PlaceholderExpression.class);
         assertThat(call.arguments().get(2)).isInstanceOf(PlaceholderExpression.class);
         assertThat(call.arguments().get(3)).isInstanceOf(PlaceholderExpression.class);
+    }
+
+    @Test
+    @DisplayName("should parse union keyword function calls as function calls")
+    void parseUnionKeywordFunctionCallsAsFunctionCalls() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun union(): int = 1
+                fun call_union(): int = union()
+                """));
+
+        var function = findFunction("call_union", module.functional());
+        assertThat(function.expression()).isInstanceOf(FunctionCall.class);
+        var call = (FunctionCall) function.expression();
+        assertThat(call.name()).isEqualTo("union");
+        assertThat(call.arguments()).isEmpty();
     }
 
     @Test
@@ -239,7 +254,7 @@ class CapybaraParserTest {
                 }
 
                 data User { name: String, age: int } derive Show
-                type Named { id: String } = Person derive Show
+                union Named { id: String } = Person derive Show
                 data Person { id: String, name: String }
                 """));
 
@@ -285,7 +300,7 @@ class CapybaraParserTest {
     @DisplayName("should parse type constructor and constructor-local star data")
     void parseTypeConstructor() {
         var module = parseSuccess(new RawModule("Test", "/parser", """
-                type User { age: int } with constructor {
+                union User { age: int } with constructor {
                    if age > 0 then Success { * { age: age } } else Error { "age" }
                 } = Adult | Child
                 """));
@@ -295,6 +310,18 @@ class CapybaraParserTest {
         assertThat(type.constructor().orElseThrow()).isInstanceOf(IfExpression.class);
         var constructor = (IfExpression) type.constructor().orElseThrow();
         assertThat(constructor.thenBranch()).isInstanceOf(NewData.class);
+    }
+
+    @Test
+    @DisplayName("should reject old type keyword for union declarations")
+    void rejectTypeKeywordForUnionDeclarations() {
+        var result = new CapybaraParser().parseModule(new RawModule("Test", "/parser", """
+                type Result = Success | Error
+                data Success {}
+                data Error {}
+                """));
+
+        assertThat(result).isInstanceOf(Result.Error.class);
     }
 
     @Test
@@ -595,7 +622,7 @@ class CapybaraParserTest {
                 data JUnitReport { suites: List[JUnitTestSuite] }
 
                 /// Represents a single suite
-                type JUnitNode = JUnitTestSuite
+                union JUnitNode = JUnitTestSuite
                 """));
 
         var data = findDefinition(DataDeclaration.class, "JUnitReport", module.functional());
@@ -609,7 +636,7 @@ class CapybaraParserTest {
     @DisplayName("should parse trailing comma in data and type field declarations")
     void parseTrailingCommaInDataAndTypeFieldDeclarations() {
         var module = parseSuccess(new RawModule("Test", "/parser", """
-                type T1 { a: int, b: String, c: int, } = D1 | D2
+                union T1 { a: int, b: String, c: int, } = D1 | D2
                 data D1 { d: int, e: int, }
                 data D2 { f: int, g: int, }
                 """));

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -18,7 +18,7 @@ from /capy/lang/String import { * }
 /// `Duration` is a sum type:
 /// - `DateDuration` for year/month/day/time durations
 /// - `WeekDuration` for ISO week-only durations like `P2W`
-type Duration = DateDuration | WeekDuration
+union Duration = DateDuration | WeekDuration
 
 /// Duration expressed with calendar and clock components.
 ///

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -5,7 +5,7 @@ from /capy/lang/Result import { * }
 from /capy/lang/String import { * }
 
 /// ISO 8601 interval represented using UTC date-time endpoints.
-type Interval =
+union Interval =
     DateTimeStartEnd
     | DateTimeStartDuration
     | DateTimeDurationEnd

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Effect.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Effect.cfun
@@ -1,4 +1,4 @@
-type Effect[T] = _UnsafeEffect[T]
+union Effect[T] = _UnsafeEffect[T]
 
 private data _UnsafeEffect[T] { unsafe_thunk: () => T }
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
@@ -1,3 +1,3 @@
-type Option[T] = Some[T] | None
+union Option[T] = Some[T] | None
 data Some[T] { value: T }
 single None

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Program.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Program.cfun
@@ -1,3 +1,3 @@
-type Program = Success | Failed
+union Program = Success | Failed
 data Success { results: List[String] }
 data Failed { exitCode: int, errors: List[String] }

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
@@ -1,4 +1,4 @@
-type Result[T] = Success[T] | Error
+union Result[T] = Success[T] | Error
 data Success[T] { value: T }
 data Error { message: String }
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -2,7 +2,7 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 
-type Seq[T] = Cons[T] | End
+union Seq[T] = Cons[T] | End
 data Cons[T] { value: T, rest: () => Seq[T] }
 single End
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/TimeUnit.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/TimeUnit.cfun
@@ -1,4 +1,4 @@
-type TimeUnit = NanoSecond | MicroSecond | MilliSecond | Second | Minute | Hour | Day | Week
+union TimeUnit = NanoSecond | MicroSecond | MilliSecond | Second | Minute | Hour | Day | Week
 
 data NanoSecond { value: long } 
 data MicroSecond { value: long } 

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Reflection.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Reflection.cfun
@@ -1,11 +1,11 @@
-type AnyInfo { name: String, pkg: PackageInfo } = CFunInfo | CooInfo
-type CFunInfo = DataInfo
+union AnyInfo { name: String, pkg: PackageInfo } = CFunInfo | CooInfo
+union CFunInfo = DataInfo
     | ListInfo
     | SetInfo
     | DictInfo
     | TupleInfo
     | FunctionTypeInfo
-type CooInfo =
+union CooInfo =
     InterfaceInfo
     | ObjectInfo
     | TraitInfo

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -7,7 +7,7 @@ from /capy/lang/Seq import { * }
 from /capy/lang/String import { * }
 from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
 
-type Json = JsonObject | JsonArray | JsonValue
+union Json = JsonObject | JsonArray | JsonValue
 data JsonObject { value: Dict[Json] }
 fun JsonObject.`+`(other: JsonObject): JsonObject = JsonObject { value: this.value + other.value }
 fun JsonObject.`+`(other: Tuple[String, Json]): JsonObject = JsonObject { value: this.value + other }
@@ -21,9 +21,9 @@ fun JsonArray.`+`(other: JsonArray): JsonArray = JsonArray { value: this.value +
 fun JsonArray.`+`(other: Json): JsonArray = JsonArray { value: this.value + other }
 fun JsonArray.get(index: int): Option[Json] = this.value[index]
 
-type JsonValue = JsonString | JsonValueObject | JsonNumber | JsonValueArray | JsonBool | JsonNull
+union JsonValue = JsonString | JsonValueObject | JsonNumber | JsonValueArray | JsonBool | JsonNull
 data JsonString { value: String }
-type JsonNumber = JsonNumberDouble | JsonNumberLong
+union JsonNumber = JsonNumberDouble | JsonNumberLong
 data JsonNumberDouble { value: double }
 data JsonNumberLong { value: long }
 data JsonValueObject { value: JsonObject }

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -13,7 +13,7 @@ from /capy/date_time/Interval import { * }
 
 data Assertion { result: bool, message: String, type: String }
 
-type Assert { assertions: List[() => Assertion] } =
+union Assert { assertions: List[() => Assertion] } =
     _TechnicalAssert
     | StringAssert | IntAssert | LongAssert | DoubleAssert | FloatAssert | BoolAssert
     | DataAssert | OptionAssert | ResultAssert

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -19,7 +19,7 @@ from /capy/serialization/Json import { JsonString, stringify }
 
 data TestFile { file_name: String, test_cases: List[TestCase], timestamp_millis: long }
 data TestCase { name: String, result: TestResult, assertions_count: int, execution_time: double, assert_supplier: () => Assert }
-type TestResult = Passed | Failed
+union TestResult = Passed | Failed
 single Passed
 data Failed { message: String, type: String }
 enum LogType { NONE, LOG, TEAM_CITY }
@@ -109,7 +109,7 @@ fun TestCase.failed(): bool =
     case Failed -> true
 
 enum ReportType { JUNIT, CTRF, JEST }
-type Report = JUnitReport | CtrfReport | JestReport
+union Report = JUnitReport | CtrfReport | JestReport
 
 /// See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml)
 data JUnitReport { suites: List[JUnitTestSuite] }


### PR DESCRIPTION
## Summary
- rename cfun union declarations from `type` to `union` in the grammar
- migrate standard library, e2e fixtures, compiler snippets, README examples, and IntelliJ syntax bundles
- add parser coverage rejecting the old `type` declaration keyword

## Impacted modules
- `compiler`
- `capy`
- `lib/capybara-lib`
- `Intellij`

## Verification
- `./gradlew :compiler:test`
- `./gradlew :capy:e2e-cfun`
- `./gradlew clean check`

## Example
```cfun
union Option[T] = Some[T] | None
```