### PR TITLE
fix(#152): preserve generated const names

### DIFF
--- a/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -329,10 +329,11 @@ public final class JavaScriptGenerator implements Generator {
 
         private String renderConst(JavaConst javaConst) {
             var expression = expressions.render(javaConst.expression(), Scope.root());
+            var name = jsConstIdentifier(javaConst.name());
             if (!javaConst.isPrivate()) {
-                exportNames.add(javaConst.name());
+                exportNames.add(name);
             }
-            return "const " + javaConst.name() + " = " + expression + ";\n";
+            return "const " + name + " = " + expression + ";\n";
         }
 
         private String renderFunction(JavaMethod method, boolean topLevel) {
@@ -1292,7 +1293,7 @@ public final class JavaScriptGenerator implements Generator {
                 return false;
             }
             var name = simpleMethodName(functionCall.name());
-            return name.contains("__local_const_") || CONST_NAME_PATTERN.matcher(name).matches();
+            return name.contains("__local_const_") || isTopLevelConstName(name);
         }
     }
 
@@ -1415,6 +1416,7 @@ public final class JavaScriptGenerator implements Generator {
                 module.javaClass().staticConsts().stream()
                         .filter(javaConst -> !javaConst.isPrivate())
                         .map(JavaConst::name)
+                        .map(JavaScriptGenerator::jsConstIdentifier)
                         .forEach(moduleExports::add);
                 module.javaClass().staticMethods().stream()
                         .filter(method -> !method.isPrivate())
@@ -1574,12 +1576,15 @@ public final class JavaScriptGenerator implements Generator {
         }
 
         String emittedFunctionName(String name, List<CompiledType> parameterTypes) {
+            var simple = simpleMethodName(name);
+            if (parameterTypes.isEmpty() && isTopLevelConstName(simple)) {
+                return jsConstIdentifier(simple);
+            }
             var key = signatureKey(name, parameterTypes);
             if (functionNameOverrides.containsKey(key)) {
                 return functionNameOverrides.get(key);
             }
             var parameterSignature = parameterTypes.stream().map(String::valueOf).collect(joining(","));
-            var simple = simpleMethodName(name);
             if (simple.contains("__local_const_")) {
                 return normalizeJsIdentifier(simple);
             }
@@ -5220,6 +5225,17 @@ public final class JavaScriptGenerator implements Generator {
             return identifier + "_";
         }
         return identifier;
+    }
+
+    static String jsConstIdentifier(String rawName) {
+        if (isTopLevelConstName(rawName) && isValidJsIdentifier(rawName) && !JS_KEYWORDS.contains(rawName)) {
+            return rawName;
+        }
+        return normalizeJsIdentifier(rawName);
+    }
+
+    private static boolean isTopLevelConstName(String name) {
+        return CONST_NAME_PATTERN.matcher(name).matches();
     }
 
     private static String encodeSymbolicIdentifier(String raw) {

--- a/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -341,7 +341,7 @@ public final class PythonGenerator implements Generator {
 
         private String renderConst(JavaConst javaConst) {
             var expression = expressions.render(javaConst.expression(), Scope.root());
-            var name = pyIdentifier(javaConst.name());
+            var name = pyConstIdentifier(javaConst.name());
             if (!javaConst.isPrivate()) {
                 exportNames.add(name);
             }
@@ -1248,7 +1248,7 @@ public final class PythonGenerator implements Generator {
                 return false;
             }
             var name = simpleMethodName(functionCall.name());
-            return name.contains("__local_const_") || CONST_NAME_PATTERN.matcher(name).matches();
+            return name.contains("__local_const_") || isTopLevelConstName(name);
         }
     }
 
@@ -1373,7 +1373,7 @@ public final class PythonGenerator implements Generator {
                 }
                 module.javaClass().staticConsts().stream()
                         .filter(javaConst -> !javaConst.isPrivate())
-                        .map(javaConst -> pyIdentifier(javaConst.name()))
+                        .map(javaConst -> pyConstIdentifier(javaConst.name()))
                         .forEach(moduleExports::add);
                 module.javaClass().staticMethods().stream()
                         .filter(method -> !method.isPrivate())
@@ -1534,12 +1534,15 @@ public final class PythonGenerator implements Generator {
         }
 
         String emittedFunctionName(String name, List<CompiledType> parameterTypes) {
+            var simple = simpleMethodName(name);
+            if (parameterTypes.isEmpty() && isTopLevelConstName(simple)) {
+                return pyConstIdentifier(simple);
+            }
             var key = signatureKey(name, parameterTypes);
             if (functionNameOverrides.containsKey(key)) {
                 return functionNameOverrides.get(key);
             }
             var parameterSignature = parameterTypes.stream().map(String::valueOf).collect(joining(","));
-            var simple = simpleMethodName(name);
             if (simple.contains("__local_const_")) {
                 return pyIdentifier(simple);
             }
@@ -3586,6 +3589,17 @@ public final class PythonGenerator implements Generator {
             return "capy" + js;
         }
         return js;
+    }
+
+    static String pyConstIdentifier(String rawName) {
+        if (isTopLevelConstName(rawName) && isValidPyIdentifier(rawName) && !PY_KEYWORDS.contains(rawName)) {
+            return rawName;
+        }
+        return pyIdentifier(rawName);
+    }
+
+    private static boolean isTopLevelConstName(String name) {
+        return CONST_NAME_PATTERN.matcher(name).matches();
     }
 
     static boolean isValidPyIdentifier(String value) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -286,12 +286,19 @@ public class JavaAstBuilder {
 
     private JavaConst buildStaticConst(CompiledFunction function) {
         return new JavaConst(
-                emittedFunctionName(function),
+                emittedConstName(function),
                 function.name().startsWith("_") || function.visibility() == Visibility.PRIVATE,
                 buildJavaType(function.returnType()),
                 function.expression(),
                 function.comments()
         );
+    }
+
+    private String emittedConstName(CompiledFunction function) {
+        if (isTopLevelConstName(function.name())) {
+            return function.name();
+        }
+        return emittedFunctionName(function);
     }
 
     private JavaMethod buildStaticMethod(CompiledFunction function, List<String> qualifiedJavaClassNames) {
@@ -402,7 +409,7 @@ public class JavaAstBuilder {
             return memberName;
         }
         if (isUpperSnakeConstName(memberName)) {
-            return buildMethodName(memberName);
+            return memberName;
         }
         if (isTypeLikeIdentifier(memberName)) {
             return buildClassName(memberName).toString();

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -685,7 +685,7 @@ public class JavaExpressionEvaluator {
         }
         var lastDot = name.lastIndexOf('.');
         var simpleName = lastDot >= 0 ? name.substring(lastDot + 1) : name;
-        return CONST_NAME_PATTERN.matcher(simpleName).matches();
+        return isTopLevelConstName(simpleName);
     }
 
     private static Scope evaluateFunctionInvoke(CompiledFunctionInvoke functionInvoke, Scope scope) {
@@ -3477,6 +3477,10 @@ public class JavaExpressionEvaluator {
 
     private static String emittedMethodName(CompiledFunctionCall functionCall) {
         var parameterTypes = functionCall.arguments().stream().map(CompiledExpression::type).toList();
+        var simpleMethodName = simpleMethodName(functionCall.name());
+        if (parameterTypes.isEmpty() && isTopLevelConstName(simpleMethodName)) {
+            return simpleMethodName;
+        }
         var key = signatureKey(functionCall.name(), parameterTypes);
         var functionNameOverrides = functionNameOverrides();
         if (functionNameOverrides.containsKey(key)) {
@@ -3489,7 +3493,6 @@ public class JavaExpressionEvaluator {
         var parameterSignature = parameterTypes.stream()
                 .map(type -> String.valueOf(type))
                 .collect(java.util.stream.Collectors.joining(","));
-        var simpleMethodName = simpleMethodName(functionCall.name());
         var overrideBySimpleName = findOverrideBySimpleName(functionCall.name(), parameterSignature);
         if (overrideBySimpleName.isPresent()) {
             return overrideBySimpleName.get();
@@ -3499,6 +3502,10 @@ public class JavaExpressionEvaluator {
             return methodName;
         }
         return normalizeJavaMethodName(methodName);
+    }
+
+    private static boolean isTopLevelConstName(String name) {
+        return CONST_NAME_PATTERN.matcher(name).matches();
     }
 
     private static Optional<String> standardEmittedMethodName(

--- a/compiler/src/test/java/dev/capylang/generator/JavaScriptGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/JavaScriptGeneratorTest.java
@@ -287,6 +287,34 @@ class JavaScriptGeneratorTest {
     }
 
     @Test
+    void shouldPreserveUpperSnakeConstNames() throws Exception {
+        var program = compileProgram("""
+                const FOO_BOO_X_Y: String = "foo"
+
+                fun read(): String = FOO_BOO_X_Y
+                """);
+
+        var generated = new JavaScriptGenerator().generate(program);
+        var main = generated.modules().stream()
+                .filter(module -> module.relativePath().equals(Path.of("foo", "Main.js")))
+                .map(GeneratedModule::code)
+                .findFirst()
+                .orElseThrow();
+        assertThat(main).contains("const FOO_BOO_X_Y = \"foo\";");
+        assertThat(main).contains("return FOO_BOO_X_Y;");
+        assertThat(main).doesNotContain("fOOBOOXY");
+
+        writeGenerated(generated);
+
+        var output = runNode("""
+                const m = require('./foo/Main.js');
+                console.log([m.FOO_BOO_X_Y, m.read()].join('|'));
+                """);
+
+        assertThat(output).isEqualTo("foo|foo");
+    }
+
+    @Test
     void shouldResolveImportedEnumQualifierStaticCall() throws Exception {
         var program = compileProgram(List.of(
                 new RawModule("Modes", "/foo/lib", """

--- a/compiler/src/test/java/dev/capylang/generator/PythonGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/PythonGeneratorTest.java
@@ -215,6 +215,34 @@ class PythonGeneratorTest {
     }
 
     @Test
+    void shouldPreserveUpperSnakeConstNames() throws Exception {
+        var program = compileProgram("""
+                const FOO_BOO_X_Y: String = "foo"
+
+                fun read(): String = FOO_BOO_X_Y
+                """);
+
+        var generated = new PythonGenerator().generate(program);
+        var main = generated.modules().stream()
+                .filter(module -> module.relativePath().equals(Path.of("foo", "Main.py")))
+                .map(GeneratedModule::code)
+                .findFirst()
+                .orElseThrow();
+        assertThat(main).contains("FOO_BOO_X_Y = \"foo\"");
+        assertThat(main).contains("return FOO_BOO_X_Y");
+        assertThat(main).doesNotContain("fOOBOOXY");
+
+        writeGenerated(generated);
+
+        var output = runPython("""
+                import foo.Main as m
+                print('|'.join([m.FOO_BOO_X_Y, m.read()]))
+                """);
+
+        assertThat(output).isEqualTo("foo|foo");
+    }
+
+    @Test
     void shouldResolveImportedEnumQualifierStaticCall() throws Exception {
         var program = compileProgram(List.of(
                 new RawModule("Modes", "/foo/lib", """

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -301,6 +301,25 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldPreserveUpperSnakeConstNames() {
+        var program = compileProgram("ConstNames", "/foo", """
+                const FOO_BOO_X_Y: String = "foo"
+
+                fun read(): String = FOO_BOO_X_Y
+                """);
+
+        var generatedProgram = new JavaGenerator().generate(program);
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated).contains("public static final java.lang.String FOO_BOO_X_Y = \"foo\";");
+        assertThat(generated).contains("return foo.ConstNames.FOO_BOO_X_Y;");
+        assertThat(generated).doesNotContain("fOOBOOXY");
+        assertGeneratedJavaCompiles(generatedProgram);
+    }
+
+    @Test
     void shouldGenerateCapyTestMethodFromSourceForCapyTestModule() {
         var program = compileProgram(List.of(collectionsModule(), new RawModule("CapyTest", "/capy/test", """
                 from /capy/collection/List import { * }
@@ -629,8 +648,8 @@ class JavaExpressionEvaluatorTest {
                 .findFirst()
                 .orElseThrow();
 
-        assertThat(generated).contains("import static foo.Bounds.fLOATBOUND;");
-        assertThat(generated).doesNotContain("import foo.Bounds.FLOATBOUND;");
+        assertThat(generated).contains("import static foo.Bounds.FLOAT_BOUND;");
+        assertThat(generated).doesNotContain("import static foo.Bounds.fLOATBOUND;");
         assertGeneratedJavaCompiles(generatedProgram);
     }
 

--- a/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/DateTimeUtil.java
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 public final class DateTimeUtil {
-    private static final int JAVA_MAX_OFFSET_MINUTES = 18 * TimeModule.mINUTESINHOUR;
+    private static final int JAVA_MAX_OFFSET_MINUTES = 18 * TimeModule.MINUTES_IN_HOUR;
 
     private DateTimeUtil() {
     }
@@ -61,12 +61,12 @@ public final class DateTimeUtil {
      */
     public static Time fromJavaOffsetTime(OffsetTime time) {
         var totalSeconds = time.getOffset().getTotalSeconds();
-        if (Math.floorMod(totalSeconds, TimeModule.sECONDSINMINUTE) != 0) {
+        if (Math.floorMod(totalSeconds, TimeModule.SECONDS_IN_MINUTE) != 0) {
             throw new IllegalArgumentException(
                     "Java offset with second precision is unsupported: " + time.getOffset()
             );
         }
-        var offsetMinutes = Math.floorDiv(totalSeconds, TimeModule.sECONDSINMINUTE);
+        var offsetMinutes = Math.floorDiv(totalSeconds, TimeModule.SECONDS_IN_MINUTE);
         var truncated = time.toLocalTime().truncatedTo(ChronoUnit.SECONDS);
         return new Time(truncated.getHour(), truncated.getMinute(), truncated.getSecond(), Optional.of(offsetMinutes));
     }
@@ -97,7 +97,7 @@ public final class DateTimeUtil {
         if (minutes < -JAVA_MAX_OFFSET_MINUTES || minutes > JAVA_MAX_OFFSET_MINUTES) {
             throw new IllegalArgumentException("Capy offset out of Java ZoneOffset range: " + minutes + " minutes");
         }
-        return ZoneOffset.ofTotalSeconds(Math.multiplyExact(minutes, TimeModule.sECONDSINMINUTE));
+        return ZoneOffset.ofTotalSeconds(Math.multiplyExact(minutes, TimeModule.SECONDS_IN_MINUTE));
     }
 
     private static Optional<Integer> offsetMinutes(Time time) {


### PR DESCRIPTION
## Summary
- Preserve upper-snake const names in Java, JavaScript, and Python generated output/exports
- Preserve upper-snake static imports and update DateTimeUtil references to generated const names
- Add Java/JS/Python generator regression coverage for FOO_BOO_X_Y

Fixes #152

## Impacted modules
- compiler
- lib/capybara-lib

## Validation
- ./gradlew :compiler:test
- ./gradlew :capy:e2e-cfun :capy:e2e-cfun-js :capy:e2e-cfun-python :lib:capybara-lib:testCapybara

## Sample
`const FOO_BOO_X_Y: String = "foo"` now emits `FOO_BOO_X_Y` in Java, JS, and Python outputs.