### PR TITLE
feat(#156): remove underscore prefixes from Capybara sources

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ConsoleIo.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ConsoleIo.cfun
@@ -51,12 +51,12 @@ fun emit_byte_lists(bytes: List[byte]): Effect[List[byte]] =
     println_error(bytes)
 
 fun read_one(): Effect[String] =
-    read_line().map(line => _line_or_eof(line))
+    read_line().map(line => line_or_eof(line))
 
 fun read_eof_marker(): Effect[String] =
-    read_line().map(line => _line_or_eof(line))
+    read_line().map(line => line_or_eof(line))
 
-fun _line_or_eof(line: Option[String]): String =
+private fun line_or_eof(line: Option[String]): String =
     match line with
     case Some { value } -> value
     case None -> "EOF"

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/Consts.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/Consts.cfun
@@ -28,15 +28,15 @@ fun pi_plus_e(): double = PI + E
 fun uses_private_const(): int = HIDDEN + 1
 
 fun local_consts(x: int): int =
-    const __BASE = 10
-    const __INC: int = 5
+    const BASE = 10
+    const INC: int = 5
     ---
-    x + __BASE + __INC
+    x + BASE + INC
 
 fun local_private_named_const(x: String): bool =
-    const __white_space: Set[String] = { " ", "\t", "\n" }
+    const white_space: Set[String] = { " ", "\t", "\n" }
     ---
-    __white_space ? x
+    white_space ? x
 
 fun primitives_summary(): String =
     BYTE_V + ":" + INT_V + ":" + LONG_V + ":" + FLOAT_V + ":" + DOUBLE_V + ":" + BOOL_V + ":" + STRING_V

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/GeneratorSemVer.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/GeneratorSemVer.cfun
@@ -12,37 +12,37 @@ fun Pretty.to_string(): String = "pretty:" + this.value
 fun custom_to_string(value: String): String = Pretty { value }.to_string()
 
 fun parse_local_option(value: int): Result[int] =
-    data __Parse[T] { buffer: String, value: T }
-    fun unwrap(parse: __Parse[Option[int]]): Result[__Parse[int]] =
+    data Parse[T] { buffer: String, value: T }
+    fun unwrap(parse: Parse[Option[int]]): Result[Parse[int]] =
         match parse.value with
-        case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
+        case Some { inner } -> Success { Parse { buffer: parse.buffer, value: inner } }
         case None -> Error { "missing value" }
     ---
-    unwrap(__Parse { buffer: "", value: Some { value } })
+    unwrap(Parse { buffer: "", value: Some { value } })
     | parsed => Success { parsed.value }
 
 fun parse_local_option_none(): Result[int] =
-    data __Parse[T] { buffer: String, value: T }
-    fun unwrap(parse: __Parse[Option[int]]): Result[__Parse[int]] =
+    data Parse[T] { buffer: String, value: T }
+    fun unwrap(parse: Parse[Option[int]]): Result[Parse[int]] =
         match parse.value with
-        case Some { inner } -> Success { __Parse { buffer: parse.buffer, value: inner } }
+        case Some { inner } -> Success { Parse { buffer: parse.buffer, value: inner } }
         case None -> Error { "missing value" }
     ---
     let none_value: Option[int] = None {}
-    unwrap(__Parse { buffer: "", value: none_value })
+    unwrap(Parse { buffer: "", value: none_value })
     | parsed => Success { parsed.value }
 
 fun parse_local_semver_build(version: String): Result[String] =
-    data __Parse[T] { buffer: String, value: T }
-    fun parse_build(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer: "", value: buffer } }
+    data Parse[T] { buffer: String, value: T }
+    fun parse_build(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer: "", value: buffer } }
     ---
-    let parse: __Parse[SemVer] = __Parse {
+    let parse: Parse[SemVer] = Parse {
         buffer: version,
         value: SemVer { major: 1, build_metadata: None {} }
     }
     parse_build(parse.buffer)
-    | parse_build => Success { __Parse {
+    | parse_build => Success { Parse {
         buffer: parse_build.buffer,
         value: parse.value.with(build_metadata: Some { parse_build.value })
     }}
@@ -52,16 +52,16 @@ fun parse_local_semver_build(version: String): Result[String] =
         case None -> Error { "missing metadata" }
 
 fun parse_local_semver_build_and_increment(version: String): Result[int] =
-    data __Parse[T] { buffer: String, value: T }
-    fun parse_build(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer: "", value: buffer } }
+    data Parse[T] { buffer: String, value: T }
+    fun parse_build(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer: "", value: buffer } }
     ---
-    let parse: __Parse[SemVer] = __Parse {
+    let parse: Parse[SemVer] = Parse {
         buffer: version,
         value: SemVer { major: 1, build_metadata: None {} }
     }
     parse_build(parse.buffer)
-    | parse_build => Success { __Parse {
+    | parse_build => Success { Parse {
         buffer: parse_build.buffer,
         value:
             parse.value

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/GroupedExpression.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/GroupedExpression.cfun
@@ -13,17 +13,17 @@ fun nested_pipe_in_match_branch(value: int): Result[int] =
     }
 
 fun grouped_guarded_match_is_exhaustive(input: String): Result[String] =
-    data __Parse[T] { buffer: String, value: T }
-    fun parse_tail(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer, "tail" } }
-    fun parse_build(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer, "build" } }
+    data Parse[T] { buffer: String, value: T }
+    fun parse_tail(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer, "tail" } }
+    fun parse_build(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer, "build" } }
     ---
-    let parse_patch: __Parse[String] = __Parse { input, "base" }
+    let parse_patch: Parse[String] = Parse { input, "base" }
     match parse_patch.buffer[0] with
     case Some { ch } when ch == '-' -> {
         parse_tail(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_tail => Success { __Parse {
+        | parse_tail => Success { Parse {
             buffer: parse_tail.buffer,
             value: "pre:" + parse_tail.value
         }}
@@ -44,18 +44,18 @@ fun grouped_guarded_match_is_exhaustive(input: String): Result[String] =
     case None -> Success { "none" }
 
 fun semver_style_mixed_case_pipe_bodies(input: String): Result[String] =
-    data __Parse[T] { buffer: String, value: T }
-    fun parse_pre_release(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer, "rc1" } }
-    fun parse_build(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer, "001" } }
+    data Parse[T] { buffer: String, value: T }
+    fun parse_pre_release(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer, "rc1" } }
+    fun parse_build(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer, "001" } }
     ---
-    let parse_patch: __Parse[String] = __Parse { input, "1.2.3" }
+    let parse_patch: Parse[String] = Parse { input, "1.2.3" }
     let raw_sem_ver = "1.2.3"
     match parse_patch.buffer[0] with
     case Some { next_char } when next_char == '-' -> {
         parse_pre_release(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_pre_release => Success { __Parse {
+        | parse_pre_release => Success { Parse {
             buffer: parse_pre_release.buffer,
             value: raw_sem_ver + "-" + parse_pre_release.value
         }}
@@ -76,18 +76,18 @@ fun semver_style_mixed_case_pipe_bodies(input: String): Result[String] =
     case None -> Success { raw_sem_ver }
 
 fun inner_ungrouped_pipe_in_match_inside_lambda(input: String): Result[String] =
-    data __Parse[T] { buffer: String, value: T }
-    fun parse_pre_release(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer, "rc1" } }
-    fun parse_build(buffer: String): Result[__Parse[String]] =
-        Success { __Parse { buffer, "001" } }
+    data Parse[T] { buffer: String, value: T }
+    fun parse_pre_release(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer, "rc1" } }
+    fun parse_build(buffer: String): Result[Parse[String]] =
+        Success { Parse { buffer, "001" } }
     ---
-    let parse_patch: __Parse[String] = __Parse { input, "1.2.3" }
+    let parse_patch: Parse[String] = Parse { input, "1.2.3" }
     let raw_sem_ver = "1.2.3"
     match parse_patch.buffer[0] with
     case Some { next_char } when next_char == '-' -> {
         parse_pre_release(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_pre_release => Success { __Parse {
+        | parse_pre_release => Success { Parse {
             buffer: parse_pre_release.buffer,
             value: raw_sem_ver + "-" + parse_pre_release.value
         }}

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LambdaValues.cfun
@@ -26,8 +26,8 @@ fun invoke_partial_add(): int =
     f(5)
 
 fun invoke_partial_add_with_generated_name_collision(): int =
-    let __capybaraPartial1 = 10
-    let f: int => int = add(__capybaraPartial1, _)
+    let capybaraPartial1 = 10
+    let f: int => int = add(capybaraPartial1, _)
     f(5)
 
 fun concat(a: String, b: String, c: String): String = a + b + c

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -1,62 +1,62 @@
 from /capy/lang/Result import { * }
 
 fun foo_me(name: String): String =
-    union __Name = __Foo | __Boo | __Unknown
-    data __Foo { foo: String }
-    data __Boo { boo: String }
-    data __Unknown { unkn: String }
-    fun name(value: __Name): String =
+    union Name = Foo | Boo | Unknown
+    data Foo { foo: String }
+    data Boo { boo: String }
+    data Unknown { unkn: String }
+    fun name(value: Name): String =
         match value with
-        case __Foo { foo } -> foo
-        case __Boo { boo } -> boo
-        case __Unknown { unkn } -> unkn
+        case Foo { foo } -> foo
+        case Boo { boo } -> boo
+        case Unknown { unkn } -> unkn
     ---
     let x =
         match name with
-        case "foo" -> __Foo { "xyz" }
-        case "boo" -> __Boo { "zyx" }
-        case _ -> __Unknown { name }
+        case "foo" -> Foo { "xyz" }
+        case "boo" -> Boo { "zyx" }
+        case _ -> Unknown { name }
     name(x)
 
 fun local_data_with_imported_result(v: int): String =
-    data __Entry { key: String, value: Result[int] }
+    data Entry { key: String, value: Result[int] }
     ---
-    let entry = __Entry { "k", Success { value: v } }
+    let entry = Entry { "k", Success { value: v } }
     match entry.value with
     case Success { value } -> "ok:" + value
     case Error { message } -> "err:" + message
 
 fun local_data_used_in_local_function(v: int): String =
-    data __Parse[T] { value: T }
-    fun unwrap(parse: __Parse[int]): String =
+    data Parse[T] { value: T }
+    fun unwrap(parse: Parse[int]): String =
         "value:" + parse.value
     ---
-    unwrap(__Parse { v })
+    unwrap(Parse { v })
 
 fun local_generic_data_used_in_local_function_return_type(v: int): String =
-    data __Parse[T] { value: T }
-    fun parse(value: int): Result[__Parse[int]] =
-        Success { __Parse { value } }
+    data Parse[T] { value: T }
+    fun parse(value: int): Result[Parse[int]] =
+        Success { Parse { value } }
     ---
     match parse(v) with
     case Success { value } -> "value:" + value.value
     case Error { message } -> "error:" + message
 
 fun local_single_used_in_local_type_and_function(use_stop: bool): String =
-    union __Token = __Value | Stop
-    data __Value { value: int }
+    union Token = Value | Stop
+    data Value { value: int }
     single Stop
-    fun describe(token: __Token): String =
+    fun describe(token: Token): String =
         match token with
-        case __Value { value } -> "value:" + value
+        case Value { value } -> "value:" + value
         case Stop -> "stop"
     ---
-    describe(if use_stop then Stop {} else __Value { 7 })
+    describe(if use_stop then Stop {} else Value { 7 })
 
 fun local_generic_data_field_access_followed_by_index(buffer: String): String =
-    data __Parse[T] { buffer: String, value: T }
-    fun parse(value: String): Result[__Parse[int]] =
-        Success { __Parse { buffer: value, value: 1 } }
+    data Parse[T] { buffer: String, value: T }
+    fun parse(value: String): Result[Parse[int]] =
+        Success { Parse { buffer: value, value: 1 } }
     ---
     match (parse(buffer) | parse =>
         match parse.buffer[0] with
@@ -66,9 +66,9 @@ fun local_generic_data_field_access_followed_by_index(buffer: String): String =
     case Error { message } -> message
 
 fun local_generic_option_constructor_pattern_binding(v: int): int =
-    data __Parse[T] { value: T }
+    data Parse[T] { value: T }
     ---
-    let parse: __Parse[Option[int]] = __Parse { Some { v } }
+    let parse: Parse[Option[int]] = Parse { Some { v } }
     match parse.value with
     case Some { value } -> value * 10 + v
     case None -> 0

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/PrivateData.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/PrivateData.cfun
@@ -1,11 +1,11 @@
-data _Parse[T] { value: T, parsing_string: String }
+private data InternalParse[T] { value: T, parsing_string: String }
 data Parse[T] { message: T }
 
 fun parse_int(v: int): String =
-    let parsed = _Parse[int] { value: v, parsing_string: "ok" }
+    let parsed = InternalParse[int] { value: v, parsing_string: "ok" }
     parsed.parsing_string + ":" + parsed.value
 
 fun parse_conflict(v: String): String =
-    let private_parse = _Parse[String] { value: v, parsing_string: "internal" }
+    let private_parse = InternalParse[String] { value: v, parsing_string: "internal" }
     let public_parse = Parse[String] { message: v }
     private_parse.parsing_string + ":" + public_parse.message

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/RecFunctions.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/RecFunctions.cfun
@@ -5,10 +5,10 @@ fun rec sum(n: int, acc: int): int =
     if n <= 0 then acc else sum(n - 1, acc + n)
 
 fun sum_inner(n: int): int =
-    fun rec __sum(n: int, acc: int): int =
-        if n <= 0 then acc else __sum(n - 1, acc + n)
+    fun rec sum(n: int, acc: int): int =
+        if n <= 0 then acc else sum(n - 1, acc + n)
     ---
-    __sum(n, 0)
+    sum(n, 0)
 
 fun rec sum_with_let(n: int, acc: int): int =
     let next_n = n - 1
@@ -30,16 +30,16 @@ fun unmarked_tail_factorial_large(n: int, acc: int): int =
     if n <= 1 then acc else unmarked_tail_factorial_large(n - 1, acc * n)
 
 fun unmarked_local_tail_sum(n: int): int =
-    fun __sum(n: int, acc: int): int =
-        if n <= 0 then acc else __sum(n - 1, acc + n)
+    fun sum(n: int, acc: int): int =
+        if n <= 0 then acc else sum(n - 1, acc + n)
     ---
-    __sum(n, 0)
+    sum(n, 0)
 
 fun unmarked_local_tail_factorial_large(n: int): int =
-    fun __factorial(n: int, acc: int): int =
-        if n <= 1 then acc else __factorial(n - 1, acc * n)
+    fun factorial(n: int, acc: int): int =
+        if n <= 1 then acc else factorial(n - 1, acc * n)
     ---
-    __factorial(n, 1)
+    factorial(n, 1)
 
 fun unmarked_non_tail_sum(n: int): int =
     if n <= 0 then 0 else n + unmarked_non_tail_sum(n - 1)

--- a/capy/src/e2e-cfun/java/dev/capylang/test/PrivateDataTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/PrivateDataTest.java
@@ -9,15 +9,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PrivateDataTest {
     @Test
-    void underscorePrefixedDataCanBeUsedInsideModule() {
+    void privateDataCanBeUsedInsideModule() {
         assertThat(PrivateData.parseInt(7)).isEqualTo("ok:7");
         assertThat(PrivateData.parseConflict("x")).isEqualTo("internal:x");
     }
 
     @Test
-    void underscorePrefixedDataIsGeneratedAsPrivateRecord() {
+    void privateDataIsGeneratedAsPrivateRecord() {
         var privateParseClass = Arrays.stream(PrivateData.class.getDeclaredClasses())
-                .filter(clazz -> clazz.getSimpleName().equals("_Parse"))
+                .filter(clazz -> clazz.getSimpleName().equals("InternalParse"))
                 .findFirst()
                 .orElseThrow();
         var parseClass = Arrays.stream(PrivateData.class.getDeclaredClasses())

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/LocalConstCompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/LocalConstCompilationErrorTest.java
@@ -13,13 +13,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class LocalConstCompilationErrorTest {
     @Test
-    void localConstRequiresPrivatePrefix() {
+    void duplicateLocalConstReportsLocations() {
         var programResult = CapybaraCompiler.INSTANCE.compile(
                 List.of(new RawModule("LocalConst", "/foo/boo", """
-                        fun foo(x: String): bool =
+                        fun foo(): int =
                             const white_space = 1
+                            const white_space = 2
                             ---
-                            x == ""
+                            white_space
                         """)),
                 new TreeSet<>()
         );
@@ -31,7 +32,7 @@ class LocalConstCompilationErrorTest {
                     assertThat(error.file()).isEqualTo("/foo/boo/LocalConst.cfun");
                     assertThat(error.line()).isEqualTo(2);
                     assertThat(error.column()).isEqualTo(4);
-                    assertThat(error.message()).contains("Local const name has to start with `__` and use a private identifier style: white_space");
+                    assertThat(error.message()).contains("Duplicate local const name: white_space. Declared at: 2:4, 3:4");
                 });
     }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -25,7 +25,6 @@ public class CapybaraParser {
     private static final Pattern NO_VIABLE_ALTERNATIVE_PATTERN = Pattern.compile("no viable alternative at input '(.+)'");
     private static final Pattern MISMATCHED_INPUT_PATTERN = Pattern.compile("mismatched input '(.+)' expecting '(.+)'");
     private static final Pattern CONST_NAME_PATTERN = Pattern.compile("^_?[A-Z_][A-Z0-9_]*$");
-    private static final Pattern PRIVATE_LOCAL_CONST_NAME_PATTERN = Pattern.compile("^__[A-Za-z_][A-Za-z0-9_]*$");
     private static final Pattern ENUM_VALUE_NAME_PATTERN = Pattern.compile("^[A-Z]+(?:_[A-Z]+)*$");
     private static final Pattern IMPORT_PATTERN = Pattern.compile(
             "^\\s*from\\s+([A-Za-z_][A-Za-z0-9_]*|/[A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)+)\\s+import\\s*\\{\\s*([^}]*)\\s*}(?:\\s+except\\s*\\{\\s*([^}]*)\\s*})?\\s*$"
@@ -250,7 +249,7 @@ public class CapybaraParser {
     private Result.Error.SingleError duplicateLocalFunctionError(List<Function> functions) {
         var firstFunction = functions.getFirst();
         var firstPosition = firstFunction.position().orElseThrow();
-        var originalName = "__" + firstFunction.name().replaceFirst("^.*__local_fun_\\d+_", "");
+        var originalName = firstFunction.name().replaceFirst("^.*__local_fun_\\d+_", "");
         var locations = functions.stream()
                 .map(function -> function.position().orElseThrow())
                 .map(position -> "%d:%d".formatted(position.line(), position.column()))
@@ -282,7 +281,7 @@ public class CapybaraParser {
     private Result.Error.SingleError duplicateLocalConstError(List<Function> functions) {
         var firstFunction = functions.getFirst();
         var firstPosition = firstFunction.position().orElseThrow();
-        var originalName = "__" + firstFunction.name().replaceFirst("^.*__local_const_\\d+_", "");
+        var originalName = firstFunction.name().replaceFirst("^.*__local_const_\\d+_", "");
         var locations = functions.stream()
                 .map(function -> function.position().orElseThrow())
                 .map(position -> "%d:%d".formatted(position.line(), position.column()))
@@ -633,9 +632,7 @@ public class CapybaraParser {
                 if (localFunctionNameMap.containsKey(localName)) {
                     continue;
                 }
-                var normalizedLocalName = localName.startsWith("__")
-                        ? localName.substring(2)
-                        : localName;
+                var normalizedLocalName = normalizeLocalDefinitionName(localName);
                 localFunctionNameMap.put(
                         localName,
                         localScopePrefix + "__local_fun_" + localFunctionIndex + "_" + normalizedLocalName
@@ -645,30 +642,24 @@ public class CapybaraParser {
             var localType = localDefinition.localTypeDeclaration();
             if (localType != null) {
                 var localTypeName = genericTypeName(localType.genericTypeDeclaration(0));
-                if (!localTypeName.startsWith("__")) {
-                    throw new IllegalStateException("Local type name has to start with `__`: " + localTypeName);
-                }
                 if (localTypeNameMap.containsKey(localTypeName)) {
                     throw new IllegalStateException("Duplicate local type/data name: " + localTypeName);
                 }
                 localTypeNameMap.put(
                         localTypeName,
-                        localScopePrefix + "__local_type_" + localTypeIndex + "_" + localTypeName.substring(2)
+                        localScopePrefix + "__local_type_" + localTypeIndex + "_" + normalizeLocalDefinitionName(localTypeName)
                 );
                 localTypeIndex++;
             }
             var localData = localDefinition.localDataDeclaration();
             if (localData != null) {
                 var localDataName = genericTypeName(localData.genericTypeDeclaration());
-                if (!localDataName.startsWith("__")) {
-                    throw new IllegalStateException("Local data name has to start with `__`: " + localDataName);
-                }
                 if (localTypeNameMap.containsKey(localDataName)) {
                     throw new IllegalStateException("Duplicate local type/data name: " + localDataName);
                 }
                 localTypeNameMap.put(
                         localDataName,
-                        localScopePrefix + "__local_type_" + localTypeIndex + "_" + localDataName.substring(2)
+                        localScopePrefix + "__local_type_" + localTypeIndex + "_" + normalizeLocalDefinitionName(localDataName)
                 );
                 localTypeIndex++;
             }
@@ -688,7 +679,6 @@ public class CapybaraParser {
             if (localConst != null) {
                 var localConstNameNode = localConst.privateLocalConstName();
                 var localConstName = localConstName(localConstNameNode);
-                validateLocalConstName(localConstName, position(localConst));
                 var occurrences = localConstPositions.computeIfAbsent(localConstName, ignored -> new java.util.ArrayList<>());
                 occurrences.add(localConst.start);
                 if (localConstNameMap.containsKey(localConstName)) {
@@ -696,7 +686,7 @@ public class CapybaraParser {
                 }
                 localConstNameMap.put(
                         localConstName,
-                        localScopePrefix + "__local_const_" + localConstIndex + "_" + localConstName.substring(2)
+                        localScopePrefix + "__local_const_" + localConstIndex + "_" + normalizeLocalDefinitionName(localConstName)
                 );
                 localConstIndex++;
             }
@@ -3167,18 +3157,8 @@ public class CapybaraParser {
         }
     }
 
-    private static void validateLocalConstName(String name, Optional<SourcePosition> position) {
-        if (PRIVATE_LOCAL_CONST_NAME_PATTERN.matcher(name).matches()) {
-            return;
-        }
-        var message = "Local const name has to start with `__` and use a private identifier style: " + name;
-        if (position.isPresent()) {
-            var sourcePosition = position.orElseThrow();
-            throw new IllegalStateException(
-                    "line %d:%d: %s".formatted(sourcePosition.line(), sourcePosition.column(), message)
-            );
-        }
-        throw new IllegalStateException(message);
+    private static String normalizeLocalDefinitionName(String name) {
+        return name.startsWith("__") ? name.substring(2) : name;
     }
 
     private static void validateEnumValueName(String name) {

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -582,13 +582,13 @@ class CapybaraParserTest {
     }
 
     @Test
-    @DisplayName("should parse lowercase private local const declaration")
-    void parseLowercasePrivateLocalConstDeclaration() {
+    @DisplayName("should parse lowercase local const declaration")
+    void parseLowercaseLocalConstDeclaration() {
         var module = parseSuccess(new RawModule("Test", "/parser", """
                 fun foo(x: String): bool =
-                    const __white_space = { " ", "\\t", "\\n" }
+                    const white_space = { " ", "\\t", "\\n" }
                     ---
-                    __white_space ? x
+                    white_space ? x
                 """));
 
         var localConst = findFunction("__foo__scope_1_0__local_const_0_white_space", module.functional());
@@ -603,24 +603,17 @@ class CapybaraParserTest {
     }
 
     @Test
-    @DisplayName("should reject local const name without private prefix")
-    void rejectLocalConstNameWithoutPrivatePrefix() {
-        var result = new CapybaraParser().parseModule(new RawModule("Test", "/parser", """
+    @DisplayName("should parse local const name without private prefix")
+    void parseLocalConstNameWithoutPrivatePrefix() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
                 fun foo(x: String): bool =
                     const white_space = { " ", "\\t", "\\n" }
                     ---
-                    x == ""
+                    white_space ? x
                 """));
 
-        assertThat(result).isInstanceOf(Result.Error.class);
-        assertThat(((Result.Error<dev.capylang.compiler.parser.Module>) result).errors())
-                .singleElement()
-                .satisfies(error -> {
-                    assertThat(error.file()).isEqualTo("/parser/Test.cfun");
-                    assertThat(error.line()).isEqualTo(2);
-                    assertThat(error.column()).isEqualTo(4);
-                    assertThat(error.message()).contains("Local const name has to start with `__`");
-                });
+        var localConst = findFunction("__foo__scope_1_0__local_const_0_white_space", module.functional());
+        assertThat(localConst.returnType()).contains(new CollectionType.SetType(PrimitiveType.STRING));
     }
 
     @Test
@@ -628,10 +621,10 @@ class CapybaraParserTest {
     void rejectDuplicateLocalConstNames() {
         var result = new CapybaraParser().parseModule(new RawModule("Test", "/parser", """
                 fun foo(): int =
-                    const __white_space = 1
-                    const __white_space = 2
+                    const white_space = 1
+                    const white_space = 2
                     ---
-                    __white_space
+                    white_space
                 """));
 
         assertThat(result).isInstanceOf(Result.Error.class);
@@ -641,7 +634,7 @@ class CapybaraParserTest {
                     assertThat(error.file()).isEqualTo("/parser/Test.cfun");
                     assertThat(error.line()).isEqualTo(2);
                     assertThat(error.column()).isEqualTo(4);
-                    assertThat(error.message()).contains("Duplicate local const name: __white_space. Declared at: 2:4, 3:4");
+                    assertThat(error.message()).contains("Duplicate local const name: white_space. Declared at: 2:4, 3:4");
                 });
     }
 
@@ -744,8 +737,8 @@ class CapybaraParserTest {
         method.setAccessible(true);
                 var module = new RawModule("SemVer", "/capy/util", """
                 fun parse(): int =
-                    fun rec __parse_positive_digit(value: int): int = __parse_positive_digit(value)
-                    fun __parse_positive_digit(value: int): int = value + 1
+                    fun rec parse_positive_digit(value: int): int = parse_positive_digit(value)
+                    fun parse_positive_digit(value: int): int = value + 1
                     ---
                     0
                 """);
@@ -754,12 +747,12 @@ class CapybaraParserTest {
                 parser,
                 module,
                 module.input(),
-                "Duplicate local function name: __parse_positive_digit"
+                "Duplicate local function name: parse_positive_digit"
         );
 
         assertThat(error.line()).isEqualTo(2);
         assertThat(error.column()).isEqualTo(4);
-        assertThat(error.message()).contains("Duplicate local function name: __parse_positive_digit. Declared at: 2:4, 3:4");
+        assertThat(error.message()).contains("Duplicate local function name: parse_positive_digit. Declared at: 2:4, 3:4");
     }
 
     @Test

--- a/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
@@ -38,29 +38,29 @@ fun List[T].minus(other: List[T]): List[T] = this - other
 
 /// Returns true when at least one value satisfies `predicate`.
 fun List[T].any(predicate: T => bool): bool =
-    fun rec __any(list: List[T], idx: int, predicate: T => bool): bool =
+    fun rec any_match(list: List[T], idx: int, predicate: T => bool): bool =
         match list[idx] with
         case None -> false
         case Some { value } ->
             if predicate(value)
             then true
-            else __any(list, idx + 1, predicate)
+            else any_match(list, idx + 1, predicate)
     ---
-    __any(this, 0, predicate)
+    any_match(this, 0, predicate)
 
 /// Returns true when every value satisfies `predicate`.
 ///
 /// Empty lists return true.
 fun List[T].all(predicate: T => bool): bool =
-    fun rec __all(list: List[T], idx: int, predicate: T => bool, acc: bool): bool =
+    fun rec all(list: List[T], idx: int, predicate: T => bool, acc: bool): bool =
         match list[idx] with
         case None -> acc
         case Some { value } ->
             if !acc
             then false
-            else __all(list, idx + 1, predicate, predicate(value))
+            else all(list, idx + 1, predicate, predicate(value))
     ---
-    __all(this, 0, predicate, true)
+    all(this, 0, predicate, true)
 
 /// Returns true when this List contains the given value.
 fun List[T].contains(value: T): bool =
@@ -71,51 +71,51 @@ fun List[T].`?`(value: T): bool = this.contains(value)
 
 /// Combines all values from left to right.
 fun List[T].reduce(initial: R, reducer: (R, T) => R): R =
-    fun rec __reduce(list: List[T], idx: int, acc: R, reducer: (R, T) => R): R =
+    fun rec reduce(list: List[T], idx: int, acc: R, reducer: (R, T) => R): R =
         match list[idx] with
         case None -> acc
-        case Some { value } -> __reduce(list, idx + 1, reducer(acc, value), reducer)
+        case Some { value } -> reduce(list, idx + 1, reducer(acc, value), reducer)
     ---
-    __reduce(this, 0, initial, reducer)
+    reduce(this, 0, initial, reducer)
 
 /// Combines all values from left to right.
 fun List[T].`|>`(initial: R, reducer: (R, T) => R): R = this.reduce(initial, reducer)
 
 /// Transforms each value using `map`.
 fun List[T].map(map: T => Y): Seq[Y] =
-    fun __map(list: List[T], idx: int, map: T => Y): Seq[Y] =
+    fun map_values(list: List[T], idx: int, map: T => Y): Seq[Y] =
         match list[idx] with
         case None -> End {}
-        case Some { value } -> Cons { value: map(value), rest: () => __map(list, idx + 1, map) }
+        case Some { value } -> Cons { value: map(value), rest: () => map_values(list, idx + 1, map) }
     ---
-    __map(this, 0, map)
+    map_values(this, 0, map)
 
 /// Transforms each value using `map`.
 fun List[T].`|`(map: T => Y): Seq[Y] = this.map(map)
 
 /// Returns a sequence containing only values that satisfy `predicate`.
 fun List[T].filter(predicate: T => bool): Seq[T] =
-    fun __filter(list: List[T], idx: int, predicate: T => bool): Seq[T] =
+    fun filter(list: List[T], idx: int, predicate: T => bool): Seq[T] =
         match list[idx] with
         case None -> End {}
         case Some { value } ->
             if predicate(value)
-            then Cons { value: value, rest: () => __filter(list, idx + 1, predicate) }
-            else __filter(list, idx + 1, predicate)
+            then Cons { value: value, rest: () => filter(list, idx + 1, predicate) }
+            else filter(list, idx + 1, predicate)
     ---
-    __filter(this, 0, predicate)
+    filter(this, 0, predicate)
 
 /// Returns a sequence without values that satisfy `predicate`.
 fun List[T].reject(predicate: T => bool): Seq[T] =
-    fun __reject(list: List[T], idx: int, predicate: T => bool): Seq[T] =
+    fun reject(list: List[T], idx: int, predicate: T => bool): Seq[T] =
         match list[idx] with
         case None -> End {}
         case Some { value } ->
             if predicate(value)
-            then __reject(list, idx + 1, predicate)
-            else Cons { value: value, rest: () => __reject(list, idx + 1, predicate) }
+            then reject(list, idx + 1, predicate)
+            else Cons { value: value, rest: () => reject(list, idx + 1, predicate) }
     ---
-    __reject(this, 0, predicate)
+    reject(this, 0, predicate)
 
 /// Returns a sequence containing only values that satisfy `predicate`.
 fun List[T].`|-`(predicate: T => bool): Seq[T] = this.filter(predicate)

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
@@ -273,10 +273,10 @@ fun Set[T].`×`(other: Set[U]): Set[Tuple[T, U]] = this.cartesian_product(other)
 /// {}.power_set() == {{},}
 /// ```
 fun Set[T].power_set(): Set[Set[T]] =
-    fun _set_power_subset(subset: Set[T], value: T): Set[Set[T]] = {subset + value,}
+    fun set_power_subset(subset: Set[T], value: T): Set[Set[T]] = {subset + value,}
     ---
     this.reduce({{},}, (subsets, value) =>
-        subsets.reduce(subsets, (acc, subset) => acc + _set_power_subset(subset, value)))
+        subsets.reduce(subsets, (acc, subset) => acc + set_power_subset(subset, value)))
 
 /// Returns the Set of all subsets of this Set.
 ///

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -37,14 +37,14 @@ private fun days_31_month(value: month): bool = value == JANUARY | value == MARC
 /// Returns `true` when the month has 30 days.
 private fun days_30_month(value: month): bool = value == APRIL | value == JUNE | value == SEPTEMBER | value == NOVEMBER
 
-const __DAYS_PER_400_YEARS: int = 146097
-const __DAYS_PER_YEAR: int = 365
-const __UNIX_EPOCH_CIVIL_OFFSET_DAYS: int = 719468
-const __DAYS_PER_4_YEARS_MINUS_1: int = 1460
-const __DAYS_PER_100_YEARS_MINUS_1: int = 36524
-const __DAYS_PER_400_YEARS_MINUS_1: int = 146096
-const __MONTH_TO_DAY_NUMERATOR: int = 153
-const __MONTH_TO_DAY_BIAS: int = 2
+private const DAYS_PER_400_YEARS: int = 146097
+private const DAYS_PER_YEAR: int = 365
+private const UNIX_EPOCH_CIVIL_OFFSET_DAYS: int = 719468
+private const DAYS_PER_4_YEARS_MINUS_1: int = 1460
+private const DAYS_PER_100_YEARS_MINUS_1: int = 36524
+private const DAYS_PER_400_YEARS_MINUS_1: int = 146096
+private const MONTH_TO_DAY_NUMERATOR: int = 153
+private const MONTH_TO_DAY_BIAS: int = 2
 
 /// Calendar date represented by day, month and year.
 ///
@@ -86,20 +86,20 @@ fun Date.to_days_since_unix_epoch(): int =
     let era = floor_div(y, 400)
     let yoe = y - era * 400
     let mp = if this.month > FEBRUARY then month_value - 3 else month_value + 9
-    let doy = floor_div(__MONTH_TO_DAY_NUMERATOR * mp + __MONTH_TO_DAY_BIAS, 5) + this.day - 1
-    let doe = yoe * __DAYS_PER_YEAR + floor_div(yoe, 4) - floor_div(yoe, 100) + doy
-    era * __DAYS_PER_400_YEARS + doe - __UNIX_EPOCH_CIVIL_OFFSET_DAYS
+    let doy = floor_div(MONTH_TO_DAY_NUMERATOR * mp + MONTH_TO_DAY_BIAS, 5) + this.day - 1
+    let doe = yoe * DAYS_PER_YEAR + floor_div(yoe, 4) - floor_div(yoe, 100) + doy
+    era * DAYS_PER_400_YEARS + doe - UNIX_EPOCH_CIVIL_OFFSET_DAYS
 
 /// Converts days since Unix epoch (`1970-01-01`) to `Date`.
 fun from_days_since_unix_epoch(days_since_epoch: int): Date =
-    let z: int = days_since_epoch + __UNIX_EPOCH_CIVIL_OFFSET_DAYS
-    let era: int = floor_div(z, __DAYS_PER_400_YEARS)
-    let doe: int = z - era * __DAYS_PER_400_YEARS
-    let yoe: int = floor_div(doe - floor_div(doe, __DAYS_PER_4_YEARS_MINUS_1) + floor_div(doe, __DAYS_PER_100_YEARS_MINUS_1) - floor_div(doe, __DAYS_PER_400_YEARS_MINUS_1), __DAYS_PER_YEAR)
+    let z: int = days_since_epoch + UNIX_EPOCH_CIVIL_OFFSET_DAYS
+    let era: int = floor_div(z, DAYS_PER_400_YEARS)
+    let doe: int = z - era * DAYS_PER_400_YEARS
+    let yoe: int = floor_div(doe - floor_div(doe, DAYS_PER_4_YEARS_MINUS_1) + floor_div(doe, DAYS_PER_100_YEARS_MINUS_1) - floor_div(doe, DAYS_PER_400_YEARS_MINUS_1), DAYS_PER_YEAR)
     let y: int = yoe + era * 400
-    let doy: int = doe - (__DAYS_PER_YEAR * yoe + floor_div(yoe, 4) - floor_div(yoe, 100))
-    let mp: int = floor_div(5 * doy + __MONTH_TO_DAY_BIAS, __MONTH_TO_DAY_NUMERATOR)
-    let day: int = doy - floor_div(__MONTH_TO_DAY_NUMERATOR * mp + __MONTH_TO_DAY_BIAS, 5) + 1
+    let doy: int = doe - (DAYS_PER_YEAR * yoe + floor_div(yoe, 4) - floor_div(yoe, 100))
+    let mp: int = floor_div(5 * doy + MONTH_TO_DAY_BIAS, MONTH_TO_DAY_NUMERATOR)
+    let day: int = doy - floor_div(MONTH_TO_DAY_NUMERATOR * mp + MONTH_TO_DAY_BIAS, 5) + 1
     let month_value: int = if mp < 10 then mp + 3 else mp - 9
     let year: int = if month_value <= FEBRUARY.value then y + 1 else y
     Date! { day, month: month! { month_value }, year }
@@ -109,7 +109,7 @@ fun Date.add_days(days: int): Date = from_days_since_unix_epoch(this.to_days_sin
 
 /// Adds years and months to this date, clamping the day to target month length.
 fun Date.add_years_months(years: int, months: int): Date =
-    fun __floor_mod(a: int, b: int): int = a - floor_div(a, b) * b
+    fun floor_mod(a: int, b: int): int = a - floor_div(a, b) * b
     fun days_in_month(year: int, value: month): int =
         if value == APRIL | value == JUNE | value == SEPTEMBER | value == NOVEMBER
         then 30
@@ -119,7 +119,7 @@ fun Date.add_years_months(years: int, months: int): Date =
     ---
     let total_months = (this.year + years) * 12 + (this.month.value + months - 1)
     let normalized_year = floor_div(total_months, 12)
-    let normalized_month_value = __floor_mod(total_months, 12) + 1
+    let normalized_month_value = floor_mod(total_months, 12) + 1
     let normalized_month = month! { normalized_month_value }
     Date! {
         day: min(this.day, days_in_month(normalized_year, normalized_month)),
@@ -129,92 +129,92 @@ fun Date.add_years_months(years: int, months: int): Date =
 
 /// Formats this date as an ISO 8601 calendar date.
 fun Date.to_iso_8601(): String =
-    fun rec __pad_left(value: String, size: int): String =
+    fun rec pad_left(value: String, size: int): String =
         if value.size() >= size
         then value
-        else __pad_left("0" + value, size)
-    fun __year_to_iso_8601(year: int): String =
+        else pad_left("0" + value, size)
+    fun year_to_iso_8601(year: int): String =
         if year < 0
-        then "-" + __pad_left("" + (0 - year), 4)
+        then "-" + pad_left("" + (0 - year), 4)
         else if year > 9999
             then "+" + year
-            else __pad_left("" + year, 4)
+            else pad_left("" + year, 4)
     ---
-    __year_to_iso_8601(this.year)
+    year_to_iso_8601(this.year)
     + "-"
-    + __pad_left("" + this.month.value, 2)
+    + pad_left("" + this.month.value, 2)
     + "-"
-    + __pad_left("" + this.day, 2)
+    + pad_left("" + this.day, 2)
 
 /// Parses an ISO 8601 calendar date in basic or extended complete form.
 fun from_iso_8601(iso: String): Result[Date] =
-    data __Parse[T] { buffer: String, value: T }
-    fun __invalid(message: String): String = "Invalid ISO 8601 date format: " + message
-    fun __parse_single_digit(value: String): Result[__Parse[int]] =
+    data Parse[T] { buffer: String, value: T }
+    fun invalid(message: String): String = "Invalid ISO 8601 date format: " + message
+    fun parse_single_digit(value: String): Result[Parse[int]] =
         match value[0] with
-        case None -> Error { __invalid("unexpected end of string while parsing digits") }
+        case None -> Error { invalid("unexpected end of string while parsing digits") }
         case Some { char } ->
             match ("" + char).to_int() with
-            case Success { digit } -> Success { __Parse { buffer: value[1, value.size()], value: digit } }
-            case Error -> Error { __invalid("expected digit, got `" + char + "`") }
-    fun rec __parse_rest_digits(value: String, parsed: int): Result[__Parse[int]] =
+            case Success { digit } -> Success { Parse { buffer: value[1, value.size()], value: digit } }
+            case Error -> Error { invalid("expected digit, got `" + char + "`") }
+    fun rec parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
         if value.is_empty()
-        then Success { __Parse { buffer: value, value: parsed } }
+        then Success { Parse { buffer: value, value: parsed } }
         else
-            match __parse_single_digit(value) with
-            case Success { next } -> __parse_rest_digits(next.buffer, parsed * 10 + next.value)
-            case Error -> Success { __Parse { buffer: value, value: parsed } }
-    fun __parse_digits(value: String): Result[__Parse[int]] =
-        let parse <- __parse_single_digit(value)
-        __parse_rest_digits(parse.buffer, parse.value)
-    fun __parse_exact_digits(value: String, label: String): Result[int] =
-        let parse <- __parse_digits(value)
+            match parse_single_digit(value) with
+            case Success { next } -> parse_rest_digits(next.buffer, parsed * 10 + next.value)
+            case Error -> Success { Parse { buffer: value, value: parsed } }
+    fun parse_digits(value: String): Result[Parse[int]] =
+        let parse <- parse_single_digit(value)
+        parse_rest_digits(parse.buffer, parse.value)
+    fun parse_exact_digits(value: String, label: String): Result[int] =
+        let parse <- parse_digits(value)
         if parse.buffer.is_empty()
         then Success { parse.value }
-        else Error { __invalid("expected digits for " + label + ", got `" + value + "`") }
-    fun rec __drop_prefix(value: String, size: int): String =
+        else Error { invalid("expected digits for " + label + ", got `" + value + "`") }
+    fun rec drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
-            case Some { _ } -> __drop_prefix(value[1, value.size()], size - 1)
-    fun rec __take_prefix(value: String, size: int, acc: String): String =
+            case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
+    fun rec take_prefix(value: String, size: int, acc: String): String =
         if size <= 0
         then acc
         else
             match value[0] with
             case None -> acc
-            case Some { char } -> __take_prefix(value[1, value.size()], size - 1, acc + char)
-    fun __slice(value: String, start: int, size: int): String = __take_prefix(__drop_prefix(value, start), size, "")
-    fun __parse_year(value: String): Result[int] =
+            case Some { char } -> take_prefix(value[1, value.size()], size - 1, acc + char)
+    fun slice(value: String, start: int, size: int): String = take_prefix(drop_prefix(value, start), size, "")
+    fun parse_year(value: String): Result[int] =
         if value.is_empty()
-        then Error { __invalid("expected year") }
+        then Error { invalid("expected year") }
         else if value.starts_with("+")
             then if value.size() < 5
-                then Error { __invalid("expected expanded year, got `" + value + "`") }
+                then Error { invalid("expected expanded year, got `" + value + "`") }
                 else {
-                    let year <- __parse_exact_digits(value[1, value.size()], "year")
+                    let year <- parse_exact_digits(value[1, value.size()], "year")
                     Success { year }
                 }
             else if value.starts_with("-")
                 then if value.size() < 5
-                    then Error { __invalid("expected expanded year, got `" + value + "`") }
+                    then Error { invalid("expected expanded year, got `" + value + "`") }
                     else {
-                        let year <- __parse_exact_digits(value[1, value.size()], "year")
+                        let year <- parse_exact_digits(value[1, value.size()], "year")
                         Success { 0 - year }
                     }
                 else if value.size() < 4
-                    then Error { __invalid("expected four-digit year, got `" + value + "`") }
-                    else __parse_exact_digits(value, "year")
-    fun __parse_date(year_part: String, month_part: String, day_part: String): Result[Date] = {
-        let year <- __parse_year(year_part)
-        let month_value <- __parse_exact_digits(month_part, "month")
+                    then Error { invalid("expected four-digit year, got `" + value + "`") }
+                    else parse_exact_digits(value, "year")
+    fun parse_date(year_part: String, month_part: String, day_part: String): Result[Date] = {
+        let year <- parse_year(year_part)
+        let month_value <- parse_exact_digits(month_part, "month")
         let parsed_month <- month { month_value }
-        let day <- __parse_exact_digits(day_part, "day")
+        let day <- parse_exact_digits(day_part, "day")
         match Date { day, month: parsed_month, year } with
         case Success { date } -> Success { date }
-        case Error { message } -> Error { __invalid(message) }
+        case Error { message } -> Error { invalid(message) }
     }
     ---
     let extended_year_end = iso.size().value - 6
@@ -226,11 +226,11 @@ fun from_iso_8601(iso: String): Result[Date] =
     let basic_month_end = iso.size().value - 2
     let basic_day_start = iso.size().value - 2
     let is_extended = iso.size() >= 10
-        & __slice(iso, extended_year_end, 1) == "-"
-        & __slice(iso, extended_month_end, 1) == "-"
+        & slice(iso, extended_year_end, 1) == "-"
+        & slice(iso, extended_month_end, 1) == "-"
     let is_basic = iso.size() >= 8
     if is_extended
-    then __parse_date(__take_prefix(iso, extended_year_end, ""), __slice(iso, extended_month_start, 2), __slice(iso, extended_day_start, 2))
+    then parse_date(take_prefix(iso, extended_year_end, ""), slice(iso, extended_month_start, 2), slice(iso, extended_day_start, 2))
     else if is_basic
-        then __parse_date(__take_prefix(iso, basic_year_end, ""), __slice(iso, basic_month_start, 2), __slice(iso, basic_day_start, 2))
-        else Error { __invalid("expected date in `YYYY-MM-DD` or `YYYYMMDD` format, got `" + iso + "`") }
+        then parse_date(take_prefix(iso, basic_year_end, ""), slice(iso, basic_month_start, 2), slice(iso, basic_day_start, 2))
+        else Error { invalid("expected date in `YYYY-MM-DD` or `YYYYMMDD` format, got `" + iso + "`") }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -55,7 +55,7 @@ fun DateTime.`-`(duration: Duration): DateTime = this.minus(duration)
 
 /// Returns the duration from `other` to this `DateTime`.
 fun DateTime.minus(other: DateTime): Duration =
-    fun __positive_duration_from_seconds(total_seconds: long): Duration =
+    fun positive_duration_from_seconds(total_seconds: long): Duration =
         let days = floor_div(total_seconds, SECONDS_IN_DAY)
         let remainder_after_days = floor_mod(total_seconds, SECONDS_IN_DAY)
         let hours = floor_div(remainder_after_days, SECONDS_IN_HOUR)
@@ -73,8 +73,8 @@ fun DateTime.minus(other: DateTime): Duration =
     ---
     let delta = this.timestamp() - other.timestamp()
     if delta < 0L
-    then __positive_duration_from_seconds(0L - delta).negate()
-    else __positive_duration_from_seconds(delta)
+    then positive_duration_from_seconds(0L - delta).negate()
+    else positive_duration_from_seconds(delta)
 
 /// Returns `true` when this date-time is after `other`.
 fun DateTime.greater_than(other: DateTime): bool =
@@ -106,9 +106,9 @@ fun DateTime.`>`(other: DateTime): bool = this.greater_than(other)
 
 /// Formats this date-time as a canonical UTC ISO 8601 string.
 fun DateTime.to_iso_8601(): String =
-    fun __format_utc(datetime: DateTime): String =
+    fun format_utc(datetime: DateTime): String =
         datetime.date.to_iso_8601() + "T" + datetime.time.to_iso_8601() + "Z"
-    fun __normalize_to_utc(datetime: DateTime): DateTime =
+    fun normalize_to_utc(datetime: DateTime): DateTime =
         match datetime.time.offset_minutes with
         case None -> datetime
         case Some { offset_minutes } ->
@@ -127,58 +127,58 @@ fun DateTime.to_iso_8601(): String =
                 seconds: 0
             })
     ---
-    __format_utc(__normalize_to_utc(this))
+    format_utc(normalize_to_utc(this))
 
 /// Parses a UTC ISO 8601 date-time in basic or extended form.
 fun from_iso_8601(iso: String): Result[DateTime] =
-    data __Split { left: String, right: String }
-    data __SplitScan { left: String, right: String, seen_separator: bool }
-    fun __invalid(message: String): String = "Invalid ISO 8601 date-time format: " + message
-    fun rec __scan_split(value: String, scan: __SplitScan): Result[__Split] =
+    data Split { left: String, right: String }
+    data SplitScan { left: String, right: String, seen_separator: bool }
+    fun invalid(message: String): String = "Invalid ISO 8601 date-time format: " + message
+    fun rec scan_split(value: String, scan: SplitScan): Result[Split] =
         if value.is_empty()
         then if !scan.seen_separator
-            then Error { __invalid("expected `T` separator between date and time") }
+            then Error { invalid("expected `T` separator between date and time") }
             else if scan.left.is_empty() | scan.right.is_empty()
-            then Error { __invalid("date-time parts must not be empty") }
-            else Success { __Split { left: scan.left, right: scan.right } }
+            then Error { invalid("date-time parts must not be empty") }
+            else Success { Split { left: scan.left, right: scan.right } }
         else if value[0, 1] == "T"
             then if scan.seen_separator
-                then Error { __invalid("expected exactly one `T` separator") }
-                else __scan_split(value[1, value.size()], __SplitScan {
+                then Error { invalid("expected exactly one `T` separator") }
+                else scan_split(value[1, value.size()], SplitScan {
                     left: scan.left,
                     right: "",
                     seen_separator: true
                 })
             else if scan.seen_separator
-                then __scan_split(value[1, value.size()], __SplitScan {
+                then scan_split(value[1, value.size()], SplitScan {
                     left: scan.left,
                     right: scan.right + value[0, 1],
                     seen_separator: true
                 })
-                else __scan_split(value[1, value.size()], __SplitScan {
+                else scan_split(value[1, value.size()], SplitScan {
                     left: scan.left + value[0, 1],
                     right: scan.right,
                     seen_separator: false
                 })
-    fun __is_extended_date(value: String): bool =
+    fun is_extended_date(value: String): bool =
         if value.size() == 10
         then value[4, 5] == "-" & value[7, 8] == "-"
         else false
-    fun __is_extended_time(value: String): bool =
+    fun is_extended_time(value: String): bool =
         if value.size() >= 8
         then value[2, 3] == ":" & value[5, 6] == ":"
         else false
     ---
-    let split <- __scan_split(iso, __SplitScan { left: "", right: "", seen_separator: false })
-    let date_is_extended = __is_extended_date(split.left)
-    let time_is_extended = __is_extended_time(split.right)
+    let split <- scan_split(iso, SplitScan { left: "", right: "", seen_separator: false })
+    let date_is_extended = is_extended_date(split.left)
+    let time_is_extended = is_extended_time(split.right)
     if date_is_extended != time_is_extended
-    then Error { __invalid("date and time must use the same basic or extended format") }
+    then Error { invalid("date and time must use the same basic or extended format") }
     else {
         let date <- /capy/date_time/Date.from_iso_8601(split.left)
         let time_with_offset <- /capy/date_time/Time.from_iso_8601(split.right)
         match time_with_offset.offset_minutes with
-        case None -> Error { __invalid("expected UTC designator `Z` or numeric offset") }
+        case None -> Error { invalid("expected UTC designator `Z` or numeric offset") }
         case Some { offset_minutes } -> {
             let utc_time = Time {
                 hour: time_with_offset.hour,

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -95,8 +95,8 @@ fun Duration.to_iso_8601(): String =
 ///
 /// Returns `Error` with a readable message when the input is invalid.
 fun from_iso_8601(iso: String): Result[Duration] =
-    data __Parse[T] { buffer: String, value: T }
-    data __Parts {
+    data Parse[T] { buffer: String, value: T }
+    data Parts {
         years: int,
         months: int,
         weeks: int,
@@ -105,79 +105,79 @@ fun from_iso_8601(iso: String): Result[Duration] =
         minutes: int,
         seconds: int
     }
-    data __DurationParse {
+    data DurationParse {
         buffer: String,
-        value: __Parts,
+        value: Parts,
         in_time: bool,
         previous_order: int,
         has_component: bool,
         has_time_component: bool
     }
-    fun __invalid(message: String): String = "Invalid ISO 8601 duration format: " + message
-    fun __tail(value: String): String = value[1, value.size()]
-    fun __parse_positive_digit(value: String): Result[__Parse[int]] =
+    fun invalid(message: String): String = "Invalid ISO 8601 duration format: " + message
+    fun tail(value: String): String = value[1, value.size()]
+    fun parse_positive_digit(value: String): Result[Parse[int]] =
         match value[0] with
-        case None -> Error { __invalid("unexpected end of string while parsing digits") }
-        case Some { '1' }  -> Success { __Parse { buffer: __tail(value), value: 1 } }
-        case Some { '2' }  -> Success { __Parse { buffer: __tail(value), value: 2 } }
-        case Some { '3' }  -> Success { __Parse { buffer: __tail(value), value: 3 } }
-        case Some { '4' }  -> Success { __Parse { buffer: __tail(value), value: 4 } }
-        case Some { '5' }  -> Success { __Parse { buffer: __tail(value), value: 5 } }
-        case Some { '6' }  -> Success { __Parse { buffer: __tail(value), value: 6 } }
-        case Some { '7' }  -> Success { __Parse { buffer: __tail(value), value: 7 } }
-        case Some { '8' }  -> Success { __Parse { buffer: __tail(value), value: 8 } }
-        case Some { '9' }  -> Success { __Parse { buffer: __tail(value), value: 9 } }
-        case Some { char } -> Error { __invalid("expected digit between `1` and `9`, got `" + char + "`") }
-    fun __parse_digit(value: String): Result[__Parse[int]] =
+        case None -> Error { invalid("unexpected end of string while parsing digits") }
+        case Some { '1' }  -> Success { Parse { buffer: tail(value), value: 1 } }
+        case Some { '2' }  -> Success { Parse { buffer: tail(value), value: 2 } }
+        case Some { '3' }  -> Success { Parse { buffer: tail(value), value: 3 } }
+        case Some { '4' }  -> Success { Parse { buffer: tail(value), value: 4 } }
+        case Some { '5' }  -> Success { Parse { buffer: tail(value), value: 5 } }
+        case Some { '6' }  -> Success { Parse { buffer: tail(value), value: 6 } }
+        case Some { '7' }  -> Success { Parse { buffer: tail(value), value: 7 } }
+        case Some { '8' }  -> Success { Parse { buffer: tail(value), value: 8 } }
+        case Some { '9' }  -> Success { Parse { buffer: tail(value), value: 9 } }
+        case Some { char } -> Error { invalid("expected digit between `1` and `9`, got `" + char + "`") }
+    fun parse_digit(value: String): Result[Parse[int]] =
         match value[0] with
-        case None -> Error { __invalid("unexpected end of string while parsing digits") }
-        case Some { '0' } -> Success { __Parse { buffer: __tail(value), value: 0 } }
-        case Some -> __parse_positive_digit(value)
-    fun rec __parse_rest_digits(value: String, parsed: int): Result[__Parse[int]] =
+        case None -> Error { invalid("unexpected end of string while parsing digits") }
+        case Some { '0' } -> Success { Parse { buffer: tail(value), value: 0 } }
+        case Some -> parse_positive_digit(value)
+    fun rec parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
         match value[0] with
         case Some { char } ->
             if match char with
                case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' -> true
                case _ -> false
             then {
-                let parse_digit <- __parse_digit(value)
-                __parse_rest_digits(parse_digit.buffer, parsed * 10 + parse_digit.value)
+                let parse_digit <- parse_digit(value)
+                parse_rest_digits(parse_digit.buffer, parsed * 10 + parse_digit.value)
             }
-            else Success { __Parse { buffer: value, value: parsed } }
-        case _ -> Success { __Parse { buffer: value, value: parsed } }
-    fun __parse_digits(value: String): Result[__Parse[int]] =
-        let parse <- __parse_digit(value)
-        __parse_rest_digits(parse.buffer, parse.value)
-    fun __parse_exact_digits(value: String, label: String): Result[int] =
-        let parse <- __parse_digits(value)
+            else Success { Parse { buffer: value, value: parsed } }
+        case _ -> Success { Parse { buffer: value, value: parsed } }
+    fun parse_digits(value: String): Result[Parse[int]] =
+        let parse <- parse_digit(value)
+        parse_rest_digits(parse.buffer, parse.value)
+    fun parse_exact_digits(value: String, label: String): Result[int] =
+        let parse <- parse_digits(value)
         if parse.buffer.is_empty()
         then Success { parse.value }
-        else Error { __invalid("expected digits for " + label + ", got `" + value + "`") }
-    fun __is_exact_digits(value: String): bool =
-        match __parse_exact_digits(value, "value") with
+        else Error { invalid("expected digits for " + label + ", got `" + value + "`") }
+    fun is_exact_digits(value: String): bool =
+        match parse_exact_digits(value, "value") with
         case Success -> true
         case Error -> false
-    fun __is_combined_basic(value: String): bool =
+    fun is_combined_basic(value: String): bool =
         if value.size() == 15
-        then __is_exact_digits(value[0, 8])
+        then is_exact_digits(value[0, 8])
             & value[8, 9] == "T"
-            & __is_exact_digits(value[9, 15])
+            & is_exact_digits(value[9, 15])
         else false
-    fun __is_combined_extended(value: String): bool =
+    fun is_combined_extended(value: String): bool =
         if value.size() == 19
-        then __is_exact_digits(value[0, 4])
+        then is_exact_digits(value[0, 4])
             & value[4, 5] == "-"
-            & __is_exact_digits(value[5, 7])
+            & is_exact_digits(value[5, 7])
             & value[7, 8] == "-"
-            & __is_exact_digits(value[8, 10])
+            & is_exact_digits(value[8, 10])
             & value[10, 11] == "T"
-            & __is_exact_digits(value[11, 13])
+            & is_exact_digits(value[11, 13])
             & value[13, 14] == ":"
-            & __is_exact_digits(value[14, 16])
+            & is_exact_digits(value[14, 16])
             & value[16, 17] == ":"
-            & __is_exact_digits(value[17, 19])
+            & is_exact_digits(value[17, 19])
         else false
-    fun __to_duration(parts: __Parts): Duration =
+    fun to_duration(parts: Parts): Duration =
         if parts.weeks != 0
         then WeekDuration { weeks: parts.weeks }
         else DateDuration {
@@ -188,26 +188,26 @@ fun from_iso_8601(iso: String): Result[Duration] =
             minutes: parts.minutes,
             seconds: parts.seconds
         }
-    fun __validate_combined(parts: __Parts): Result[Duration] =
+    fun validate_combined(parts: Parts): Result[Duration] =
         if parts.months < 0 | parts.months > 12
-        then Error { __invalid("combined duration month component must be between 0 and 12") }
+        then Error { invalid("combined duration month component must be between 0 and 12") }
         else if parts.days < 0 | parts.days > 31
-        then Error { __invalid("combined duration day component must be between 0 and 31") }
+        then Error { invalid("combined duration day component must be between 0 and 31") }
         else if parts.hours < 0 | parts.hours > 23
-        then Error { __invalid("combined duration hour component must be between 0 and 23") }
+        then Error { invalid("combined duration hour component must be between 0 and 23") }
         else if parts.minutes < 0 | parts.minutes > 59
-        then Error { __invalid("combined duration minute component must be between 0 and 59") }
+        then Error { invalid("combined duration minute component must be between 0 and 59") }
         else if parts.seconds < 0 | parts.seconds > 59
-        then Error { __invalid("combined duration second component must be between 0 and 59") }
-        else Success { __to_duration(parts) }
-    fun __parse_combined_basic(value: String): Result[Duration] =
-        let years <- __parse_exact_digits(value[0, 4], "years")
-        let months <- __parse_exact_digits(value[4, 6], "months")
-        let days <- __parse_exact_digits(value[6, 8], "days")
-        let hours <- __parse_exact_digits(value[9, 11], "hours")
-        let minutes <- __parse_exact_digits(value[11, 13], "minutes")
-        let seconds <- __parse_exact_digits(value[13, 15], "seconds")
-        __validate_combined(__Parts {
+        then Error { invalid("combined duration second component must be between 0 and 59") }
+        else Success { to_duration(parts) }
+    fun parse_combined_basic(value: String): Result[Duration] =
+        let years <- parse_exact_digits(value[0, 4], "years")
+        let months <- parse_exact_digits(value[4, 6], "months")
+        let days <- parse_exact_digits(value[6, 8], "days")
+        let hours <- parse_exact_digits(value[9, 11], "hours")
+        let minutes <- parse_exact_digits(value[11, 13], "minutes")
+        let seconds <- parse_exact_digits(value[13, 15], "seconds")
+        validate_combined(Parts {
             years,
             months,
             weeks: 0,
@@ -216,14 +216,14 @@ fun from_iso_8601(iso: String): Result[Duration] =
             minutes,
             seconds
         })
-    fun __parse_combined_extended(value: String): Result[Duration] =
-        let years <- __parse_exact_digits(value[0, 4], "years")
-        let months <- __parse_exact_digits(value[5, 7], "months")
-        let days <- __parse_exact_digits(value[8, 10], "days")
-        let hours <- __parse_exact_digits(value[11, 13], "hours")
-        let minutes <- __parse_exact_digits(value[14, 16], "minutes")
-        let seconds <- __parse_exact_digits(value[17, 19], "seconds")
-        __validate_combined(__Parts {
+    fun parse_combined_extended(value: String): Result[Duration] =
+        let years <- parse_exact_digits(value[0, 4], "years")
+        let months <- parse_exact_digits(value[5, 7], "months")
+        let days <- parse_exact_digits(value[8, 10], "days")
+        let hours <- parse_exact_digits(value[11, 13], "hours")
+        let minutes <- parse_exact_digits(value[14, 16], "minutes")
+        let seconds <- parse_exact_digits(value[17, 19], "seconds")
+        validate_combined(Parts {
             years,
             months,
             weeks: 0,
@@ -232,14 +232,14 @@ fun from_iso_8601(iso: String): Result[Duration] =
             minutes,
             seconds
         })
-    fun __has_non_week_components(parts: __Parts): bool =
+    fun has_non_week_components(parts: Parts): bool =
         parts.years != 0
         | parts.months != 0
         | parts.days != 0
         | parts.hours != 0
         | parts.minutes != 0
         | parts.seconds != 0
-    fun __component_order(in_time: bool, designator: String): Result[int] =
+    fun component_order(in_time: bool, designator: String): Result[int] =
         if in_time
         then
             if designator == "H"
@@ -248,7 +248,7 @@ fun from_iso_8601(iso: String): Result[Duration] =
             then Success { 6 }
             else if designator == "S"
             then Success { 7 }
-            else Error { __invalid("unexpected time designator `" + designator + "`") }
+            else Error { invalid("unexpected time designator `" + designator + "`") }
         else
             if designator == "Y"
             then Success { 1 }
@@ -258,8 +258,8 @@ fun from_iso_8601(iso: String): Result[Duration] =
             then Success { 3 }
             else if designator == "D"
             then Success { 4 }
-            else Error { __invalid("unexpected date designator `" + designator + "`") }
-    fun __set_component(parts: __Parts, in_time: bool, designator: String, amount: int): __Parts =
+            else Error { invalid("unexpected date designator `" + designator + "`") }
+    fun set_component(parts: Parts, in_time: bool, designator: String, amount: int): Parts =
         if designator == "Y"
         then parts.with(years: amount)
         else if designator == "M"
@@ -273,13 +273,13 @@ fun from_iso_8601(iso: String): Result[Duration] =
         else if designator == "H"
         then parts.with(hours: amount)
         else parts
-    fun __apply_seconds_component(parse: __DurationParse, seconds: int): Result[__DurationParse] =
-        let order <- __component_order(parse.in_time, "S")
+    fun apply_seconds_component(parse: DurationParse, seconds: int): Result[DurationParse] =
+        let order <- component_order(parse.in_time, "S")
         if order <= parse.previous_order
-        then Error { __invalid("components must appear in ISO 8601 order and may not repeat") }
+        then Error { invalid("components must appear in ISO 8601 order and may not repeat") }
         else if parse.value.weeks != 0
-        then Error { __invalid("week durations cannot be combined with other components") }
-        else Success { __DurationParse {
+        then Error { invalid("week durations cannot be combined with other components") }
+        else Success { DurationParse {
             buffer: parse.buffer,
             value: parse.value.with(seconds: seconds),
             in_time: parse.in_time,
@@ -287,37 +287,37 @@ fun from_iso_8601(iso: String): Result[Duration] =
             has_component: true,
             has_time_component: true
         }}
-    fun __apply_component(parse: __DurationParse, amount: int, designator: String): Result[__DurationParse] =
-        let order <- __component_order(parse.in_time, designator)
+    fun apply_component(parse: DurationParse, amount: int, designator: String): Result[DurationParse] =
+        let order <- component_order(parse.in_time, designator)
         if order <= parse.previous_order
-        then Error { __invalid("components must appear in ISO 8601 order and may not repeat") }
-        else if designator == "W" & (__has_non_week_components(parse.value) | parse.in_time)
-        then Error { __invalid("week durations cannot be combined with other components") }
+        then Error { invalid("components must appear in ISO 8601 order and may not repeat") }
+        else if designator == "W" & (has_non_week_components(parse.value) | parse.in_time)
+        then Error { invalid("week durations cannot be combined with other components") }
         else if designator != "W" & parse.value.weeks != 0
-        then Error { __invalid("week durations cannot be combined with other components") }
-        else Success { __DurationParse {
+        then Error { invalid("week durations cannot be combined with other components") }
+        else Success { DurationParse {
             buffer: parse.buffer,
-            value: __set_component(parse.value, parse.in_time, designator, amount),
+            value: set_component(parse.value, parse.in_time, designator, amount),
             in_time: parse.in_time,
             previous_order: order,
             has_component: true,
             has_time_component: parse.has_time_component | parse.in_time
         }}
-    fun rec __parse_designator_duration(parse: __DurationParse): Result[Duration] =
+    fun rec parse_designator_duration(parse: DurationParse): Result[Duration] =
         match parse.buffer[0] with
         case None ->
             if !parse.has_component
-            then Error { __invalid("missing components") }
+            then Error { invalid("missing components") }
             else if parse.in_time & !parse.has_time_component
-            then Error { __invalid("missing time components after `T`") }
-            else Success { __to_duration(parse.value) }
+            then Error { invalid("missing time components after `T`") }
+            else Success { to_duration(parse.value) }
         case Some { 'T' } ->
             if parse.in_time
-            then Error { __invalid("duplicate `T` separator") }
+            then Error { invalid("duplicate `T` separator") }
             else if parse.value.weeks != 0
-            then Error { __invalid("week durations cannot be combined with time components") }
-            else __parse_designator_duration(__DurationParse {
-                buffer: __tail(parse.buffer),
+            then Error { invalid("week durations cannot be combined with time components") }
+            else parse_designator_duration(DurationParse {
+                buffer: tail(parse.buffer),
                 value: parse.value,
                 in_time: true,
                 previous_order: 4,
@@ -328,55 +328,55 @@ fun from_iso_8601(iso: String): Result[Duration] =
             if !(match char with
                 case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' -> true
                 case _ -> false)
-            then Error { __invalid("expected digit or `T`, got `" + char + "`") }
+            then Error { invalid("expected digit or `T`, got `" + char + "`") }
             else {
-                let parse_number <- __parse_digits(parse.buffer)
+                let parse_number <- parse_digits(parse.buffer)
                 match parse_number.buffer[0] with
-                case None -> Error { __invalid("missing designator after `" + parse_number.value + "`") }
+                case None -> Error { invalid("missing designator after `" + parse_number.value + "`") }
                 case Some { designator } -> {
                     if designator == 'S'
                     then {
-                        let next_parse <- __apply_seconds_component(__DurationParse {
-                            buffer: __tail(parse_number.buffer),
+                        let next_parse <- apply_seconds_component(DurationParse {
+                            buffer: tail(parse_number.buffer),
                             value: parse.value,
                             in_time: parse.in_time,
                             previous_order: parse.previous_order,
                             has_component: parse.has_component,
                             has_time_component: parse.has_time_component
                         }, parse_number.value)
-                        __parse_designator_duration(next_parse)
+                        parse_designator_duration(next_parse)
                     }
                     else {
                         match ("" + parse_number.value).to_int() with
                         case Success { amount } -> {
-                            let next_parse <- __apply_component(__DurationParse {
-                                buffer: __tail(parse_number.buffer),
+                            let next_parse <- apply_component(DurationParse {
+                                buffer: tail(parse_number.buffer),
                                 value: parse.value,
                                 in_time: parse.in_time,
                                 previous_order: parse.previous_order,
                                 has_component: parse.has_component,
                                 has_time_component: parse.has_time_component
                             }, amount, "" + designator)
-                            __parse_designator_duration(next_parse)
+                            parse_designator_duration(next_parse)
                         }
-                        case Error -> Error { __invalid("component is out of range") }
+                        case Error -> Error { invalid("component is out of range") }
                     }
                 }
             }
     ---
     if !iso.starts_with("P")
-    then Error { __invalid("must start with `P`") }
+    then Error { invalid("must start with `P`") }
     else {
-        let duration = __tail(iso)
+        let duration = tail(iso)
         if duration.is_empty()
-        then Error { __invalid("missing components") }
-        else if __is_combined_basic(duration)
-        then __parse_combined_basic(duration)
-        else if __is_combined_extended(duration)
-        then __parse_combined_extended(duration)
-        else __parse_designator_duration(__DurationParse {
+        then Error { invalid("missing components") }
+        else if is_combined_basic(duration)
+        then parse_combined_basic(duration)
+        else if is_combined_extended(duration)
+        then parse_combined_extended(duration)
+        else parse_designator_duration(DurationParse {
             buffer: duration,
-            value: __Parts { years: 0, months: 0, weeks: 0, days: 0, hours: 0, minutes: 0, seconds: 0 },
+            value: Parts { years: 0, months: 0, weeks: 0, days: 0, hours: 0, minutes: 0, seconds: 0 },
             in_time: false,
             previous_order: 0,
             has_component: false,

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -49,79 +49,79 @@ fun Interval.duration(): Duration =
 ///
 /// Also accepts `--` as an alternate input separator and canonicalizes back to `/`.
 fun from_iso_8601(iso: String): Result[Interval] =
-    data __Split { left: String, right: String }
-    data __SplitScan { left: String, right: String, seen_separator: bool }
-    fun __invalid(message: String): String = "Invalid ISO 8601 interval format: " + message
-    fun rec __drop_prefix(value: String, size: int): String =
+    data Split { left: String, right: String }
+    data SplitScan { left: String, right: String, seen_separator: bool }
+    fun invalid(message: String): String = "Invalid ISO 8601 interval format: " + message
+    fun rec drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
-            case Some { _ } -> __drop_prefix(value[1, value.size()], size - 1)
-    fun rec __scan_split(separator: String, value: String, scan: __SplitScan): Result[__Split] =
+            case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
+    fun rec scan_split(separator: String, value: String, scan: SplitScan): Result[Split] =
         if value.is_empty()
         then if !scan.seen_separator
-            then Error { __invalid("expected exactly one `" + separator + "` separator") }
+            then Error { invalid("expected exactly one `" + separator + "` separator") }
             else if scan.left.is_empty() | scan.right.is_empty()
-            then Error { __invalid("interval parts must not be empty") }
-            else Success { __Split { left: scan.left, right: scan.right } }
+            then Error { invalid("interval parts must not be empty") }
+            else Success { Split { left: scan.left, right: scan.right } }
         else if value.starts_with(separator)
             then if scan.seen_separator
-                then Error { __invalid("expected exactly one interval separator") }
-                else __scan_split(separator, __drop_prefix(value, separator.size()), __SplitScan {
+                then Error { invalid("expected exactly one interval separator") }
+                else scan_split(separator, drop_prefix(value, separator.size()), SplitScan {
                     left: scan.left,
                     right: "",
                     seen_separator: true
                 })
             else if scan.seen_separator
-                then __scan_split(separator, value[1, value.size()], __SplitScan {
+                then scan_split(separator, value[1, value.size()], SplitScan {
                     left: scan.left,
                     right: scan.right + value[0, 1],
                     seen_separator: true
                 })
-                else __scan_split(separator, value[1, value.size()], __SplitScan {
+                else scan_split(separator, value[1, value.size()], SplitScan {
                     left: scan.left + value[0, 1],
                     right: scan.right,
                     seen_separator: false
                 })
-    fun __split_interval(value: String): Result[__Split] =
+    fun split_interval(value: String): Result[Split] =
         let has_slash = regex/\// ? value
         let has_dash = regex/--/ ? value
         if has_slash & !has_dash
-        then __scan_split("/", value, __SplitScan { left: "", right: "", seen_separator: false })
+        then scan_split("/", value, SplitScan { left: "", right: "", seen_separator: false })
         else if has_dash & !has_slash
-        then __scan_split("--", value, __SplitScan { left: "", right: "", seen_separator: false })
+        then scan_split("--", value, SplitScan { left: "", right: "", seen_separator: false })
         else if has_slash & has_dash
-        then Error { __invalid("expected exactly one interval separator") }
-        else Error { __invalid("expected `/` or `--` separator") }
-    fun __parse_datetime(value: String): Result[DateTime] =
+        then Error { invalid("expected exactly one interval separator") }
+        else Error { invalid("expected `/` or `--` separator") }
+    fun parse_datetime(value: String): Result[DateTime] =
         match /capy/date_time/DateTime.from_iso_8601(value) with
         case Success { datetime } -> Success { datetime }
-        case Error -> Error { __invalid("interval endpoints must be UTC date-times") }
-    fun __parse_start_end(split: __Split): Result[Interval] = {
-        let start <- __parse_datetime(split.left)
-        let end <- __parse_datetime(split.right)
+        case Error -> Error { invalid("interval endpoints must be UTC date-times") }
+    fun parse_start_end(split: Split): Result[Interval] = {
+        let start <- parse_datetime(split.left)
+        let end <- parse_datetime(split.right)
         if start.greater_than(end)
-        then Error { __invalid("interval start must not be after interval end") }
+        then Error { invalid("interval start must not be after interval end") }
         else Success { DateTimeStartEnd { start, end } }
     }
-    fun __parse_start_duration(split: __Split): Result[Interval] = {
+    fun parse_start_duration(split: Split): Result[Interval] = {
         let duration <- /capy/date_time/Duration.from_iso_8601(split.right)
-        let start <- __parse_datetime(split.left)
+        let start <- parse_datetime(split.left)
         Success { DateTimeStartDuration { start, duration } }
     }
-    fun __parse_duration_end(split: __Split): Result[Interval] = {
+    fun parse_duration_end(split: Split): Result[Interval] = {
         let duration <- /capy/date_time/Duration.from_iso_8601(split.left)
-        let end <- __parse_datetime(split.right)
+        let end <- parse_datetime(split.right)
         Success { DateTimeDurationEnd { duration, end } }
     }
     ---
-    let split <- __split_interval(iso)
+    let split <- split_interval(iso)
     if split.left.starts_with("P") & split.right.starts_with("P")
-    then Error { __invalid("interval cannot contain a duration on both sides") }
+    then Error { invalid("interval cannot contain a duration on both sides") }
     else if split.left.starts_with("P")
-    then __parse_duration_end(split)
+    then parse_duration_end(split)
     else if split.right.starts_with("P")
-    then __parse_start_duration(split)
-    else __parse_start_end(split)
+    then parse_start_duration(split)
+    else parse_start_end(split)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
@@ -85,9 +85,9 @@ fun Time.round_to_minutes(): Time = Time { hour: this.hour, minute: this.minute,
 fun Time.round_to_hours(): Time = Time { hour: this.hour, minute: ZERO_MINUTE, second: ZERO_SECOND, offset_minutes: this.offset_minutes }
 /// Adds seconds and wraps around a 24-hour day.
 fun Time.add_seconds(seconds: int): Time =
-    fun __normalize_day_seconds(total_seconds: int): int = /capy/lang/Math.floor_mod(total_seconds, SECONDS_IN_DAY)
+    fun normalize_day_seconds(total_seconds: int): int = /capy/lang/Math.floor_mod(total_seconds, SECONDS_IN_DAY)
     ---
-    let total_seconds = __normalize_day_seconds(this.to_seconds() + seconds)
+    let total_seconds = normalize_day_seconds(this.to_seconds() + seconds)
     let new_hour = (total_seconds / SECONDS_IN_HOUR) % HOURS_IN_DAY
     let new_minute = (total_seconds / SECONDS_IN_MINUTE) % MINUTES_IN_HOUR
     let new_second = total_seconds % SECONDS_IN_MINUTE
@@ -99,11 +99,11 @@ fun Time.add_hours(hours: int): Time = this.add_seconds(hours * SECONDS_IN_HOUR)
 
 /// Formats this time as an ISO 8601 extended time.
 fun Time.to_iso_8601(): String =
-    fun rec __pad_left(value: String, size: int): String =
+    fun rec pad_left(value: String, size: int): String =
         if value.size() >= size
         then value
-        else __pad_left("0" + value, size)
-    fun __format_offset(offset_minutes: int): String =
+        else pad_left("0" + value, size)
+    fun format_offset(offset_minutes: int): String =
         let absolute_offset_minutes = if offset_minutes < 0 then 0 - offset_minutes else offset_minutes
         let offset_hours = absolute_offset_minutes / MINUTES_IN_HOUR
         let offset_remaining_minutes = absolute_offset_minutes % MINUTES_IN_HOUR
@@ -111,118 +111,118 @@ fun Time.to_iso_8601(): String =
         then "Z"
         else
             (if offset_minutes < 0 then "-" else "+")
-                + __pad_left("" + offset_hours, 2)
+                + pad_left("" + offset_hours, 2)
                 + ":"
-                + __pad_left("" + offset_remaining_minutes, 2)
+                + pad_left("" + offset_remaining_minutes, 2)
     ---
-    __pad_left("" + this.hour.value, 2)
+    pad_left("" + this.hour.value, 2)
     + ":"
-    + __pad_left("" + this.minute.value, 2)
+    + pad_left("" + this.minute.value, 2)
     + ":"
-    + __pad_left("" + this.second.value, 2)
+    + pad_left("" + this.second.value, 2)
     + match this.offset_minutes with
       case None -> ""
-      case Some { value } -> __format_offset(value)
+      case Some { value } -> format_offset(value)
 
 /// Parses an ISO 8601 time in basic or extended complete form.
 fun from_iso_8601(iso: String): Result[Time] =
-    data __Parse[T] { buffer: String, value: T }
-    data __ZoneParse { buffer: String, offset_minutes: Option[offset_minutes] }
-    fun __invalid(message: String): String = "Invalid ISO 8601 time format: " + message
-    fun rec __drop_prefix(value: String, size: int): String =
+    data Parse[T] { buffer: String, value: T }
+    data ZoneParse { buffer: String, offset_minutes: Option[offset_minutes] }
+    fun invalid(message: String): String = "Invalid ISO 8601 time format: " + message
+    fun rec drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
-            case Some { _ } -> __drop_prefix(value[1, value.size()], size - 1)
-    fun rec __take_prefix(value: String, size: int, acc: String): String =
+            case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
+    fun rec take_prefix(value: String, size: int, acc: String): String =
         if size <= 0
         then acc
         else
             match value[0] with
             case None -> acc
-            case Some { char } -> __take_prefix(value[1, value.size()], size - 1, acc + char)
-    fun __slice(value: String, start: int, size: int): String = __take_prefix(__drop_prefix(value, start), size, "")
-    fun __parse_single_digit(value: String): Result[__Parse[int]] =
+            case Some { char } -> take_prefix(value[1, value.size()], size - 1, acc + char)
+    fun slice(value: String, start: int, size: int): String = take_prefix(drop_prefix(value, start), size, "")
+    fun parse_single_digit(value: String): Result[Parse[int]] =
         match value[0] with
-        case None -> Error { __invalid("unexpected end of string while parsing digits") }
+        case None -> Error { invalid("unexpected end of string while parsing digits") }
         case Some { char } ->
             match ("" + char).to_int() with
-            case Success { digit } -> Success { __Parse { buffer: value[1, value.size()], value: digit } }
-            case Error -> Error { __invalid("expected digit, got `" + char + "`") }
-    fun rec __parse_rest_digits(value: String, parsed: int): Result[__Parse[int]] =
+            case Success { digit } -> Success { Parse { buffer: value[1, value.size()], value: digit } }
+            case Error -> Error { invalid("expected digit, got `" + char + "`") }
+    fun rec parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
         if value.is_empty()
-        then Success { __Parse { buffer: value, value: parsed } }
+        then Success { Parse { buffer: value, value: parsed } }
         else
-            match __parse_single_digit(value) with
-            case Success { next } -> __parse_rest_digits(next.buffer, parsed * 10 + next.value)
-            case Error -> Success { __Parse { buffer: value, value: parsed } }
-    fun __parse_digits(value: String): Result[__Parse[int]] =
-        let parse <- __parse_single_digit(value)
-        __parse_rest_digits(parse.buffer, parse.value)
-    fun __parse_exact_digits(value: String, label: String): Result[int] =
-        let parse <- __parse_digits(value)
+            match parse_single_digit(value) with
+            case Success { next } -> parse_rest_digits(next.buffer, parsed * 10 + next.value)
+            case Error -> Success { Parse { buffer: value, value: parsed } }
+    fun parse_digits(value: String): Result[Parse[int]] =
+        let parse <- parse_single_digit(value)
+        parse_rest_digits(parse.buffer, parse.value)
+    fun parse_exact_digits(value: String, label: String): Result[int] =
+        let parse <- parse_digits(value)
         if parse.buffer.is_empty()
         then Success { parse.value }
-        else Error { __invalid("expected digits for " + label + ", got `" + value + "`") }
+        else Error { invalid("expected digits for " + label + ", got `" + value + "`") }
     fun parse_hour_value(value: int): Result[hour] =
         match hour { value } with
         case Success { parsed } -> Success { parsed }
-        case Error { message } -> Error { __invalid(message) }
+        case Error { message } -> Error { invalid(message) }
     fun parse_minute_value(value: int): Result[minute] =
         match minute { value } with
         case Success { parsed } -> Success { parsed }
-        case Error { message } -> Error { __invalid(message) }
+        case Error { message } -> Error { invalid(message) }
     fun parse_second_value(value: int): Result[second] =
         match second { value } with
         case Success { parsed } -> Success { parsed }
-        case Error { message } -> Error { __invalid(message) }
-    fun __parse_offset(sign: String, hour_part: String, minute_part: String): Result[offset_minutes] = {
-        let hours <- __parse_exact_digits(hour_part, "offset hour")
-        let minutes <- __parse_exact_digits(minute_part, "offset minute")
+        case Error { message } -> Error { invalid(message) }
+    fun parse_offset(sign: String, hour_part: String, minute_part: String): Result[offset_minutes] = {
+        let hours <- parse_exact_digits(hour_part, "offset hour")
+        let minutes <- parse_exact_digits(minute_part, "offset minute")
         if hours > 23
-        then Error { __invalid("offset hour must be between 00 and 23") }
+        then Error { invalid("offset hour must be between 00 and 23") }
         else if minutes > 59
-            then Error { __invalid("offset minute must be between 00 and 59") }
+            then Error { invalid("offset minute must be between 00 and 59") }
             else if sign == "-" & hours == 0 & minutes == 0
-                then Error { __invalid("negative zero offset is not allowed") }
+                then Error { invalid("negative zero offset is not allowed") }
                 else {
                     let direction = if sign == "-" then 0 - 1 else 1
                     match offset_minutes { direction * (hours * MINUTES_IN_HOUR + minutes) } with
                     case Success { parsed } -> Success { parsed }
-                    case Error { message } -> Error { __invalid(message) }
+                    case Error { message } -> Error { invalid(message) }
                 }
     }
-    fun __parse_zone(value: String): Result[__ZoneParse] =
+    fun parse_zone(value: String): Result[ZoneParse] =
         if value.is_empty()
-        then Error { __invalid("time must not be empty") }
-        else if __slice(value, value.size().value - 1, 1) == "Z"
-            then Success { __ZoneParse { buffer: __take_prefix(value, value.size().value - 1, ""), offset_minutes: Some { offset_minutes! { 0 } } } }
+        then Error { invalid("time must not be empty") }
+        else if slice(value, value.size().value - 1, 1) == "Z"
+            then Success { ZoneParse { buffer: take_prefix(value, value.size().value - 1, ""), offset_minutes: Some { offset_minutes! { 0 } } } }
         else if value.size() >= 6
-                & (__slice(value, value.size().value - 6, 1) == "+" | __slice(value, value.size().value - 6, 1) == "-")
-                & __slice(value, value.size().value - 3, 1) == ":"
+                & (slice(value, value.size().value - 6, 1) == "+" | slice(value, value.size().value - 6, 1) == "-")
+                & slice(value, value.size().value - 3, 1) == ":"
                 then {
-                    let offset_minutes <- __parse_offset(__slice(value, value.size().value - 6, 1), __slice(value, value.size().value - 5, 2), __slice(value, value.size().value - 2, 2))
-                    Success { __ZoneParse { buffer: __take_prefix(value, value.size().value - 6, ""), offset_minutes: Some { offset_minutes } } }
+                    let offset_minutes <- parse_offset(slice(value, value.size().value - 6, 1), slice(value, value.size().value - 5, 2), slice(value, value.size().value - 2, 2))
+                    Success { ZoneParse { buffer: take_prefix(value, value.size().value - 6, ""), offset_minutes: Some { offset_minutes } } }
                 }
             else if value.size() >= 5
-                    & (__slice(value, value.size().value - 5, 1) == "+" | __slice(value, value.size().value - 5, 1) == "-")
+                    & (slice(value, value.size().value - 5, 1) == "+" | slice(value, value.size().value - 5, 1) == "-")
                     then {
-                        let offset_minutes <- __parse_offset(__slice(value, value.size().value - 5, 1), __slice(value, value.size().value - 4, 2), __slice(value, value.size().value - 2, 2))
-                        Success { __ZoneParse { buffer: __take_prefix(value, value.size().value - 5, ""), offset_minutes: Some { offset_minutes } } }
+                        let offset_minutes <- parse_offset(slice(value, value.size().value - 5, 1), slice(value, value.size().value - 4, 2), slice(value, value.size().value - 2, 2))
+                        Success { ZoneParse { buffer: take_prefix(value, value.size().value - 5, ""), offset_minutes: Some { offset_minutes } } }
                     }
                 else if value.size() >= 3
-                        & (__slice(value, value.size().value - 3, 1) == "+" | __slice(value, value.size().value - 3, 1) == "-")
+                        & (slice(value, value.size().value - 3, 1) == "+" | slice(value, value.size().value - 3, 1) == "-")
                         then {
-                            let offset_minutes <- __parse_offset(__slice(value, value.size().value - 3, 1), __slice(value, value.size().value - 2, 2), "00")
-                            Success { __ZoneParse { buffer: __take_prefix(value, value.size().value - 3, ""), offset_minutes: Some { offset_minutes } } }
+                            let offset_minutes <- parse_offset(slice(value, value.size().value - 3, 1), slice(value, value.size().value - 2, 2), "00")
+                            Success { ZoneParse { buffer: take_prefix(value, value.size().value - 3, ""), offset_minutes: Some { offset_minutes } } }
                         }
-                        else Success { __ZoneParse { buffer: value, offset_minutes: None {} } }
-    fun __parse_parts(hour_part: String, minute_part: String, second_part: String, offset_minutes: Option[offset_minutes]): Result[Time] = {
-        let hour_value <- __parse_exact_digits(hour_part, "hour")
-        let minute_value <- __parse_exact_digits(minute_part, "minute")
-        let second_value <- __parse_exact_digits(second_part, "second")
+                        else Success { ZoneParse { buffer: value, offset_minutes: None {} } }
+    fun parse_parts(hour_part: String, minute_part: String, second_part: String, offset_minutes: Option[offset_minutes]): Result[Time] = {
+        let hour_value <- parse_exact_digits(hour_part, "hour")
+        let minute_value <- parse_exact_digits(minute_part, "minute")
+        let second_value <- parse_exact_digits(second_part, "second")
         let parsed_hour <- parse_hour_value(hour_value)
         let parsed_minute <- parse_minute_value(minute_value)
         let parsed_second <- parse_second_value(second_value)
@@ -230,11 +230,11 @@ fun from_iso_8601(iso: String): Result[Time] =
     }
     ---
     let value = if iso.starts_with("T") then iso[1, iso.size()] else iso
-    let zone <- __parse_zone(value)
+    let zone <- parse_zone(value)
     if zone.buffer.size() == 8
     then if zone.buffer[2, 3] == ":" & zone.buffer[5, 6] == ":"
-        then __parse_parts(zone.buffer[0, 2], zone.buffer[3, 5], zone.buffer[6, 8], zone.offset_minutes)
-        else Error { __invalid("expected time in `HH:MM:SS`, `HHMMSS`, `THH:MM:SS`, or `THHMMSS` format, got `" + iso + "`") }
+        then parse_parts(zone.buffer[0, 2], zone.buffer[3, 5], zone.buffer[6, 8], zone.offset_minutes)
+        else Error { invalid("expected time in `HH:MM:SS`, `HHMMSS`, `THH:MM:SS`, or `THHMMSS` format, got `" + iso + "`") }
     else if zone.buffer.size() == 6
-        then __parse_parts(zone.buffer[0, 2], zone.buffer[2, 4], zone.buffer[4, 6], zone.offset_minutes)
-        else Error { __invalid("expected time in `HH:MM:SS`, `HHMMSS`, `THH:MM:SS`, or `THHMMSS` format, got `" + iso + "`") }
+        then parse_parts(zone.buffer[0, 2], zone.buffer[2, 4], zone.buffer[4, 6], zone.offset_minutes)
+        else Error { invalid("expected time in `HH:MM:SS`, `HHMMSS`, `THH:MM:SS`, or `THHMMSS` format, got `" + iso + "`") }

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -14,7 +14,7 @@ data Path {
 }
 
 fun from_string(path_string: String): Path =
-    fun rec __segments(value: String, current: String, acc: List[String]): List[String] =
+    fun rec segments(value: String, current: String, acc: List[String]): List[String] =
         match value[0] with
         case None ->
             if current == ""
@@ -24,10 +24,10 @@ fun from_string(path_string: String): Path =
             if c == '/'
             then
                 if current == ""
-                then __segments(value[1, value.size()], "", acc)
-                else __segments(value[1, value.size()], "", acc + current)
+                then segments(value[1, value.size()], "", acc)
+                else segments(value[1, value.size()], "", acc + current)
             else
-                __segments(value[1, value.size()], current + c, acc)
+                segments(value[1, value.size()], current + c, acc)
     ---
     let value =
         if path_string.starts_with('/')
@@ -46,7 +46,7 @@ fun from_string(path_string: String): Path =
             then PathRoot.HOME
             else PathRoot.RELATIVE,
         prefix: None {},
-        segments: __segments(value, "", [])
+        segments: segments(value, "", [])
     }.normalize()
 
 fun Path.`/`(segment: String) =
@@ -90,26 +90,26 @@ fun Path.is_absolute(): bool =
 fun Path.is_root(): bool = this.segments.size() == EMPTY
 
 fun Path.normalize(): Path =
-    fun rec __normalize_path(root: PathRoot, segments: List[String], acc: List[String]): List[String] =
+    fun rec normalize_path(root: PathRoot, segments: List[String], acc: List[String]): List[String] =
         match segments[0] with
         case None -> acc
         case Some { seg } ->
             let rest = segments[1:]
             if seg == "" | seg == "."
-            then __normalize_path(root, rest, acc)
+            then normalize_path(root, rest, acc)
             else if seg == ".."
             then
                 if acc.size() > EMPTY
-                then __normalize_path(root, rest, acc[:-1])
+                then normalize_path(root, rest, acc[:-1])
                 else
                     match root with
-                    case RELATIVE -> __normalize_path(root, rest, acc + "..")
-                    case _ -> __normalize_path(root, rest, acc)
+                    case RELATIVE -> normalize_path(root, rest, acc + "..")
+                    case _ -> normalize_path(root, rest, acc)
             else
-                __normalize_path(root, rest, acc + seg)
+                normalize_path(root, rest, acc + seg)
     ---
     Path {
         root: this.root,
         prefix: this.prefix,
-        segments: __normalize_path(this.root, this.segments, [])
+        segments: normalize_path(this.root, this.segments, [])
     }

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Effect.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Effect.cfun
@@ -1,16 +1,16 @@
-union Effect[T] = _UnsafeEffect[T]
+union Effect[T] = UnsafeEffect[T]
 
-private data _UnsafeEffect[T] { unsafe_thunk: () => T }
+private data UnsafeEffect[T] { unsafe_thunk: () => T }
 
 fun pure(value: T): Effect[T] =
-    _UnsafeEffect { unsafe_thunk: () => value }
+    UnsafeEffect { unsafe_thunk: () => value }
 
 fun delay(thunk: () => T): Effect[T] =
-    _UnsafeEffect { unsafe_thunk: thunk }
+    UnsafeEffect { unsafe_thunk: thunk }
 
 fun Effect[T].unsafe_run(): T =
     match this with
-    case _UnsafeEffect { unsafe_thunk } -> unsafe_thunk()
+    case UnsafeEffect { unsafe_thunk } -> unsafe_thunk()
 
 fun Effect[T].map(map: T => Y): Effect[Y] =
     delay(() => map(this.unsafe_run()))

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -1,15 +1,15 @@
 from /capy/lang/Option import { * }
 
 fun digits(number: int): int =
-    fun rec __digits(number: int, acc: int): int =
+    fun rec digits(number: int, acc: int): int =
         if number < 10
         then acc
-        else __digits(number / 10, acc + 1)
+        else digits(number / 10, acc + 1)
     ---
     if number == -2147483648
     // abs function cannot handle -2147483648 because of overflow, so we hardcode the result for this case
     then 10
-    else __digits(abs(number), 1)
+    else digits(abs(number), 1)
 
 fun abs(number: long): long = if number < 0 then -number else number
 
@@ -60,14 +60,14 @@ fun min(a: int, b: int): int = if a < b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun min(values: List[int]): Option[int] =
-    fun rec __min(min: int, values: List[int]): int =
+    fun rec min(min: int, values: List[int]): int =
         match values[0] with
         case None -> min
-        case Some { v } -> if min < v then __min(min, values[1:]) else __min(v, values[1:])
+        case Some { v } -> if min < v then min(min, values[1:]) else min(v, values[1:])
     ---
     match values[0] with
     case None -> None {}
-    case Some { v } -> Some { __min(v, values[1:]) }
+    case Some { v } -> Some { min(v, values[1:]) }
 
 /// Returns the greater of two integers.
 fun max(a: int, b: int): int = if a > b then a else b
@@ -76,14 +76,14 @@ fun max(a: int, b: int): int = if a > b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun max(values: List[int]): Option[int] =
-    fun rec __max(max: int, values: List[int]): int =
+    fun rec max(max: int, values: List[int]): int =
         match values[0] with
         case None -> max
-        case Some { v } -> if max < v then __max(v, values[1:]) else __max(max, values[1:])
+        case Some { v } -> if max < v then max(v, values[1:]) else max(max, values[1:])
     ---
     match values[0] with
     case None -> None {}
-    case Some { v } -> Some { __max(v, values[1:]) }
+    case Some { v } -> Some { max(v, values[1:]) }
 
 /// Returns the smaller of two long integers.
 fun min(a: long, b: long): long = if a < b then a else b
@@ -92,14 +92,14 @@ fun min(a: long, b: long): long = if a < b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun min(values: List[long]): Option[long] =
-    fun rec __min(min: long, values: List[long]): long =
+    fun rec min(min: long, values: List[long]): long =
         match values[0] with
         case None -> min
-        case Some { v } -> if min < v then __min(min, values[1:]) else __min(v, values[1:])
+        case Some { v } -> if min < v then min(min, values[1:]) else min(v, values[1:])
     ---
     match values[0] with
     case None -> None {}
-    case Some { v } -> Some { __min(v, values[1:]) }
+    case Some { v } -> Some { min(v, values[1:]) }
 
 /// Returns the greater of two long integers.
 fun max(a: long, b: long): long = if a > b then a else b
@@ -108,14 +108,14 @@ fun max(a: long, b: long): long = if a > b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun max(values: List[long]): Option[long] =
-    fun rec __max(max: long, values: List[long]): long =
+    fun rec max(max: long, values: List[long]): long =
         match values[0] with
         case None -> max
-        case Some { v } -> if max < v then __max(v, values[1:]) else __max(max, values[1:])
+        case Some { v } -> if max < v then max(v, values[1:]) else max(max, values[1:])
     ---
     match values[0] with
     case None -> None {}
-    case Some { v } -> Some { __max(v, values[1:]) }
+    case Some { v } -> Some { max(v, values[1:]) }
 
 enum RoundMode { FLOOR, CEILING, HALF_UP, HALF_DOWN, HALF_EVEN }
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
@@ -12,18 +12,18 @@ data Match { group_value: String }
 fun from_literal(pattern: String, flags: String): Regex = Regex { pattern, flags }
 
 private fun drop_prefix(value: String, size: int): String =
-    fun rec __drop_prefix(value: String, size: int): String =
+    fun rec drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
-            case Some { _ } -> __drop_prefix(value[1, value.size()], size - 1)
+            case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
     ---
-    __drop_prefix(value, size)
+    drop_prefix(value, size)
 
 private fun find_all(pattern: String, input: String, acc: List[Match]): List[Match] =
-    fun rec __find_all(pattern: String, input: String, acc: List[Match]): List[Match] =
+    fun rec find_all(pattern: String, input: String, acc: List[Match]): List[Match] =
         if pattern == ""
         then acc
         else
@@ -31,13 +31,13 @@ private fun find_all(pattern: String, input: String, acc: List[Match]): List[Mat
             case None -> acc
             case Some { _ } ->
                 if input.starts_with(pattern)
-                then __find_all(pattern, drop_prefix(input, pattern.size()), acc + Match { group_value: pattern })
-                else __find_all(pattern, input[1, input.size()], acc)
+                then find_all(pattern, drop_prefix(input, pattern.size()), acc + Match { group_value: pattern })
+                else find_all(pattern, input[1, input.size()], acc)
     ---
-    __find_all(pattern, input, acc)
+    find_all(pattern, input, acc)
 
 private fun split(pattern: String, input: String, current: String, acc: List[String]): List[String] =
-    fun rec __split(pattern: String, input: String, current: String, acc: List[String]): List[String] =
+    fun rec split(pattern: String, input: String, current: String, acc: List[String]): List[String] =
         if pattern == ""
         then [input]
         else
@@ -45,10 +45,10 @@ private fun split(pattern: String, input: String, current: String, acc: List[Str
             case None -> acc + current
             case Some { c } ->
                 if input.starts_with(pattern)
-                then __split(pattern, drop_prefix(input, pattern.size()), "", acc + current)
-                else __split(pattern, input[1, input.size()], current + c, acc)
+                then split(pattern, drop_prefix(input, pattern.size()), "", acc + current)
+                else split(pattern, input[1, input.size()], current + c, acc)
     ---
-    __split(pattern, input, current, acc)
+    split(pattern, input, current, acc)
 
 fun Regex.matches(input: String): bool = input ? this.pattern
 

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -11,27 +11,27 @@ single End
 ///
 /// To start at `1`, drop the first element.
 fun natural_seq(): Seq[int] =
-    fun __next(i: int): Seq[int] = Cons { i, () => __next(i+1) }
+    fun next(i: int): Seq[int] = Cons { i, () => next(i+1) }
     ---
-    __next(0)
+    next(0)
 
 /// Returns an infinite Fibonacci sequence: `1, 1, 2, 3, 5, 8, 13, ...`.
 fun fibonacci_seq(): Seq[int] =
-    fun __next(a: int, b: int) = Cons { b, () => __next(b, a+b) }
+    fun next(a: int, b: int) = Cons { b, () => next(b, a+b) }
     ---
-    __next(0,1)
+    next(0,1)
 
 /// Returns an infinite sequence of zeros.
 fun zeros_seq(): Seq[int] =
-    fun __next() = Cons { 0, () => __next() }
+    fun next() = Cons { 0, () => next() }
     ---
-    __next()
+    next()
 
 /// Returns an infinite sequence of ones.
 fun ones_seq(): Seq[int] =
-    fun __next() = Cons { 1, () => __next() }
+    fun next() = Cons { 1, () => next() }
     ---
-    __next()
+    next()
 
 /// Returns an infinite sequence of powers of `base`: `base^0, base^1, base^2, ...`.
 ///
@@ -47,26 +47,26 @@ fun powers_of_2_seq() = powers_seq(2)
 ///
 /// This method is safe to use with infinite sequences.
 fun Seq[T].take(n: size): List[T] =
-    fun rec __take(seq: Seq[T], n: int, list: List[T]): List[T] =
+    fun rec take(seq: Seq[T], n: int, list: List[T]): List[T] =
         if n <=0
         then list
         else
             match seq with
             case End -> list
-            case Cons { value, rest } -> __take(rest(), n-1, list + value)
+            case Cons { value, rest } -> take(rest(), n-1, list + value)
     ---
-    __take(this, n, [])
+    take(this, n, [])
 
 /// Collects the entire sequence into a `List`.
 ///
 /// Important: calling this on an infinite sequence does not terminate.
 fun Seq[T].as_list(): List[T] =
-    fun rec __as_list(seq: Seq[T], list: List[T]): List[T] =
+    fun rec as_list(seq: Seq[T], list: List[T]): List[T] =
         match seq with
         case End -> list
-        case Cons { value, rest } -> __as_list(rest(), list + value)
+        case Cons { value, rest } -> as_list(rest(), list + value)
     ---
-    __as_list(this, [])
+    as_list(this, [])
 
 /// Converts a `List` into a finite `Seq`.
 fun to_seq(list: List[T]): Seq[T] =
@@ -87,16 +87,16 @@ fun to_seq(list: Dict[T]): Seq[Tuple[String, T]] =
 ///
 /// Important: calling this on an infinite sequence does not terminate.
 fun Seq[T].take_last(n: size): List[T] =
-    fun __add_to_list(max: int, list: List[T], value: T) = (if list.size() >= max then list[1:] else list) + value
-    fun __take_last(seq: Seq[T], max: int, n: int, list: List[T]) =
+    fun add_to_list(max: int, list: List[T], value: T) = (if list.size() >= max then list[1:] else list) + value
+    fun take_last(seq: Seq[T], max: int, n: int, list: List[T]) =
         if n <= 0
         then list
         else
             match seq with
             case End -> list
-            case Cons { value, rest } -> __take_last(rest(), max, n-1, __add_to_list(max, list, value))
+            case Cons { value, rest } -> take_last(rest(), max, n-1, add_to_list(max, list, value))
     ---
-    __take_last(this, n, n, [])
+    take_last(this, n, n, [])
 
 /// Returns a sequence containing only elements that satisfy `pred`.
 ///
@@ -105,41 +105,41 @@ fun Seq[T].take_last(n: size): List[T] =
 /// natural_seq().filter(x => x % 2 == 0)
 /// ```
 fun Seq[T].filter(pred: T => bool): Seq[T] =
-    fun __filter(seq: Seq[T], pred: T => bool): Seq[T] =
+    fun filter(seq: Seq[T], pred: T => bool): Seq[T] =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
-            then Cons { value, () => __filter(rest(), pred) }
-            else __filter(rest(), pred)
+            then Cons { value, () => filter(rest(), pred) }
+            else filter(rest(), pred)
     ---
-    __filter(this, pred)
+    filter(this, pred)
 
 fun Seq[T].`|-`(pred: T => bool): Seq[T] = this.filter(pred)
 
 /// Returns a sequence without elements that satisfy `pred`.
 fun Seq[T].reject(pred: T => bool): Seq[T] =
-    fun __reject(seq: Seq[T], pred: T => bool): Seq[T] =
+    fun reject(seq: Seq[T], pred: T => bool): Seq[T] =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
-            then __reject(rest(), pred)
-            else Cons { value, () => __reject(rest(), pred) }
+            then reject(rest(), pred)
+            else Cons { value, () => reject(rest(), pred) }
     ---
-    __reject(this, pred)
+    reject(this, pred)
 
 /// Skips the first `n` elements of the sequence.
 fun Seq[T].drop(n: size): Seq[T] =
-    fun rec __drop(seq: Seq[T], n: int) =
+    fun rec drop(seq: Seq[T], n: int) =
         if n <= 0
         then seq
         else
             match seq with
             case End -> End {}
-            case Cons { value, rest } -> __drop(rest(), n - 1)
+            case Cons { value, rest } -> drop(rest(), n - 1)
     ---
-    __drop(this, n)
+    drop(this, n)
 
 /// Drops elements until `pred` becomes `true`.
 ///
@@ -149,40 +149,40 @@ fun Seq[T].drop(n: size): Seq[T] =
 ///
 /// The first element that satisfies `pred` is included in the result.
 fun Seq[T].drop_until(pred: T => bool): Seq[T] =
-    fun rec __drop_until(seq: Seq[T], pred: T => bool) =
+    fun rec drop_until(seq: Seq[T], pred: T => bool) =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
             then Cons { value, rest }
-            else __drop_until(rest(), pred)
+            else drop_until(rest(), pred)
     ---
-    __drop_until(this, pred)
+    drop_until(this, pred)
 
 /// Returns elements from the start of the sequence until `pred` becomes `true`.
 ///
 /// The element that satisfies `pred` is not included.
 fun Seq[T].until(pred: T => bool): Seq[T] =
-    fun __until(seq: Seq[T], pred: T => bool) =
+    fun until(seq: Seq[T], pred: T => bool) =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
             if pred(value)
             then End {}
-            else Cons { value, () => __until(rest(), pred) }
+            else Cons { value, () => until(rest(), pred) }
     ---
-    __until(this, pred)
+    until(this, pred)
 
 /// Concatenates this sequence with `other`.
 ///
 /// If this sequence is infinite, `other` is never reached.
 fun Seq[T].`+`(other: Seq[T]): Seq[T] =
-    fun __add(seq: Seq[T], other: Seq[T]) =
+    fun add(seq: Seq[T], other: Seq[T]) =
         match seq with
         case End -> other
-        case Cons { value, rest } -> Cons { value, () => __add(rest(), other) }
+        case Cons { value, rest } -> Cons { value, () => add(rest(), other) }
     ---
-    __add(this, other)
+    add(this, other)
 
 /// Transforms each element using `map`.
 fun Seq[T].`|`(map: T => Y): Seq[Y] =
@@ -202,30 +202,30 @@ fun Seq[T].map(map: T => Y): Seq[Y] =
 /// produces:
 /// `[1, 2, 3, 2, 4, 6, 4, 8, 12, ...]`
 fun Seq[T].`|*`(map: T => Seq[Y]): Seq[Y] =
-    fun __flat_map(seq: Seq[T], map: T => Seq[Y]) =
+    fun flat_map(seq: Seq[T], map: T => Seq[Y]) =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
-            map(value) + __flat_map(rest(), map)
+            map(value) + flat_map(rest(), map)
     ---
-    __flat_map(this, map)
+    flat_map(this, map)
 
 fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
-    fun __flat_map(seq: Seq[T], map: T => Seq[Y]) =
+    fun flat_map(seq: Seq[T], map: T => Seq[Y]) =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
-            map(value) + __flat_map(rest(), map)
+            map(value) + flat_map(rest(), map)
     ---
-    __flat_map(this, map)
+    flat_map(this, map)
 
 fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
-    fun rec __reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
+    fun rec reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
         match seq with
         case End -> acc
-        case Cons { value, rest } -> __reduce(rest(), reducer(acc, value), reducer)
+        case Cons { value, rest } -> reduce(rest(), reducer(acc, value), reducer)
     ---
-    __reduce(this, initial, reducer)
+    reduce(this, initial, reducer)
 
 fun Seq[T].`|>`(initial: R, reducer: (R, T) => R): R = this.reduce(initial, reducer)
 
@@ -240,15 +240,15 @@ fun Seq[T].reduce_left(initial: R, reducer: (R, T) => R): R = this.reduce(initia
 /// `s2 = [a, b, c, ..., z]` (finite)
 /// `s1.zip(s2)` -> [(1, a), (2, b), (3, c), ..., (26, z)]
 fun Seq[T].zip(other: Seq[Y]): Seq[Tuple[T,Y]] =
-    fun __zip(this: Seq[T], other: Seq[Y]): Seq[Tuple[T,Y]] =
+    fun zip(this: Seq[T], other: Seq[Y]): Seq[Tuple[T,Y]] =
         match this with
         case End -> End {}
         case Cons { v1, r1 } ->
             match other with
             case End -> End {}
-            case Cons { v2, r2 } -> Cons { (v1, v2), () => __zip(r1, r2) }
+            case Cons { v2, r2 } -> Cons { (v1, v2), () => zip(r1, r2) }
     ---
-    __zip(this, other)
+    zip(this, other)
 
 /// Returns the first element wrapped in `Option`.
 ///

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -57,55 +57,55 @@ fun String.plus(value: any): String = this + value
 
 /// Returns true when at least one character satisfies `predicate`.
 fun String.any(predicate: String => bool): bool =
-    fun rec __any(value: String, idx: int, predicate: String => bool): bool =
+    fun rec any_match(value: String, idx: int, predicate: String => bool): bool =
         match value[idx] with
         case None -> false
         case Some { char } ->
             if predicate(char)
             then true
-            else __any(value, idx + 1, predicate)
+            else any_match(value, idx + 1, predicate)
     ---
-    __any(this, 0, predicate)
+    any_match(this, 0, predicate)
 
 /// Returns true when at least one character and index pair satisfies `predicate`.
 fun String.any(predicate: (String, int) => bool): bool =
-    fun rec __any(value: String, idx: int, predicate: (String, int) => bool): bool =
+    fun rec any_match(value: String, idx: int, predicate: (String, int) => bool): bool =
         match value[idx] with
         case None -> false
         case Some { char } ->
             if predicate(char, idx)
             then true
-            else __any(value, idx + 1, predicate)
+            else any_match(value, idx + 1, predicate)
     ---
-    __any(this, 0, predicate)
+    any_match(this, 0, predicate)
 
 /// Returns true when every character satisfies `predicate`.
 ///
 /// Empty strings return true.
 fun String.all(predicate: String => bool): bool =
-    fun rec __all(value: String, idx: int, predicate: String => bool): bool =
+    fun rec all(value: String, idx: int, predicate: String => bool): bool =
         match value[idx] with
         case None -> true
         case Some { char } ->
             if !predicate(char)
             then false
-            else __all(value, idx + 1, predicate)
+            else all(value, idx + 1, predicate)
     ---
-    __all(this, 0, predicate)
+    all(this, 0, predicate)
 
 /// Returns true when every character and index pair satisfies `predicate`.
 ///
 /// Empty strings return true.
 fun String.all(predicate: (String, int) => bool): bool =
-    fun rec __all(value: String, idx: int, predicate: (String, int) => bool): bool =
+    fun rec all(value: String, idx: int, predicate: (String, int) => bool): bool =
         match value[idx] with
         case None -> true
         case Some { char } ->
             if !predicate(char, idx)
             then false
-            else __all(value, idx + 1, predicate)
+            else all(value, idx + 1, predicate)
     ---
-    __all(this, 0, predicate)
+    all(this, 0, predicate)
 
 /// Returns true when this String contains the given substring.
 fun String.contains(part: String): bool =
@@ -121,51 +121,51 @@ fun String.`?`(part: String): bool = this.contains(part)
 
 /// Combines all characters from left to right.
 fun String.reduce(initial: R, reducer: (R, String) => R): R =
-    fun rec __reduce(value: String, idx: int, acc: R, reducer: (R, String) => R): R =
+    fun rec reduce(value: String, idx: int, acc: R, reducer: (R, String) => R): R =
         match value[idx] with
         case None -> acc
-        case Some { char } -> __reduce(value, idx + 1, reducer(acc, char), reducer)
+        case Some { char } -> reduce(value, idx + 1, reducer(acc, char), reducer)
     ---
-    __reduce(this, 0, initial, reducer)
+    reduce(this, 0, initial, reducer)
 
 /// Combines all characters from left to right.
 fun String.`|>`(initial: R, reducer: (R, String) => R): R = this.reduce(initial, reducer)
 
 /// Transforms each character using `map`.
 fun String.map(map: String => Y): Seq[Y] =
-    fun __map(value: String, idx: int, map: String => Y): Seq[Y] =
+    fun map_chars(value: String, idx: int, map: String => Y): Seq[Y] =
         match value[idx] with
         case None -> End {}
-        case Some { char } -> Cons { value: map(char), rest: () => __map(value, idx + 1, map) }
+        case Some { char } -> Cons { value: map(char), rest: () => map_chars(value, idx + 1, map) }
     ---
-    __map(this, 0, map)
+    map_chars(this, 0, map)
 
 /// Transforms each character using `map`.
 fun String.`|`(map: String => Y): Seq[Y] = this.map(map)
 
 /// Returns a sequence containing only characters that satisfy `predicate`.
 fun String.filter(predicate: String => bool): Seq[String] =
-    fun __filter(value: String, idx: int, predicate: String => bool): Seq[String] =
+    fun filter(value: String, idx: int, predicate: String => bool): Seq[String] =
         match value[idx] with
         case None -> End {}
         case Some { char } ->
             if predicate(char)
-            then Cons { value: char, rest: () => __filter(value, idx + 1, predicate) }
-            else __filter(value, idx + 1, predicate)
+            then Cons { value: char, rest: () => filter(value, idx + 1, predicate) }
+            else filter(value, idx + 1, predicate)
     ---
-    __filter(this, 0, predicate)
+    filter(this, 0, predicate)
 
 /// Returns a sequence without characters that satisfy `predicate`.
 fun String.reject(predicate: String => bool): Seq[String] =
-    fun __reject(value: String, idx: int, predicate: String => bool): Seq[String] =
+    fun reject(value: String, idx: int, predicate: String => bool): Seq[String] =
         match value[idx] with
         case None -> End {}
         case Some { char } ->
             if predicate(char)
-            then __reject(value, idx + 1, predicate)
-            else Cons { value: char, rest: () => __reject(value, idx + 1, predicate) }
+            then reject(value, idx + 1, predicate)
+            else Cons { value: char, rest: () => reject(value, idx + 1, predicate) }
     ---
-    __reject(this, 0, predicate)
+    reject(this, 0, predicate)
 
 /// Returns a sequence containing only characters that satisfy `predicate`.
 fun String.`|-`(predicate: String => bool): Seq[String] = this.filter(predicate)
@@ -192,20 +192,20 @@ fun String.end_with(part: String): bool =
 fun String.trim(): String =
     fun is_trim_whitespace(char: String): bool =
         char == " " | char == '\t' | char == '\n' | char == '\r' | char == '\f'
-    fun rec __trim_left(value: String): String =
+    fun rec trim_left(value: String): String =
         if value.size() == EMPTY
         then ""
         else if is_trim_whitespace(value[0, 1])
-            then __trim_left(value[1, value.size()])
+            then trim_left(value[1, value.size()])
             else value
-    fun rec __trim_right(value: String): String =
+    fun rec trim_right(value: String): String =
         if value.size() == EMPTY
         then ""
         else if is_trim_whitespace(value[value.size().value - 1, value.size()])
-            then __trim_right(value[0, value.size().value - 1])
+            then trim_right(value[0, value.size().value - 1])
             else value
     ---
-    __trim_right(__trim_left(this))
+    trim_right(trim_left(this))
 
 /// Replaces every occurrence of old with new.
 fun String.replace(old: String, new: String): String = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -39,8 +39,8 @@ deriver Jsonable {
 }
 
 fun to_json(obj: data): Result[JsonObject] =
-    data __JsonEntry { key: String, value: Result[Json] }
-    fun __merge_json_entry(acc: Result[Dict[Json]], json_entry: __JsonEntry): Result[Dict[Json]] =
+    data JsonEntry { key: String, value: Result[Json] }
+    fun merge_json_entry(acc: Result[Dict[Json]], json_entry: JsonEntry): Result[Dict[Json]] =
         let parsed_dict <- acc
         let json <- json_entry.value
         parsed_dict + { json_entry.key : json }
@@ -75,7 +75,7 @@ fun to_json(obj: data): Result[JsonObject] =
         case Dict d -> {
             let initial: Result[Dict[Json]] = Success { {:} }
             d
-                |> initial, (acc, key, item) => __merge_json_entry(acc, __JsonEntry { key, any_to_json(item) })
+                |> initial, (acc, key, item) => merge_json_entry(acc, JsonEntry { key, any_to_json(item) })
                 | values => Success { JsonObject { values } }
         }
         case Option o -> {
@@ -128,8 +128,8 @@ fun stringify(json: Json): String =
 fun serialize(obj: JsonObject): String = stringify(obj)
 
 private fun escape_string(value: String): String =
-    fun __unicode_control(hex: String): String = '\\' + 'u00' + hex
-    fun __escape_char(char: String): String =
+    fun unicode_control(hex: String): String = '\\' + 'u00' + hex
+    fun escape_char(char: String): String =
         match char with
         case '"' -> '\\' + '"'
         case '\\' -> '\\' + '\\'
@@ -138,36 +138,36 @@ private fun escape_string(value: String): String =
         case '\n' -> '\\' + 'n'
         case '\r' -> '\\' + 'r'
         case '\t' -> '\\' + 't'
-        case '\u0000' -> __unicode_control('00')
-        case '\u0001' -> __unicode_control('01')
-        case '\u0002' -> __unicode_control('02')
-        case '\u0003' -> __unicode_control('03')
-        case '\u0004' -> __unicode_control('04')
-        case '\u0005' -> __unicode_control('05')
-        case '\u0006' -> __unicode_control('06')
-        case '\u0007' -> __unicode_control('07')
-        case '\u000b' -> __unicode_control('0b')
-        case '\u000e' -> __unicode_control('0e')
-        case '\u000f' -> __unicode_control('0f')
-        case '\u0010' -> __unicode_control('10')
-        case '\u0011' -> __unicode_control('11')
-        case '\u0012' -> __unicode_control('12')
-        case '\u0013' -> __unicode_control('13')
-        case '\u0014' -> __unicode_control('14')
-        case '\u0015' -> __unicode_control('15')
-        case '\u0016' -> __unicode_control('16')
-        case '\u0017' -> __unicode_control('17')
-        case '\u0018' -> __unicode_control('18')
-        case '\u0019' -> __unicode_control('19')
-        case '\u001a' -> __unicode_control('1a')
-        case '\u001b' -> __unicode_control('1b')
-        case '\u001c' -> __unicode_control('1c')
-        case '\u001d' -> __unicode_control('1d')
-        case '\u001e' -> __unicode_control('1e')
-        case '\u001f' -> __unicode_control('1f')
+        case '\u0000' -> unicode_control('00')
+        case '\u0001' -> unicode_control('01')
+        case '\u0002' -> unicode_control('02')
+        case '\u0003' -> unicode_control('03')
+        case '\u0004' -> unicode_control('04')
+        case '\u0005' -> unicode_control('05')
+        case '\u0006' -> unicode_control('06')
+        case '\u0007' -> unicode_control('07')
+        case '\u000b' -> unicode_control('0b')
+        case '\u000e' -> unicode_control('0e')
+        case '\u000f' -> unicode_control('0f')
+        case '\u0010' -> unicode_control('10')
+        case '\u0011' -> unicode_control('11')
+        case '\u0012' -> unicode_control('12')
+        case '\u0013' -> unicode_control('13')
+        case '\u0014' -> unicode_control('14')
+        case '\u0015' -> unicode_control('15')
+        case '\u0016' -> unicode_control('16')
+        case '\u0017' -> unicode_control('17')
+        case '\u0018' -> unicode_control('18')
+        case '\u0019' -> unicode_control('19')
+        case '\u001a' -> unicode_control('1a')
+        case '\u001b' -> unicode_control('1b')
+        case '\u001c' -> unicode_control('1c')
+        case '\u001d' -> unicode_control('1d')
+        case '\u001e' -> unicode_control('1e')
+        case '\u001f' -> unicode_control('1f')
         case _ -> char
     ---
-    value |> '', (acc, char) => acc + __escape_char(char)
+    value |> '', (acc, char) => acc + escape_char(char)
 
 fun deserialize(json: String): Result[JsonObject] =
     deserialize_json_object(json)
@@ -176,10 +176,10 @@ fun deserialize(json: String): Result[JsonObject] =
         then Success { value: parse.value }
         else Error { "Expected string to end, but still got `{parse.parsing_string}`" }
 
-data _Parse[T] { value: T, parsing_string: String }
-fun _Parse[T].pop(): Tuple[Option[String], _Parse[T]] = (this.parsing_string[0], _Parse { this.value, this.parsing_string[1, this.parsing_string.size()] })
+private data Parse[T] { value: T, parsing_string: String }
+private fun Parse[T].pop(): Tuple[Option[String], Parse[T]] = (this.parsing_string[0], Parse { this.value, this.parsing_string[1, this.parsing_string.size()] })
 
-private fun rec deserialize_json(json: String): Result[_Parse[Json]] =
+private fun rec deserialize_json(json: String): Result[Parse[Json]] =
     match json[0] with
     case None -> Error { "Expected JSON, but got end of string" }
     case Some { first_char } when is_white_space(first_char) -> deserialize_json(drop_white_space(json[1, json.size()]))
@@ -193,14 +193,14 @@ private fun rec deserialize_json(json: String): Result[_Parse[Json]] =
         case '[' -> deserialize_json_array(json)
         case _ -> Error { "Do not know what to do with char `" + first_char + "`!" }
 
-private fun deserialize_json_array(json: String): Result[_Parse[JsonArray]] =
-    fun rec __deserialize_json_array(parse: _Parse[JsonArray]): Result[_Parse[JsonArray]] =
+private fun deserialize_json_array(json: String): Result[Parse[JsonArray]] =
+    fun rec deserialize_json_array(parse: Parse[JsonArray]): Result[Parse[JsonArray]] =
         match parse.parsing_string[0] with
         case None -> Error { "Expected `,` or `]`, but got end of string!" }
         case Some { ']' } -> Success { parse.pop()[1] }
         case Some { ',' } -> {
             let parse_json <- deserialize_json(parse.parsing_string[1, parse.parsing_string.size()])
-            __deserialize_json_array(_Parse {
+            deserialize_json_array(Parse {
                 value: parse.value + parse_json.value,
                 parsing_string: parse_json.parsing_string
             })
@@ -208,17 +208,17 @@ private fun deserialize_json_array(json: String): Result[_Parse[JsonArray]] =
         case Some { v } ->  Error { "Expected `,` or `]`, but got `" + v + "`!" }
     ---
     if json.starts_with('[]')
-    then Success { _Parse { JsonArray { [] }, json[2, json.size()] } }
+    then Success { Parse { JsonArray { [] }, json[2, json.size()] } }
     else
         deserialize_json(json[1, json.size()])
-            | parse => __deserialize_json_array(_Parse {
+            | parse => deserialize_json_array(Parse {
                 value: JsonArray {[parse.value]},
                 parsing_string: parse.parsing_string
             })
 
-private fun deserialize_json_null(json: String): Result[_Parse[JsonNull]] =
+private fun deserialize_json_null(json: String): Result[Parse[JsonNull]] =
     if json.starts_with('null')
-    then Success { _Parse { JsonNull {}, json[4, json.size()] } }
+    then Success { Parse { JsonNull {}, json[4, json.size()] } }
     else {
         let actual =
             if json.size() > 4
@@ -233,11 +233,11 @@ private fun deserialize_json_null(json: String): Result[_Parse[JsonNull]] =
         Error { "Expected `null`, but got `" + actual + "`!" }
     }
 
-private fun deserialize_json_bool(json: String): Result[_Parse[JsonBool]] =
+private fun deserialize_json_bool(json: String): Result[Parse[JsonBool]] =
     if json.starts_with('true')
-    then Success { _Parse { JsonBool {true}, json[4, json.size()] } }
+    then Success { Parse { JsonBool {true}, json[4, json.size()] } }
     else if json.starts_with('false')
-    then Success { _Parse { JsonBool {false}, json[5, json.size()] } }
+    then Success { Parse { JsonBool {false}, json[5, json.size()] } }
     else {
         let actual =
             if json.size() > 5
@@ -254,65 +254,65 @@ private fun deserialize_json_bool(json: String): Result[_Parse[JsonBool]] =
         Error { "Expected `true` or `false`, but got `" + actual + "`!" }
     }
 
-private fun deserialize_json_number(json: String): Result[_Parse[JsonNumber]] =
-    fun rec __parse_number(parse: _Parse[String]): Result[_Parse[String]] =
+private fun deserialize_json_number(json: String): Result[Parse[JsonNumber]] =
+    fun rec parse_number(parse: Parse[String]): Result[Parse[String]] =
         match parse.parsing_string[0] with
         case None -> Error { 'Expected `-[0-9]`, but got empty string!' }
         case Some { first_char } ->
             match first_char with
             case '-' ->
                 if parse.value.is_empty() | parse.value ? 'E' | parse.value ? 'e'
-                then __parse_number(_Parse { parse.value + first_char, parse.parsing_string[1, parse.parsing_string.size()] })
+                then parse_number(Parse { parse.value + first_char, parse.parsing_string[1, parse.parsing_string.size()] })
                 else Error { 'Expected `[0-9]`, but got `-`' }
-            case '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '.', 'E', 'e', '+' -> __parse_number(_Parse { parse.value + first_char, parse.parsing_string[1, parse.parsing_string.size()] })
+            case '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '.', 'E', 'e', '+' -> parse_number(Parse { parse.value + first_char, parse.parsing_string[1, parse.parsing_string.size()] })
             case '}', ']', ',' -> Success { parse }
             case _ v -> {
                 let no_white_space = drop_white_space(parse.parsing_string)
                 if no_white_space.starts_with('}') | no_white_space.starts_with(']') | no_white_space.starts_with(',')
-                then Success { _Parse { parse.value, no_white_space } }
+                then Success { Parse { parse.value, no_white_space } }
                 else
                     match  no_white_space[0] with
                     case None -> Error { 'Expected `}`, `]` or `,`, but got end of string!' }
                     case Some { v2 } -> Error { 'Expected `}`, `]` or `,`, but got `' + v2 + '`!' }
             }
     ---
-    __parse_number(_Parse {'', drop_white_space(json)})
+    parse_number(Parse {'', drop_white_space(json)})
     | parse =>
         if parse.value ? '.'
         then {
             let parsed_double <- parse.value.to_double()
-            _Parse { JsonNumberDouble { parsed_double }, drop_white_space(parse.parsing_string) }
+            Parse { JsonNumberDouble { parsed_double }, drop_white_space(parse.parsing_string) }
         }
         else {
             let parsed_long <- parse.value.to_long()
-            _Parse { JsonNumberLong { parsed_long }, drop_white_space(parse.parsing_string) }
+            Parse { JsonNumberLong { parsed_long }, drop_white_space(parse.parsing_string) }
         }
 
-private fun deserialize_json_string(json: String): Result[_Parse[JsonString]] =
+private fun deserialize_json_string(json: String): Result[Parse[JsonString]] =
     let parse <- parse_string(json)
-    _Parse {
+    Parse {
             value: JsonString { parse.value },
             parsing_string: parse.parsing_string
     }
 
-private fun deserialize_json_object(json: String): Result[_Parse[JsonObject]] =
+private fun deserialize_json_object(json: String): Result[Parse[JsonObject]] =
     match json[0] with
     case None -> Error { "message": "Expected JSON object, but got empty string!" }
     case Some { "{" } -> {
         deserialize_key_values(drop_white_space(json[1, json.size()]))
         | parse  =>
-            Success { _Parse {
+            Success { Parse {
                 value: JsonObject { parse.value },
                 parsing_string: parse.parsing_string
             }}
     }
     case Some { v } -> Error { message: "Expected `{`, but got `" + v + "`."}
 
-private fun deserialize_key_values(json: String): Result[_Parse[Dict[Json]]] =
-    fun rec __deserialize_key_values(json: String, acc: Dict[Json]): Result[_Parse[Dict[Json]]] =
+private fun deserialize_key_values(json: String): Result[Parse[Dict[Json]]] =
+    fun rec deserialize_key_values(json: String, acc: Dict[Json]): Result[Parse[Dict[Json]]] =
         match json[0] with
         case None -> Error { "Expected `,` or `}`, but got empty string!" }
-        case Some { "}" } -> Success { _Parse { acc, json[1, json.size()] } }
+        case Some { "}" } -> Success { Parse { acc, json[1, json.size()] } }
         case Some { _ } ->
             match deserialize_key_value(drop_white_space(json)) with
             case Error e -> e
@@ -320,9 +320,9 @@ private fun deserialize_key_values(json: String): Result[_Parse[Dict[Json]]] =
                 let next = acc + { parse_key_value.value.key : parse_key_value.value.value }
                 match parse_key_value.parsing_string[0] with
                 case None -> Error { "Expected `,` or `}`, but got empty string!" }
-                case Some { "," } -> __deserialize_key_values(drop_white_space(parse_key_value.parsing_string[1, parse_key_value.parsing_string.size()]), next)
+                case Some { "," } -> deserialize_key_values(drop_white_space(parse_key_value.parsing_string[1, parse_key_value.parsing_string.size()]), next)
                 case Some { "}" } -> Success {
-                    _Parse {
+                    Parse {
                         next,
                         drop_white_space(parse_key_value.parsing_string[1, parse_key_value.parsing_string.size()])
                     }
@@ -331,11 +331,11 @@ private fun deserialize_key_values(json: String): Result[_Parse[Dict[Json]]] =
             }
     ---
     let empty: Dict[Json] = {:}
-    __deserialize_key_values(json, empty)
+    deserialize_key_values(json, empty)
 
-data _KeyValue { key: String, value: Json }
+private data KeyValue { key: String, value: Json }
 
-private fun deserialize_key_value(json: String): Result[_Parse[_KeyValue]] =
+private fun deserialize_key_value(json: String): Result[Parse[KeyValue]] =
     parse_string(json)
     | parse =>
         match parse.parsing_string[0] with
@@ -343,16 +343,16 @@ private fun deserialize_key_value(json: String): Result[_Parse[_KeyValue]] =
         case Some { ":" } -> {
             deserialize_json(drop_white_space(parse.parsing_string[1, parse.parsing_string.size()]))
             | parse_json => Success {
-                _Parse {
-                    _KeyValue { parse.value, parse_json.value },
+                Parse {
+                    KeyValue { parse.value, parse_json.value },
                     drop_white_space(parse_json.parsing_string)
                 }
             }
         }
         case Some { v } ->  Error { "Expected `:`, but got `" + v + "`!" }
 
-private fun parse_string(json: String): Result[_Parse[String]] =
-    const __escape_chars: Set[String] = { '"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u' }
+private fun parse_string(json: String): Result[Parse[String]] =
+    const escape_chars: Set[String] = { '"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u' }
     /// Parses JSON string, the quotation marks `"` are not included in final string
     /// Supports escape character `\`:
     /// - `\"` - quotation mark
@@ -364,33 +364,33 @@ private fun parse_string(json: String): Result[_Parse[String]] =
     /// - `\r` - carriage return
     /// - `\t` - horizontal tab
     /// - `\\uXXXX` - 4 HEX digits
-    fun rec __parse_string_until_quotation(parse: _Parse[String], escape: bool): Result[_Parse[String]] =
+    fun rec parse_string_until_quotation(parse: Parse[String], escape: bool): Result[Parse[String]] =
         if escape
         then
             match parse.parsing_string[0] with
-            case None -> Error { message: "Expected one of " + (__escape_chars |> "", (a,b) => a + ", " + b) + " but got end of string" }
+            case None -> Error { message: "Expected one of " + (escape_chars |> "", (a,b) => a + ", " + b) + " but got end of string" }
             case Some { v } ->
-                if __escape_chars ? v
+                if escape_chars ? v
                 then
                     if v == 'u'
                     // support \uXXXX
                     // todo check if next chars are [0-9A-F]
-                    then __parse_string_until_quotation( _Parse { parse.value[0] + 'u' + parse.parsing_string[1, 5], parse.parsing_string[5, parse.parsing_string.size()] }, false)
-                    else __parse_string_until_quotation( _Parse { parse.value[0] + v, parse.parsing_string[1, parse.parsing_string.size()] }, false)
-                else Error { message: "Expected one of " + (__escape_chars |> "", (a,b) => a + ", " + b) + " but got `" + v + "`" }
+                    then parse_string_until_quotation( Parse { parse.value[0] + 'u' + parse.parsing_string[1, 5], parse.parsing_string[5, parse.parsing_string.size()] }, false)
+                    else parse_string_until_quotation( Parse { parse.value[0] + v, parse.parsing_string[1, parse.parsing_string.size()] }, false)
+                else Error { message: "Expected one of " + (escape_chars |> "", (a,b) => a + ", " + b) + " but got `" + v + "`" }
         else
             // no escape
             match parse.parsing_string[0] with
             case Some { v } -> {
                 match v with
-                case '\\' -> __parse_string_until_quotation(_Parse { parse.value + v, parse.parsing_string[1, parse.parsing_string.size()] } , true)
-                case '"'  -> Success { _Parse { parse.value, drop_white_space(parse.parsing_string[1, parse.parsing_string.size()]) }} // quotation mark found, ending
-                case _    -> __parse_string_until_quotation(_Parse { parse.value + v, parse.parsing_string[1, parse.parsing_string.size()] }, false) // quotation mark not found, parsing...
+                case '\\' -> parse_string_until_quotation(Parse { parse.value + v, parse.parsing_string[1, parse.parsing_string.size()] } , true)
+                case '"'  -> Success { Parse { parse.value, drop_white_space(parse.parsing_string[1, parse.parsing_string.size()]) }} // quotation mark found, ending
+                case _    -> parse_string_until_quotation(Parse { parse.value + v, parse.parsing_string[1, parse.parsing_string.size()] }, false) // quotation mark not found, parsing...
                 }
             case None -> Error { message: '"parse_string: Expected `"`, but got end of string."' }
     ---
     match json[0] with
-    case Some { '"' } -> __parse_string_until_quotation(_Parse { "", json[1, json.size()] },  false)
+    case Some { '"' } -> parse_string_until_quotation(Parse { "", json[1, json.size()] },  false)
     case Some { v } -> Error { message: "parse_string: Expected `\"`, but got `" + v + "`." }
     case None -> Error { message: "parse_string: Expected JSON string, got end of string." }
 
@@ -400,20 +400,20 @@ private fun rec drop_white_space(s: String): String =
     case _ -> s
 
 private fun is_white_space(s: String): bool =
-    const __white_spaces = { " ", "\r", "\n", "\t" }
-    fun rec __is_white_space(s: String, white_spaces: Set[String]): bool =
+    const white_spaces = { " ", "\r", "\n", "\t" }
+    fun rec is_white_space(s: String, white_spaces: Set[String]): bool =
         match s[0] with
         case None -> true
         case Some { c } ->
             if white_spaces ? c
-            then __is_white_space(s[1, s.size()], white_spaces)
+            then is_white_space(s[1, s.size()], white_spaces)
             else false
     ---
-    __is_white_space(s, __white_spaces)
+    is_white_space(s, white_spaces)
 
 fun deserialize(dict: Dict[any]): Result[JsonObject] =
-    fun __initial_result(): Result[Dict[Json]] = Success { {:} }
-    fun __to_json_value(value: any): Result[Json] =
+    fun initial_result(): Result[Dict[Json]] = Success { {:} }
+    fun to_json_value(value: any): Result[Json] =
         match value with
         case String s -> Success { JsonString { s } }
         case int i -> Success { JsonNumberLong { i } }
@@ -423,12 +423,12 @@ fun deserialize(dict: Dict[any]): Result[JsonObject] =
         case Dict d -> deserialize(d)
         case Json j -> Success { j }
         case _ x -> Error { "Don't know how to deserialize: " + x }
-    fun __merge(acc: Result[Dict[Json]], key: String, value: any): Result[Dict[Json]] =
+    fun merge(acc: Result[Dict[Json]], key: String, value: any): Result[Dict[Json]] =
         let parsed_dict <- acc
-        let json <- __to_json_value(value)
+        let json <- to_json_value(value)
         parsed_dict + { key : json }
     ---
-    let initial_result: Result[Dict[Json]] = __initial_result()
+    let initial_result: Result[Dict[Json]] = initial_result()
     dict
-        |> initial_result, (acc, k, v) => __merge(acc, k, v)
+        |> initial_result, (acc, k, v) => merge(acc, k, v)
         | d => Success { JsonObject { d } }

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -15,7 +15,7 @@ from /capy/date_time/Interval import { * }
 data Assertion { result: bool, message: String, type: String }
 
 union Assert { assertions: List[() => Assertion] } =
-    _TechnicalAssert
+    TechnicalAssert
     | StringAssert | IntAssert | LongAssert | DoubleAssert | FloatAssert | BoolAssert
     | DataAssert | OptionAssert | ResultAssert
     | DateAssert | TimeAssert | DateTimeAssert | DurationAssert | IntervalAssert
@@ -25,7 +25,7 @@ fun Assert.failed(): bool = (this.assertions | supplier => supplier().result).an
 
 fun Assert.succeeded(): bool = !this.failed()
 
-data _TechnicalAssert { assertions: List[() => Assertion] }
+private data TechnicalAssert { assertions: List[() => Assertion] }
 data StringAssert { value: String }
 data IntAssert { value: int }
 data LongAssert { value: long }
@@ -48,7 +48,7 @@ data SeqAssert[T] { value: Seq[T] }
 fun assert_all(asserts: List[Assert]): Assert =
     let initial: List[() => Assertion] = []
     let assertions: List[() => Assertion] = asserts |> initial, (acc, assert) => acc + assert.assertions
-    _TechnicalAssert { assertions: assertions }
+    TechnicalAssert { assertions: assertions }
 
 fun StringAssert.is_equal_to(other: String): StringAssert =
     let assertion = Assertion {

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -364,18 +364,18 @@ private fun team_city_messages_case(test_case: TestCase): List[String] =
     ]
 
 fun team_city_escape(value: String): String =
-    fun rec __team_city_escape(value: String, acc: String): String =
+    fun rec team_city_escape(value: String, acc: String): String =
         match value[0] with
         case None -> acc
-        case Some { '\'' } -> __team_city_escape(value[1, value.size()], acc + "|'")
-        case Some { '\n' } -> __team_city_escape(value[1, value.size()], acc + '|n')
-        case Some { '\r' } -> __team_city_escape(value[1, value.size()], acc + '|r')
-        case Some { '|' } -> __team_city_escape(value[1, value.size()], acc + '||')
-        case Some { '[' } -> __team_city_escape(value[1, value.size()], acc + '|[')
-        case Some { ']' } -> __team_city_escape(value[1, value.size()], acc + '|]')
-        case Some { c } -> __team_city_escape(value[1, value.size()], acc + c)
+        case Some { '\'' } -> team_city_escape(value[1, value.size()], acc + "|'")
+        case Some { '\n' } -> team_city_escape(value[1, value.size()], acc + '|n')
+        case Some { '\r' } -> team_city_escape(value[1, value.size()], acc + '|r')
+        case Some { '|' } -> team_city_escape(value[1, value.size()], acc + '||')
+        case Some { '[' } -> team_city_escape(value[1, value.size()], acc + '|[')
+        case Some { ']' } -> team_city_escape(value[1, value.size()], acc + '|]')
+        case Some { c } -> team_city_escape(value[1, value.size()], acc + c)
     ---
-    __team_city_escape(value, '')
+    team_city_escape(value, '')
 
 private fun test_suite_name(file_name: String): String = file_name
 
@@ -412,16 +412,16 @@ private fun stale_output_files(output_dir: Path, manifest_file: Path, expected_f
     )
 
 private fun stale_files(files: List[Path], expected_files: List[Path]): List[Path] =
-    fun rec __stale_files(files: List[Path], expected_files: List[Path], acc: List[Path]): List[Path] =
+    fun rec stale_files(files: List[Path], expected_files: List[Path], acc: List[Path]): List[Path] =
         match files[0] with
         case None -> acc
         case Some { file } ->
             let normalized = file.normalize()
             if path_to_manifest_line(normalized) == OUTPUT_MANIFEST_FILE | path_list_contains(expected_files, normalized)
-            then __stale_files(files[1:], expected_files, acc)
-            else __stale_files(files[1:], expected_files, acc + normalized)
+            then stale_files(files[1:], expected_files, acc)
+            else stale_files(files[1:], expected_files, acc + normalized)
     ---
-    __stale_files(files, expected_files, [])
+    stale_files(files, expected_files, [])
 
 private fun delete_stale_outputs(output_dir: Path, stale_files: List[Path]): Effect[Result[List[Path]]] =
     match stale_files[0] with
@@ -536,14 +536,14 @@ private fun path_to_manifest_line(path: Path): String =
     path_segments_to_string(path.normalize().segments)
 
 private fun path_segments_to_string(segments: List[String]): String =
-    fun rec __path_segments_to_string(segments: List[String], acc: String): String =
+    fun rec path_segments_to_string(segments: List[String], acc: String): String =
         match segments[0] with
         case None -> acc
         case Some { segment } ->
             let next = if acc.is_empty() then segment else acc + '/' + segment
-            __path_segments_to_string(segments[1:], next)
+            path_segments_to_string(segments[1:], next)
     ---
-    __path_segments_to_string(segments, '')
+    path_segments_to_string(segments, '')
 
 private fun has_failures(test_outputs: List[TestOutput]): bool = test_outputs.any(output => output.failed)
 

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -79,29 +79,29 @@ fun sem_ver(
 ///                  | <version core> "-" <pre-release> "+" <build>
 /// ```
 fun parse_semver(version: String): Result[SemVer] =
-    data __Parse[T] { buffer: String, value: T }
-    fun __tail(value: String): String = value[1, value.size()]
+    data Parse[T] { buffer: String, value: T }
+    fun tail(value: String): String = value[1, value.size()]
     /// ```
     /// <version core> ::= <major> "." <minor> "." <patch>
     /// ```
-    fun __parse_version_core(version: String): Result[__Parse[SemVer]] =
-        let parse_major: __Parse[major] <- __parse_major(version)
+    fun parse_version_core(version: String): Result[Parse[SemVer]] =
+        let parse_major: Parse[major] <- parse_major(version)
         match parse_major.buffer[0] with
         case None ->  Error { 'Unexpected end of version string!' }
         case Some { dot1 } ->
             if dot1 != '.'
             then Error { 'Expected `.` after major version, but got `' + dot1 + '`!' }
             else {
-                let parse_minor: __Parse[minor] <- __parse_minor(__tail(parse_major.buffer))
+                let parse_minor: Parse[minor] <- parse_minor(tail(parse_major.buffer))
                 match parse_minor.buffer[0] with
                 case None -> Error { 'Unexpected end of version string!' }
                 case Some { dot2 } ->
                     if dot2 != '.'
                     then Error { 'Expected `.` after minor version, but got `' + dot2 + '`!' }
                     else {
-                        let parse_patch: __Parse[patch] <- __parse_patch(__tail(parse_minor.buffer))
+                        let parse_patch: Parse[patch] <- parse_patch(tail(parse_minor.buffer))
                         let raw_sem_ver =
-                            __Parse {
+                            Parse {
                                 buffer: parse_patch.buffer,
                                 value: SemVer {
                                    major: parse_major.value,
@@ -112,17 +112,17 @@ fun parse_semver(version: String): Result[SemVer] =
                             }}
                         match parse_patch.buffer[0] with
                         case Some { next_char } when next_char == '-' -> {
-                            let parse_pre_release: __Parse[String] <- __parse_pre_release(__tail(parse_patch.buffer))
+                            let parse_pre_release: Parse[String] <- parse_pre_release(tail(parse_patch.buffer))
                             let parse =
-                                __Parse {
+                                Parse {
                                     buffer: parse_pre_release.buffer,
                                     value: raw_sem_ver.value.with(pre_release: Some { parse_pre_release.value })
                                 }
                             match parse.buffer[0] with
                             case None -> parse
                             case Some { char } when char == '+' -> {
-                                let parse_build: __Parse[String] <- __parse_build(__tail(parse.buffer))
-                                __Parse {
+                                let parse_build: Parse[String] <- parse_build(tail(parse.buffer))
+                                Parse {
                                     buffer: parse_build.buffer,
                                     value: parse.value.with(build_metadata: Some { parse_build.value })
                                 }
@@ -130,8 +130,8 @@ fun parse_semver(version: String): Result[SemVer] =
                             case Some { char } -> Error { 'Expected end of version string or `+` for build metadata, but got `' + char + '`!' }
                         }
                         case Some { next_char } when next_char == '+' -> {
-                            let parse_build: __Parse[String] <- __parse_build(__tail(parse_patch.buffer))
-                            __Parse {
+                            let parse_build: Parse[String] <- parse_build(tail(parse_patch.buffer))
+                            Parse {
                                 buffer: parse_build.buffer,
                                 value: raw_sem_ver.value.with(build_metadata: Some { parse_build.value })
                             }
@@ -145,96 +145,96 @@ fun parse_semver(version: String): Result[SemVer] =
     /// ```
     /// <major> ::= <numeric identifier>
     /// ```
-    fun __parse_major(version: String): Result[__Parse[major]] =
-        let parse <- __parse_numeric_identifier(version)
+    fun parse_major(version: String): Result[Parse[major]] =
+        let parse <- parse_numeric_identifier(version)
         let value <- major { parse.value }
-        Success { __Parse { buffer: parse.buffer, value: value } }
+        Success { Parse { buffer: parse.buffer, value: value } }
     /// ```
     /// <minor> ::= <numeric identifier>
     /// ```
-    fun __parse_minor(version: String): Result[__Parse[minor]] =
-        let parse <- __parse_numeric_identifier(version)
+    fun parse_minor(version: String): Result[Parse[minor]] =
+        let parse <- parse_numeric_identifier(version)
         let value <- minor { parse.value }
-        Success { __Parse { buffer: parse.buffer, value: value } }
+        Success { Parse { buffer: parse.buffer, value: value } }
     /// ```
     /// <patch> ::= <numeric identifier>
     /// ```
-    fun __parse_patch(version: String): Result[__Parse[patch]] =
-        let parse <- __parse_numeric_identifier(version)
+    fun parse_patch(version: String): Result[Parse[patch]] =
+        let parse <- parse_numeric_identifier(version)
         let value <- patch { parse.value }
-        Success { __Parse { buffer: parse.buffer, value: value } }
+        Success { Parse { buffer: parse.buffer, value: value } }
     /// ```
     /// <numeric identifier> ::= "0"
     ///                        | <positive digit>
     ///                        | <positive digit> <digits>
     /// ```
-    fun __parse_numeric_identifier(version: String): Result[__Parse[int]] =
+    fun parse_numeric_identifier(version: String): Result[Parse[int]] =
         match version[0] with
         case None -> Error { 'Unexpected end of version string!' }
-        case Some { '0' } -> Success { __Parse { __tail(version), 0 } }
+        case Some { '0' } -> Success { Parse { tail(version), 0 } }
         case Some { value } ->
-            let first_positive_digit_parse <- __parse_positive_digit(version)
-            __parse_digits_rest(first_positive_digit_parse.buffer, first_positive_digit_parse.value)
+            let first_positive_digit_parse <- parse_positive_digit(version)
+            parse_digits_rest(first_positive_digit_parse.buffer, first_positive_digit_parse.value)
 
         /// ```
         /// <pre-release> ::= <dot-separated pre-release identifiers>
         /// ```
-        fun __parse_pre_release(version: String): Result[__Parse[String]] = __parse_dot_separated_pre_release_identifiers(version)
+        fun parse_pre_release(version: String): Result[Parse[String]] = parse_dot_separated_pre_release_identifiers(version)
         /// ```
         /// <dot-separated pre-release identifiers> ::= <pre-release identifier>
         ///                                           | <pre-release identifier> "." <dot-separated pre-release identifiers>
         /// ```
-        fun __parse_dot_separated_pre_release_identifiers(version: String): Result[__Parse[String]] =
-            let parse <- __parse_pre_release_identifier(version)
-            __parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parse.value)
-        fun rec __parse_dot_separated_pre_release_identifiers_rest(version: String, parsed: String): Result[__Parse[String]] =
+        fun parse_dot_separated_pre_release_identifiers(version: String): Result[Parse[String]] =
+            let parse <- parse_pre_release_identifier(version)
+            parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parse.value)
+        fun rec parse_dot_separated_pre_release_identifiers_rest(version: String, parsed: String): Result[Parse[String]] =
             match version[0] with
-            case None -> Success { __Parse { buffer: version, value: parsed } }
+            case None -> Success { Parse { buffer: version, value: parsed } }
             case Some { char } when char == '.' -> {
-                let parse <- __parse_pre_release_identifier(__tail(version))
-                __parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parsed + "." + parse.value)
+                let parse <- parse_pre_release_identifier(tail(version))
+                parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parsed + "." + parse.value)
             }
-            case Some { char } when char == '+' -> Success { __Parse { buffer: version, value: parsed } }
+            case Some { char } when char == '+' -> Success { Parse { buffer: version, value: parsed } }
             case Some { char } -> Error { 'Expected end of version string or `.` for next pre-release identifier, but got `' + char + '`!' }
         /// ```
         /// <pre-release identifier> ::= <alphanumeric identifier>
         ///                            | <numeric identifier>
         /// ```
-        fun __parse_pre_release_identifier(version: String): Result[__Parse[String]] =
+        fun parse_pre_release_identifier(version: String): Result[Parse[String]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some ->
-                __parse_alphanumeric_identifier(version)
-                    .or(__parse_numeric_identifier(version)
-                        | parse => Success { __Parse { buffer: parse.buffer, value: "" + parse.value } })
+                parse_alphanumeric_identifier(version)
+                    .or(parse_numeric_identifier(version)
+                        | parse => Success { Parse { buffer: parse.buffer, value: "" + parse.value } })
                     | parse => Success { parse }
         /// ```
         /// <build> ::= <dot-separated build identifiers>
         /// ```
-        fun __parse_build(version: String): Result[__Parse[String]] = __parse_dot_separated_build_identifiers(version)
+        fun parse_build(version: String): Result[Parse[String]] = parse_dot_separated_build_identifiers(version)
         /// ```
         // <dot-separated build identifiers> ::= <build identifier>
         //                                     | <build identifier> "." <dot-separated build identifiers>
         /// ```
-        fun __parse_dot_separated_build_identifiers(version: String): Result[__Parse[String]] =
-            let parse_identifier <- __parse_dot_separated_build_identifier(version)
-            __parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parse_identifier.value)
-        fun rec __parse_dot_separated_build_identifiers_rest(version: String, parsed: String): Result[__Parse[String]] =
+        fun parse_dot_separated_build_identifiers(version: String): Result[Parse[String]] =
+            let parse_identifier <- parse_dot_separated_build_identifier(version)
+            parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parse_identifier.value)
+        fun rec parse_dot_separated_build_identifiers_rest(version: String, parsed: String): Result[Parse[String]] =
             match version[0] with
-            case None -> Success { __Parse { buffer: version, value: parsed } }
+            case None -> Success { Parse { buffer: version, value: parsed } }
             case Some { char } when char == '.' -> {
-                let parse_identifier <- __parse_dot_separated_build_identifier(__tail(version))
-                __parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parsed + "." + parse_identifier.value)
+                let parse_identifier <- parse_dot_separated_build_identifier(tail(version))
+                parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parsed + "." + parse_identifier.value)
             }
             case Some { char } -> Error { 'Expected end of version string or `.` for next build identifier, but got `' + char + '`!' }
         /// ```
         // <build identifier> ::= <alphanumeric identifier>
         //                      | <digits>
         /// ```
-        fun __parse_dot_separated_build_identifier(version: String): Result[__Parse[String]] =
-            __parse_alphanumeric_identifier(version)
-                .or(__parse_digits_as_string(version)
-                    | parse => Success { __Parse { buffer: parse.buffer, value: "" + parse.value } })
+        fun parse_dot_separated_build_identifier(version: String): Result[Parse[String]] =
+            parse_alphanumeric_identifier(version)
+                .or(parse_digits_as_string(version)
+                    | parse => Success { Parse { buffer: parse.buffer, value: "" + parse.value } })
 
         /// ```
         /// <alphanumeric identifier> ::= <non-digit>
@@ -242,25 +242,25 @@ fun parse_semver(version: String): Result[SemVer] =
         ///                             | <identifier characters> <non-digit>
         ///                             | <identifier characters> <non-digit> <identifier characters>
         /// ```
-        fun __parse_alphanumeric_identifier(version: String): Result[__Parse[String]] =
+        fun parse_alphanumeric_identifier(version: String): Result[Parse[String]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some ->
-                __parse_non_digit(version)
+                parse_non_digit(version)
                 | (parse_non_digit => {
-                    match __parse_identifier_characters(parse_non_digit.buffer) with
+                    match parse_identifier_characters(parse_non_digit.buffer) with
                     case Error -> Success { parse_non_digit }
-                    case Success { parse_identifier_characters } -> Success { __Parse {
+                    case Success { parse_identifier_characters } -> Success { Parse {
                         buffer: parse_identifier_characters.buffer,
                         value: parse_non_digit.value + parse_identifier_characters.value
                     }}})
                 .or(
-                    __parse_identifier_characters(version)
-                    | pic => { __parse_non_digit(pic.buffer) | pnd => Success { __Parse { buffer: pnd.buffer, pic.value + pnd.value }} }
+                    parse_identifier_characters(version)
+                    | pic => { parse_non_digit(pic.buffer) | pnd => Success { Parse { buffer: pnd.buffer, pic.value + pnd.value }} }
                     | parse_non_digit => {
-                        match __parse_identifier_characters(parse_non_digit.buffer) with
+                        match parse_identifier_characters(parse_non_digit.buffer) with
                         case Error -> Success { parse_non_digit }
-                        case Success { parse_identifier_characters } -> Success { __Parse {
+                        case Success { parse_identifier_characters } -> Success { Parse {
                             buffer: parse_identifier_characters.buffer,
                             value: pic.value + parse_non_digit.value + parse_identifier_characters.value }}
                     })
@@ -268,88 +268,88 @@ fun parse_semver(version: String): Result[SemVer] =
         // <identifier characters> ::= <identifier character>
         //                           | <identifier character> <identifier characters>
         /// ```
-        fun __parse_identifier_characters(version: String): Result[__Parse[String]] =
-            let pic <- __parse_identifier_character(version)
-            __parse_identifier_characters_rest(pic.buffer, pic.value)
-        fun rec __parse_identifier_characters_rest(version: String, parsed: String): Result[__Parse[String]] =
-            match __parse_identifier_character(version) with
-            case Success { parse } -> __parse_identifier_characters_rest(parse.buffer, parsed + parse.value)
-            case Error -> Success { __Parse { buffer: version, value: parsed } }
+        fun parse_identifier_characters(version: String): Result[Parse[String]] =
+            let pic <- parse_identifier_character(version)
+            parse_identifier_characters_rest(pic.buffer, pic.value)
+        fun rec parse_identifier_characters_rest(version: String, parsed: String): Result[Parse[String]] =
+            match parse_identifier_character(version) with
+            case Success { parse } -> parse_identifier_characters_rest(parse.buffer, parsed + parse.value)
+            case Error -> Success { Parse { buffer: version, value: parsed } }
         /// ```
         /// <identifier character> ::= <digit>
         ///                          | <non-digit>
         /// ```
-        fun __parse_identifier_character(version: String): Result[__Parse[String]] =
-            (__parse_digit(version)
-                | parse => Success { __Parse { buffer: parse.buffer, value: "" + parse.value } })
-                .or(__parse_non_digit(version))
+        fun parse_identifier_character(version: String): Result[Parse[String]] =
+            (parse_digit(version)
+                | parse => Success { Parse { buffer: parse.buffer, value: "" + parse.value } })
+                .or(parse_non_digit(version))
         /// ```
         /// <non-digit> ::= <letter>
         ///               | "-"
         /// ```
-        fun __parse_non_digit(version: String): Result[__Parse[String]] =
+        fun parse_non_digit(version: String): Result[Parse[String]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some { value } ->
                 if value == '-'
-                then Success { __Parse { __tail(version), "-" } }
-                else __parse_letter(version)
+                then Success { Parse { tail(version), "-" } }
+                else parse_letter(version)
         /// ```
         /// <digits> ::= <digit>
         ///            | <digit> <digits>
         /// ```
-        fun __parse_digits(version: String): Result[__Parse[int]] =
-            let parse <- __parse_digit(version)
-            __parse_digits_rest(parse.buffer, parse.value)
-        fun rec __parse_digits_rest(version: String, parsed: int): Result[__Parse[int]] =
-            match __parse_digit(version) with
-            case Success { parse } -> __parse_digits_rest(parse.buffer, parsed * 10 + parse.value)
-            case Error -> Success { __Parse { buffer: version, value: parsed } }
-        /// Same as `__parse_digits(version: String): Result[__Parse[int]]`, but returns String to prevent prefix zeroes from being stripped, which is important for build metadata identifiers
-        fun __parse_digits_as_string(version: String): Result[__Parse[String]] =
-            let parse <- __parse_digit_as_string(version)
-            __parse_digits_as_string_rest(parse.buffer, parse.value)
-        fun rec __parse_digits_as_string_rest(version: String, parsed: String): Result[__Parse[String]] =
-            match __parse_digit_as_string(version) with
-            case Success { parse } -> __parse_digits_as_string_rest(parse.buffer, parsed + parse.value)
-            case Error -> Success { __Parse { buffer: version, value: parsed } }
+        fun parse_digits(version: String): Result[Parse[int]] =
+            let parse <- parse_digit(version)
+            parse_digits_rest(parse.buffer, parse.value)
+        fun rec parse_digits_rest(version: String, parsed: int): Result[Parse[int]] =
+            match parse_digit(version) with
+            case Success { parse } -> parse_digits_rest(parse.buffer, parsed * 10 + parse.value)
+            case Error -> Success { Parse { buffer: version, value: parsed } }
+        /// Same as `parse_digits(version: String): Result[Parse[int]]`, but returns String to prevent prefix zeroes from being stripped, which is important for build metadata identifiers
+        fun parse_digits_as_string(version: String): Result[Parse[String]] =
+            let parse <- parse_digit_as_string(version)
+            parse_digits_as_string_rest(parse.buffer, parse.value)
+        fun rec parse_digits_as_string_rest(version: String, parsed: String): Result[Parse[String]] =
+            match parse_digit_as_string(version) with
+            case Success { parse } -> parse_digits_as_string_rest(parse.buffer, parsed + parse.value)
+            case Error -> Success { Parse { buffer: version, value: parsed } }
         /// ```
         /// <digit> ::= "0"
         ///           | <positive digit>
         /// ```
-        fun __parse_digit(version: String): Result[__Parse[int]] =
+        fun parse_digit(version: String): Result[Parse[int]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some { value } ->
                 match value with
-                case '0' -> Success { __Parse { __tail(version), 0 } }
-                case _ -> __parse_positive_digit(version)
-        /// Same as `__parse_digit(version: String): Result[__Parse[int]]`, but returns String to prevent prefix zeroes from being stripped, which is important for build metadata identifiers
-        fun __parse_digit_as_string(version: String): Result[__Parse[String]] =
+                case '0' -> Success { Parse { tail(version), 0 } }
+                case _ -> parse_positive_digit(version)
+        /// Same as `parse_digit(version: String): Result[Parse[int]]`, but returns String to prevent prefix zeroes from being stripped, which is important for build metadata identifiers
+        fun parse_digit_as_string(version: String): Result[Parse[String]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some { value } ->
                 match value with
-                case '0' -> Success { __Parse { __tail(version), '0' } }
-                case _ -> __parse_positive_digit(version)
-                    | parse => Success { __Parse { buffer: parse.buffer, value: parse.value + '' } }
+                case '0' -> Success { Parse { tail(version), '0' } }
+                case _ -> parse_positive_digit(version)
+                    | parse => Success { Parse { buffer: parse.buffer, value: parse.value + '' } }
         /// ```
         /// <positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
         /// ```
-        fun __parse_positive_digit(version: String): Result[__Parse[int]] =
+        fun parse_positive_digit(version: String): Result[Parse[int]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some { value } ->
                 match value with
-                case '1' -> Success { __Parse { __tail(version), 1 } }
-                case '2' -> Success { __Parse { __tail(version), 2 } }
-                case '3' -> Success { __Parse { __tail(version), 3 } }
-                case '4' -> Success { __Parse { __tail(version), 4 } }
-                case '5' -> Success { __Parse { __tail(version), 5 } }
-                case '6' -> Success { __Parse { __tail(version), 6 } }
-                case '7' -> Success { __Parse { __tail(version), 7 } }
-                case '8' -> Success { __Parse { __tail(version), 8 } }
-                case '9' -> Success { __Parse { __tail(version), 9 } }
+                case '1' -> Success { Parse { tail(version), 1 } }
+                case '2' -> Success { Parse { tail(version), 2 } }
+                case '3' -> Success { Parse { tail(version), 3 } }
+                case '4' -> Success { Parse { tail(version), 4 } }
+                case '5' -> Success { Parse { tail(version), 5 } }
+                case '6' -> Success { Parse { tail(version), 6 } }
+                case '7' -> Success { Parse { tail(version), 7 } }
+                case '8' -> Success { Parse { tail(version), 8 } }
+                case '9' -> Success { Parse { tail(version), 9 } }
                 case _ -> Error { 'Expected digit between 1 and 9, but got `' + value + '`!' }
         /// ```
         /// <letter> ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J"
@@ -359,7 +359,7 @@ fun parse_semver(version: String): Result[SemVer] =
         ///            | "o" | "p" | "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x"
         ///            | "y" | "z"
         /// ```
-        fun __parse_letter(version: String): Result[__Parse[String]] =
+        fun parse_letter(version: String): Result[Parse[String]] =
             match version[0] with
             case None -> Error { 'Unexpected end of version string!' }
             case Some { value } ->
@@ -369,10 +369,10 @@ fun parse_semver(version: String): Result[SemVer] =
                    | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
                    | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j'
                    | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't'
-                   | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'  -> Success { __Parse { __tail(version), value } }
+                   | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'  -> Success { Parse { tail(version), value } }
                 case _ -> Error { "Expected A-Z or a-z, but got `" + value + "`!" }
     ---
-    __parse_version_core(version)
+    parse_version_core(version)
     | version_parse =>
         if !version_parse.buffer.is_empty()
         then Error { 'Unexpected characters after patch version: `' + version_parse.buffer + '`!' }

--- a/lib/capybara-lib/src/test/capybara/capy/collection/SetTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/collection/SetTest.cfun
@@ -23,12 +23,12 @@ fun tests(): Effect[TestFile] =
         test("should flat map values", () => set_should_flat_map_values()),
     ])
 
-fun _empty_int_set(): Set[int] = {1, 2} - {1, 2}
+private fun empty_int_set(): Set[int] = {1, 2} - {1, 2}
 
-fun _single_int_set(value: int): Set[int] = _empty_int_set() + value
+private fun single_int_set(value: int): Set[int] = empty_int_set() + value
 
 fun set_should_report_size_and_emptiness(): Assert =
-    let empty = _empty_int_set()
+    let empty = empty_int_set()
     let non_empty = {1, 2} - 2
     assert_all([
         assert_that({1, 2, 3}.size()).is_equal_to(3),
@@ -65,7 +65,7 @@ fun set_should_remove_values_and_sets(): Assert =
     ])
 
 fun set_should_test_any_and_all_values(): Assert =
-    let empty = _empty_int_set()
+    let empty = empty_int_set()
     assert_all([
         assert_that({1, 2, 3}.any(value => value > 2)).is_true(),
         assert_that({1, 2, 3}.any(value => value > 5)).is_false(),
@@ -102,7 +102,7 @@ fun set_should_combine_and_intersect_sets(): Assert =
         assert_that({1, 2} ∪ {2, 3}).is_equal_to({1, 2, 3}),
         assert_that({1, 2, 3}.intersection({2, 3, 4})).is_equal_to({2, 3}),
         assert_that({1, 2, 3} ∩ {2, 3, 4}).is_equal_to({2, 3}),
-        assert_that({1, 2, 3}.difference(_single_int_set(2))).is_equal_to({1, 3}),
+        assert_that({1, 2, 3}.difference(single_int_set(2))).is_equal_to({1, 3}),
     ])
 
 fun set_should_calculate_symmetric_differences(): Assert =
@@ -124,9 +124,9 @@ fun set_should_calculate_cartesian_products(): Assert =
     ])
 
 fun set_should_calculate_power_sets(): Assert =
-    let empty = _empty_int_set()
-    let one = _single_int_set(1)
-    let two = _single_int_set(2)
+    let empty = empty_int_set()
+    let one = single_int_set(1)
+    let two = single_int_set(2)
     let expected: Set[Set[int]] = {
         empty,
         one,
@@ -141,7 +141,7 @@ fun set_should_calculate_power_sets(): Assert =
 fun set_should_reduce_values(): Assert =
     assert_all([
         assert_that({1, 2, 3} |> 0, (acc, value) => acc + value).is_equal_to(6),
-        assert_that(_empty_int_set().reduce(10, (acc, value) => acc + value)).is_equal_to(10),
+        assert_that(empty_int_set().reduce(10, (acc, value) => acc + value)).is_equal_to(10),
     ])
 
 fun set_should_map_values(): Assert =

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTest.cfun
@@ -56,16 +56,16 @@ fun tests(): Effect[TestFile] =
         // invalid dates
         (-1, JANUARY, 2020, false),
         (0, FEBRUARY, 2020, false),
-    ] | (day, month, year, is_valid) => _test_date(day, month, year, is_valid)).as_list()
+    ] | (day, month, year, is_valid) => test_date(day, month, year, is_valid)).as_list()
     test_file('/capy/date_time/Date.cfun',
         test_cases
-        + _test_month()
-        + _test_leap_year()
-        + _date_test_to_iso_8601()
-        + _date_test_from_iso_8601_success()
-        + _date_test_from_iso_8601_failure())
+        + test_month()
+        + test_leap_year()
+        + date_test_to_iso_8601()
+        + date_test_from_iso_8601_success()
+        + date_test_from_iso_8601_failure())
 
-fun _test_date(day: int, month: month, year: int, is_valid: bool): TestCase =
+private fun test_date(day: int, month: month, year: int, is_valid: bool): TestCase =
     let assert: Assert =
         if is_valid
         then assert_that(Date { day, month, year })
@@ -79,7 +79,7 @@ fun _test_date(day: int, month: month, year: int, is_valid: bool): TestCase =
         "Date \{ day: {day}, month: {month}, year: {year} } should be " + (if is_valid then 'valid' else 'invalid'),
         () => assert)
 
-fun _test_month(): List[TestCase] =
+private fun test_month(): List[TestCase] =
     ([
         (0, false),
         (1, true),
@@ -95,14 +95,14 @@ fun _test_month(): List[TestCase] =
         test("month.previous should rewind middle months", () => assert_that((APRIL).previous()).is_equal_to(MARCH)),
     ]
 
-fun _test_leap_year(): List[TestCase] =
+private fun test_leap_year(): List[TestCase] =
     let leap_year = Date { day: 1, month: JANUARY, year: 2020 } | d => Success { d.leap_year() }
     let not_leap_year = Date { day: 1, month: JANUARY, year: 2019 } | d => Success { d.leap_year() }
     [
         test('1/1/2020 should be a leap year', () => assert_that(leap_year).succeeds(true)),
         test('1/1/2019 should not be a leap year', () => assert_that(not_leap_year).succeeds(false)) ]
 
-fun _date_test_to_iso_8601(): List[TestCase] =
+private fun date_test_to_iso_8601(): List[TestCase] =
     ([
         (7, JANUARY, 2000, "2000-01-07"),
         (7, JANUARY, -1, "-0001-01-07"),
@@ -111,7 +111,7 @@ fun _date_test_to_iso_8601(): List[TestCase] =
         "Date.to_iso_8601() should format {day}/{month}/{year}",
         () => assert_that(Date { day, month, year } | d => Success { d.to_iso_8601() }).succeeds(expected))).as_list()
 
-fun _date_test_from_iso_8601_success(): List[TestCase] =
+private fun date_test_from_iso_8601_success(): List[TestCase] =
     ([
         ("2000-01-07", 7, JANUARY, 2000),
         ("20000107", 7, JANUARY, 2000),
@@ -125,7 +125,7 @@ fun _date_test_from_iso_8601_success(): List[TestCase] =
                 .has_month(month)
                 .has_year(year)))).as_list()
 
-fun _date_test_from_iso_8601_failure(): List[TestCase] =
+private fun date_test_from_iso_8601_failure(): List[TestCase] =
     ([
         "2000-02-30",
         "2000-01",
@@ -136,7 +136,7 @@ fun _date_test_from_iso_8601_failure(): List[TestCase] =
         "Date.from_iso_8601 should fail for {iso}",
         () => assert_that(/capy/date_time/Date.from_iso_8601(iso)).fails())).as_list()
 
-fun _date_test_value(day: int, month: month, year: int): Date =
+private fun date_test_value(day: int, month: month, year: int): Date =
     match Date { day: day, month: month, year: year } with
     case Success { value } -> value
     case Error -> UNIX_DATE

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
@@ -12,7 +12,7 @@ from /capy/test/Assert import { * }
 from /capy/lang/Effect import { * }
 from /capy/test/CapyTest import { * }
 
-fun _at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
+private fun at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
     let epoch_date = UNIX_DATE
     let midnight = MIDNIGHT
     DateTime {
@@ -22,18 +22,18 @@ fun _at(days_since_epoch: int, seconds_since_midnight: int): DateTime =
 
 fun tests(): Effect[TestFile] =
     test_file('/capy/date_time/DateTime.cfun',
-        [_test_unix_epoch()]
-        + _datetime_test_to_iso_8601()
-        + _test_timestamp()
-        + _test_from_timestamp()
-        + _test_plus()
-        + _test_minus_duration()
-        + _test_minus_datetime()
-        + _test_comparisons()
-        + _datetime_test_from_iso_8601_success()
-        + _datetime_test_from_iso_8601_failure())
+        [test_unix_epoch()]
+        + datetime_test_to_iso_8601()
+        + test_timestamp()
+        + test_from_timestamp()
+        + test_plus()
+        + test_minus_duration()
+        + test_minus_datetime()
+        + test_comparisons()
+        + datetime_test_from_iso_8601_success()
+        + datetime_test_from_iso_8601_failure())
 
-fun _test_unix_epoch(): TestCase =
+private fun test_unix_epoch(): TestCase =
     test("UNIX_EPOCH should return the correct DateTime for 1 January 1970 at 00:00:00",
         () => let epoch = UNIX_EPOCH
         assert_that(epoch)
@@ -44,96 +44,96 @@ fun _test_unix_epoch(): TestCase =
             .has_minute(0)
             .has_second(0))
 
-fun _datetime_test_to_iso_8601(): List[TestCase] =
+private fun datetime_test_to_iso_8601(): List[TestCase] =
     let offset_time =
         match /capy/date_time/Time.from_iso_8601("13:00:00+01:00") with
         case Success { time } -> time
         case Error -> MIDNIGHT
     [
         test("DateTime.to_iso_8601 should format canonical UTC date-time",
-            () => assert_that(_at(1, 3661).to_iso_8601()).is_equal_to("1970-01-02T01:01:01Z")),
+            () => assert_that(at(1, 3661).to_iso_8601()).is_equal_to("1970-01-02T01:01:01Z")),
         test("DateTime.to_iso_8601 should normalize offset-bearing time to UTC",
             () => assert_that(DateTime { date: UNIX_DATE, time: offset_time }.to_iso_8601()).is_equal_to("1970-01-01T12:00:00Z")),
     ]
 
-fun _test_timestamp(): List[TestCase] =
+private fun test_timestamp(): List[TestCase] =
     ([
-        (_at(0, 0), 0L),
-        (_at(1, 0), 86400L),
-        (_at(0, 3600), 3600L),
-        (_at(0, 60), 60L),
-        (_at(0, 1), 1L),
-        (_at(-1, 86399), -1L),
-        (_at(1, 3600), 90000L),
+        (at(0, 0), 0L),
+        (at(1, 0), 86400L),
+        (at(0, 3600), 3600L),
+        (at(0, 60), 60L),
+        (at(0, 1), 1L),
+        (at(-1, 86399), -1L),
+        (at(1, 3600), 90000L),
     ] | (datetime, expected) => test(
         "{datetime}.timestamp() should return the correct Unix timestamp",
         () => assert_that(datetime.timestamp()).is_equal_to(expected))).as_list()
 
-fun _test_from_timestamp(): List[TestCase] =
+private fun test_from_timestamp(): List[TestCase] =
     ([
-        (0L, _at(0, 0)),
-        (86400L, _at(1, 0)),
-        (3600L, _at(0, 3600)),
-        (1L, _at(0, 1)),
-        (-1L, _at(-1, 86399)),
-        (90000L, _at(1, 3600)),
+        (0L, at(0, 0)),
+        (86400L, at(1, 0)),
+        (3600L, at(0, 3600)),
+        (1L, at(0, 1)),
+        (-1L, at(-1, 86399)),
+        (90000L, at(1, 3600)),
     ] | (timestamp, expected) => test(
         "DateTime.from_timestamp should convert {timestamp} to DateTime",
         () => assert_that(/capy/date_time/DateTime.from_timestamp(timestamp)).is_equal_to(expected))).as_list()
 
-fun _test_plus(): List[TestCase] =
+private fun test_plus(): List[TestCase] =
     let epoch_date = UNIX_DATE
     let jan_31_2024 = epoch_date.add_years_months(54, 0).add_days(30)
     [
         test("plus should add ISO 8601 week durations as whole calendar weeks",
-            () => assert_that(_at(0, 0).plus(WeekDuration { weeks: 2 })).is_equal_to(_at(14, 0))),
+            () => assert_that(at(0, 0).plus(WeekDuration { weeks: 2 })).is_equal_to(at(14, 0))),
         test("plus should apply calendar units before clock carry",
-            () => assert_that(_at(0, 0).plus(DateDuration { years: 0, months: 0, days: 1, hours: 1, minutes: 30, seconds: 0 })).is_equal_to(_at(1, 5400))),
+            () => assert_that(at(0, 0).plus(DateDuration { years: 0, months: 0, days: 1, hours: 1, minutes: 30, seconds: 0 })).is_equal_to(at(1, 5400))),
         test("plus should clamp month-end dates per ISO 8601 calendar arithmetic",
             () => assert_that(DateTime { date: jan_31_2024, time: MIDNIGHT }.plus(DateDuration { years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0 })).is_equal_to(DateTime { date: jan_31_2024.add_years_months(0, 1), time: MIDNIGHT })),
         test("operator + should delegate to plus",
-            () => assert_that(_at(0, 0) + DateDuration { years: 0, months: 0, days: 0, hours: 25, minutes: 0, seconds: 0 }).is_equal_to(_at(1, 3600))),
+            () => assert_that(at(0, 0) + DateDuration { years: 0, months: 0, days: 0, hours: 25, minutes: 0, seconds: 0 }).is_equal_to(at(1, 3600))),
         test("plus should normalize negative clock components across midnight",
-            () => assert_that(_at(1, 1800).plus(DateDuration { years: 0, months: 0, days: 0, hours: -1, minutes: 0, seconds: 0 })).is_equal_to(_at(0, 84600))),
+            () => assert_that(at(1, 1800).plus(DateDuration { years: 0, months: 0, days: 0, hours: -1, minutes: 0, seconds: 0 })).is_equal_to(at(0, 84600))),
         test("plus should handle large hour components without overflowing the intra-day clock",
-            () => assert_that(_at(0, 0).plus(DateDuration { years: 0, months: 0, days: 0, hours: 600000, minutes: 0, seconds: 0 })).is_equal_to(_at(25000, 0))),
+            () => assert_that(at(0, 0).plus(DateDuration { years: 0, months: 0, days: 0, hours: 600000, minutes: 0, seconds: 0 })).is_equal_to(at(25000, 0))),
     ]
 
-fun _test_minus_duration(): List[TestCase] =
+private fun test_minus_duration(): List[TestCase] =
     let epoch_date = UNIX_DATE
     let mar_31_2024 = epoch_date.add_years_months(54, 2).add_days(30)
     [
         test("minus should subtract ISO 8601 week durations as whole calendar weeks",
-            () => assert_that(_at(14, 0).minus(WeekDuration { weeks: 2 })).is_equal_to(_at(0, 0))),
+            () => assert_that(at(14, 0).minus(WeekDuration { weeks: 2 })).is_equal_to(at(0, 0))),
         test("minus should apply calendar subtraction before clock normalization",
-            () => assert_that(_at(1, 1800).minus(DateDuration { years: 0, months: 0, days: 0, hours: 1, minutes: 0, seconds: 0 })).is_equal_to(_at(0, 84600))),
+            () => assert_that(at(1, 1800).minus(DateDuration { years: 0, months: 0, days: 0, hours: 1, minutes: 0, seconds: 0 })).is_equal_to(at(0, 84600))),
         test("minus should clamp month-end dates per ISO 8601 calendar arithmetic",
             () => assert_that(DateTime { date: mar_31_2024, time: MIDNIGHT }.minus(DateDuration { years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0 })).is_equal_to(DateTime { date: mar_31_2024.add_years_months(0, -1), time: MIDNIGHT })),
         test("operator - should delegate to minus",
-            () => assert_that(_at(1, 3600) - DateDuration { years: 0, months: 0, days: 0, hours: 25, minutes: 0, seconds: 0 }).is_equal_to(_at(0, 0))),
+            () => assert_that(at(1, 3600) - DateDuration { years: 0, months: 0, days: 0, hours: 25, minutes: 0, seconds: 0 }).is_equal_to(at(0, 0))),
     ]
 
-fun _test_minus_datetime(): List[TestCase] =
+private fun test_minus_datetime(): List[TestCase] =
     [
         test("minus(DateTime) should return a canonical positive elapsed duration",
-            () => assert_that(_at(1, 3661).minus(_at(0, 0)).to_iso_8601()).is_equal_to("P1DT1H1M1S")),
+            () => assert_that(at(1, 3661).minus(at(0, 0)).to_iso_8601()).is_equal_to("P1DT1H1M1S")),
         test("minus(DateTime) should return a negated canonical elapsed duration when this is earlier",
-            () => assert_that(_at(0, 0).minus(_at(1, 3661)).to_iso_8601()).is_equal_to("P-1DT-1H-1M-1S")),
+            () => assert_that(at(0, 0).minus(at(1, 3661)).to_iso_8601()).is_equal_to("P-1DT-1H-1M-1S")),
         test("minus(DateTime) should return zero duration for identical instants",
-            () => assert_that(_at(3, 42).minus(_at(3, 42)).to_iso_8601()).is_equal_to("PT0S")),
+            () => assert_that(at(3, 42).minus(at(3, 42)).to_iso_8601()).is_equal_to("PT0S")),
         test("minus(DateTime) should produce a duration that plus can reapply",
-            () => let start = _at(10, 30)
-            let finish = _at(12, 7325)
+            () => let start = at(10, 30)
+            let finish = at(12, 7325)
             let duration = finish.minus(start)
             assert_that(start.plus(duration))
                 .has_date(finish.date)
                 .has_time(finish.time)),
     ]
 
-fun _test_comparisons(): List[TestCase] =
-    let first = _at(0, 0)
-    let second = _at(0, 1)
-    let third = _at(1, 0)
+private fun test_comparisons(): List[TestCase] =
+    let first = at(0, 0)
+    let second = at(0, 1)
+    let third = at(1, 0)
     [
         test("DateTimeAssert.is_greater_than should assert later instants",
             () => assert_all([
@@ -157,21 +157,21 @@ fun _test_comparisons(): List[TestCase] =
             ])),
     ]
 
-fun _datetime_test_from_iso_8601_success(): List[TestCase] =
+private fun datetime_test_from_iso_8601_success(): List[TestCase] =
     ([
-        ("1970-01-01T00:00:00Z", _at(0, 0)),
-        ("19700101T000000Z", _at(0, 0)),
-        ("1970-01-01T00:00:00+00:00", _at(0, 0)),
-        ("19700101T000000+0000", _at(0, 0)),
-        ("1970-01-01T00:00:00+00", _at(0, 0)),
-        ("1970-01-01T02:30:00+02:30", _at(0, 0)),
-        ("1970-01-01T02:00:00+02", _at(0, 0)),
-        ("19700101T020000+0200", _at(0, 0)),
-        ("1969-12-31T21:00:00-03:00", _at(0, 0)),
-        ("1970-01-01T00:30:00+01:00", _at(-1, 84600)),
-        ("1970-01-01T23:30:00-01:00", _at(1, 1800)),
-        ("1970-01-01T14:00:00+14:00", _at(0, 0)),
-        ("1970-01-01T00:30:00-11:30", _at(0, 43200)),
+        ("1970-01-01T00:00:00Z", at(0, 0)),
+        ("19700101T000000Z", at(0, 0)),
+        ("1970-01-01T00:00:00+00:00", at(0, 0)),
+        ("19700101T000000+0000", at(0, 0)),
+        ("1970-01-01T00:00:00+00", at(0, 0)),
+        ("1970-01-01T02:30:00+02:30", at(0, 0)),
+        ("1970-01-01T02:00:00+02", at(0, 0)),
+        ("19700101T020000+0200", at(0, 0)),
+        ("1969-12-31T21:00:00-03:00", at(0, 0)),
+        ("1970-01-01T00:30:00+01:00", at(-1, 84600)),
+        ("1970-01-01T23:30:00-01:00", at(1, 1800)),
+        ("1970-01-01T14:00:00+14:00", at(0, 0)),
+        ("1970-01-01T00:30:00-11:30", at(0, 43200)),
     ] | (iso, expected) => test(
         "DateTime.from_iso_8601 should parse {iso}",
         () => assert_that(/capy/date_time/DateTime.from_iso_8601(iso)).succeeds(datetime =>
@@ -182,7 +182,7 @@ fun _datetime_test_from_iso_8601_success(): List[TestCase] =
                 assert_that(datetime.to_iso_8601()).is_equal_to(expected.to_iso_8601()),
             ])))).as_list()
 
-fun _datetime_test_from_iso_8601_failure(): List[TestCase] =
+private fun datetime_test_from_iso_8601_failure(): List[TestCase] =
     ([
         "1970-01-01T00:00:00",
         "1970-01-01 00:00:00Z",

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
@@ -14,81 +14,81 @@ from /capy/test/CapyTest import { * }
 
 fun tests(): Effect[TestFile] =
     let success_test_cases = [
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z",
             "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2008, 5, 11, 15, 30, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2008, 5, 11, 15, 30, 0),
             DateDuration { years: 0, months: 0, days: 437, hours: 2, minutes: 30, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "20070301T130000Z/20080511T153000Z",
             "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2008, 5, 11, 15, 30, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2008, 5, 11, 15, 30, 0),
             DateDuration { years: 0, months: 0, days: 437, hours: 2, minutes: 30, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T13:00:00Z/P1Y2M10DT2H30M",
             "2007-03-01T13:00:00Z/P1Y2M10DT2H30M",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2008, 5, 11, 15, 30, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2008, 5, 11, 15, 30, 0),
             DateDuration { years: 1, months: 2, days: 10, hours: 2, minutes: 30, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T14:00:00+01:00/P1D",
             "2007-03-01T13:00:00Z/P1D",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2007, 3, 2, 13, 0, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2007, 3, 2, 13, 0, 0),
             DateDuration { years: 0, months: 0, days: 1, hours: 0, minutes: 0, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "P1Y2M10DT2H30M/2008-05-11T15:30:00Z",
             "P1Y2M10DT2H30M/2008-05-11T15:30:00Z",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2008, 5, 11, 15, 30, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2008, 5, 11, 15, 30, 0),
             DateDuration { years: 1, months: 2, days: 10, hours: 2, minutes: 30, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T13:00:00Z--2008-05-11T15:30:00Z",
             "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2008, 5, 11, 15, 30, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2008, 5, 11, 15, 30, 0),
             DateDuration { years: 0, months: 0, days: 437, hours: 2, minutes: 30, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T13:00:00Z--P10D",
             "2007-03-01T13:00:00Z/P10D",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2007, 3, 11, 13, 0, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2007, 3, 11, 13, 0, 0),
             DateDuration { years: 0, months: 0, days: 10, hours: 0, minutes: 0, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "P10D--2007-03-11T13:00:00Z",
             "P10D/2007-03-11T13:00:00Z",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2007, 3, 11, 13, 0, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2007, 3, 11, 13, 0, 0),
             DateDuration { years: 0, months: 0, days: 10, hours: 0, minutes: 0, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "P1D/2007-03-03T15:30:10Z",
             "P1D/2007-03-03T15:30:10Z",
-            _interval_datetime(2007, 3, 2, 15, 30, 10),
-            _interval_datetime(2007, 3, 3, 15, 30, 10),
+            interval_datetime(2007, 3, 2, 15, 30, 10),
+            interval_datetime(2007, 3, 3, 15, 30, 10),
             DateDuration { years: 0, months: 0, days: 1, hours: 0, minutes: 0, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T13:00:00Z/P1D",
             "2007-03-01T13:00:00Z/P1D",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2007, 3, 2, 13, 0, 0),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2007, 3, 2, 13, 0, 0),
             DateDuration { years: 0, months: 0, days: 1, hours: 0, minutes: 0, seconds: 0 }
         ),
-        _should_parse_interval(
+        should_parse_interval(
             "2007-03-01T13:00:00Z/2007-03-03T15:30:10Z",
             "2007-03-01T13:00:00Z/2007-03-03T15:30:10Z",
-            _interval_datetime(2007, 3, 1, 13, 0, 0),
-            _interval_datetime(2007, 3, 3, 15, 30, 10),
+            interval_datetime(2007, 3, 1, 13, 0, 0),
+            interval_datetime(2007, 3, 3, 15, 30, 10),
             DateDuration { years: 0, months: 0, days: 2, hours: 2, minutes: 30, seconds: 10 }
         ),
     ]
@@ -106,7 +106,7 @@ fun tests(): Effect[TestFile] =
 
     test_file("/capy/date_time/Interval.cfun", success_test_cases + failed_test_cases)
 
-fun _should_parse_interval(
+private fun should_parse_interval(
     iso: String,
     canonical: String,
     start: DateTime,
@@ -124,12 +124,12 @@ fun _should_parse_interval(
                         .has_duration(duration),
                 ])))
 
-fun _interval_date(year: int, month_value: int, day: int): Date =
+private fun interval_date(year: int, month_value: int, day: int): Date =
     let parsed_month = (month { month_value }).or_else(JANUARY)
     let parsed_date = Date { day: day, month: parsed_month, year: year }
     parsed_date.or_else(UNIX_DATE)
 
-fun _interval_time(hour_value: int, minute_value: int, second_value: int): Time =
+private fun interval_time(hour_value: int, minute_value: int, second_value: int): Time =
     let parsed_time = {
         let parsed_hour <- hour { hour_value }
         let parsed_minute <- minute { minute_value }
@@ -138,8 +138,8 @@ fun _interval_time(hour_value: int, minute_value: int, second_value: int): Time 
     }
     parsed_time.or_else(MIDNIGHT)
 
-fun _interval_datetime(year: int, month: int, day: int, hour: int, minute: int, second: int): DateTime =
+private fun interval_datetime(year: int, month: int, day: int, hour: int, minute: int, second: int): DateTime =
     DateTime {
-        date: _interval_date(year, month, day),
-        time: _interval_time(hour, minute, second)
+        date: interval_date(year, month, day),
+        time: interval_time(hour, minute, second)
     }

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/TimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/TimeTest.cfun
@@ -24,21 +24,21 @@ fun tests(): Effect[TestFile] =
         (-1, 0, 0, false),
         (0, -1, 0, false),
         (0, 0, -1, false),
-    ] | (hour, minute, second, is_valid) => _test_time(hour, minute, second, is_valid)).as_list()
+    ] | (hour, minute, second, is_valid) => test_time(hour, minute, second, is_valid)).as_list()
     test_file('/capy/date_time/Time.cfun',
         test_cases
         + component_type_tests()
-        + _test_to_seconds()
-        + _test_to_minutes()
-        + _test_to_hours()
-        + _test_round_to_minutes()
-        + _test_round_to_hours()
-        + _test_add_seconds()
-        + _test_add_minutes()
-        + _test_add_hours()
-        + _time_test_to_iso_8601()
-        + _time_test_from_iso_8601_success()
-        + _time_test_from_iso_8601_failure())
+        + test_to_seconds()
+        + test_to_minutes()
+        + test_to_hours()
+        + test_round_to_minutes()
+        + test_round_to_hours()
+        + test_add_seconds()
+        + test_add_minutes()
+        + test_add_hours()
+        + time_test_to_iso_8601()
+        + time_test_from_iso_8601_success()
+        + time_test_from_iso_8601_failure())
 
 private fun time_from_parts(hour_value: int, minute_value: int, second_value: int, offset_minutes: Option[offset_minutes]): Result[Time] = {
     let parsed_hour <- hour { hour_value }
@@ -47,10 +47,10 @@ private fun time_from_parts(hour_value: int, minute_value: int, second_value: in
     Success { Time { hour: parsed_hour, minute: parsed_minute, second: parsed_second, offset_minutes } }
 }
 
-fun _local_time(hour: int, minute: int, second: int): Result[Time] =
+private fun local_time(hour: int, minute: int, second: int): Result[Time] =
     time_from_parts(hour, minute, second, None {})
 
-fun _offset_time(hour: int, minute: int, second: int, offset_value: int): Result[Time] = {
+private fun offset_time(hour: int, minute: int, second: int, offset_value: int): Result[Time] = {
     let parsed_offset <- offset_minutes { offset_value }
     time_from_parts(hour, minute, second, Some { parsed_offset })
 }
@@ -106,50 +106,50 @@ private fun component_type_tests(): List[TestCase] =
                 ]))
     ]
 
-fun _test_time(hour: int, minute: int, second: int, is_valid: bool): TestCase =
+private fun test_time(hour: int, minute: int, second: int, is_valid: bool): TestCase =
     let assert: Assert =
         if is_valid
-        then assert_that(_local_time(hour, minute, second))
+        then assert_that(local_time(hour, minute, second))
             .succeeds(time =>
                 assert_that(time)
                     .has_hour(hour)
                     .has_minute(minute)
                     .has_second(second)
                     .has_offset_minutes(None {}))
-        else assert_that(_local_time(hour, minute, second)).fails()
+        else assert_that(local_time(hour, minute, second)).fails()
     test("Time \{ hour: {hour}, minute: {minute}, second: {second} } should " + (if is_valid then "succeed" else "fail"), () => assert)
 
-fun _test_to_seconds(): List[TestCase] =
+private fun test_to_seconds(): List[TestCase] =
     ([
         (4, 23, 59, 15839),
         (2, 30, 0, 9000),
         (3, 0, 0, 10800),
     ] | (hour, minute, second, expected) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.to_seconds() should return the {expected} seconds",
-        () => assert_that(_local_time(hour, minute, second) | t => Success { t.to_seconds() }).succeeds(expected))).as_list()
+        () => assert_that(local_time(hour, minute, second) | t => Success { t.to_seconds() }).succeeds(expected))).as_list()
 
-fun _test_to_minutes(): List[TestCase] =
+private fun test_to_minutes(): List[TestCase] =
     ([
         (4, 23, 59, 263),
         (2, 30, 0, 150),
         (3, 0, 0, 180),
     ] | (hour, minute, second, expected) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.to_minutes() should return the {expected} minutes",
-        () => assert_that(_local_time(hour, minute, second) | t => Success { t.to_minutes() }).succeeds(expected))).as_list()
+        () => assert_that(local_time(hour, minute, second) | t => Success { t.to_minutes() }).succeeds(expected))).as_list()
 
-fun _test_to_hours(): List[TestCase] =
+private fun test_to_hours(): List[TestCase] =
     ([
         (4, 23, 59, 4),
         (2, 30, 0, 2),
         (3, 0, 0, 3),
     ] | (hour, minute, second, expected) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.to_hours() should return the {expected} hours",
-        () => assert_that(_local_time(hour, minute, second) | t => Success { t.to_hours() }).succeeds(expected))).as_list()
+        () => assert_that(local_time(hour, minute, second) | t => Success { t.to_hours() }).succeeds(expected))).as_list()
 
-fun _test_round_to_minutes(): TestCase =
+private fun test_round_to_minutes(): TestCase =
     test(
         "Time \{hour: 23, minute: 59, seconds: 59}.round_to_minutes() should preserve offset and zero seconds",
-        () => assert_that(_offset_time(23, 59, 59, 90))
+        () => assert_that(offset_time(23, 59, 59, 90))
             .succeeds(time =>
                 assert_that(time.round_to_minutes())
                     .has_hour(23)
@@ -157,10 +157,10 @@ fun _test_round_to_minutes(): TestCase =
                     .has_second(0)
                     .has_offset_minutes(some_offset(90))))
 
-fun _test_round_to_hours(): TestCase =
+private fun test_round_to_hours(): TestCase =
     test(
         "Time \{hour: 23, minute: 59, seconds: 59}.round_to_hours() should preserve offset and zero minutes",
-        () => assert_that(_offset_time(23, 59, 59, -300))
+        () => assert_that(offset_time(23, 59, 59, -300))
             .succeeds(time =>
                 assert_that(time.round_to_hours())
                     .has_hour(23)
@@ -168,7 +168,7 @@ fun _test_round_to_hours(): TestCase =
                     .has_second(0)
                     .has_offset_minutes(some_offset(-300))))
 
-fun _test_add_seconds(): List[TestCase] =
+private fun test_add_seconds(): List[TestCase] =
     ([
         (23, 59, 59, 1, 0, 0, 0),
         (23, 59, 59, 60, 0, 0, 59),
@@ -181,12 +181,12 @@ fun _test_add_seconds(): List[TestCase] =
         (0, 0, 0, -3661, 22, 58, 59),
     ] | (hour, minute, second, seconds_to_add, expected_hour, expected_minute, expected_second) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.add_seconds({seconds_to_add}) should return expected time",
-        () => assert_that(_offset_time(hour, minute, second, 330))
+        () => assert_that(offset_time(hour, minute, second, 330))
             .succeeds(time =>
                 assert_that(time.add_seconds(seconds_to_add))
-                    .is_equal_to(_time_test_value(expected_hour, expected_minute, expected_second, some_offset(330)))))).as_list()
+                    .is_equal_to(time_test_value(expected_hour, expected_minute, expected_second, some_offset(330)))))).as_list()
 
-fun _test_add_minutes(): List[TestCase] =
+private fun test_add_minutes(): List[TestCase] =
     ([
         (23, 59, 59, 1, 0, 0, 59),
         (23, 59, 59, 60, 0, 59, 59),
@@ -197,55 +197,55 @@ fun _test_add_minutes(): List[TestCase] =
         (0, 0, 0, -61, 22, 59, 0),
     ] | (hour, minute, second, minutes_to_add, expected_hour, expected_minute, expected_second) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.add_minutes({minutes_to_add}) should return expected time",
-        () => assert_that(_offset_time(hour, minute, second, -300))
+        () => assert_that(offset_time(hour, minute, second, -300))
             .succeeds(time =>
                 assert_that(time.add_minutes(minutes_to_add))
-                    .is_equal_to(_time_test_value(expected_hour, expected_minute, expected_second, some_offset(-300)))))).as_list()
+                    .is_equal_to(time_test_value(expected_hour, expected_minute, expected_second, some_offset(-300)))))).as_list()
 
-fun _test_add_hours(): List[TestCase] =
+private fun test_add_hours(): List[TestCase] =
     ([
         (23, 59, 59, 1, 0, 59, 59),
         (23, 59, 59, -1, 22, 59, 59),
         (0, 0, 0, -1, 23, 0, 0),
     ] | (hour, minute, second, hours_to_add, expected_hour, expected_minute, expected_second) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.add_hours({hours_to_add}) should return expected time",
-        () => assert_that(_offset_time(hour, minute, second, 0))
+        () => assert_that(offset_time(hour, minute, second, 0))
             .succeeds(time =>
                 assert_that(time.add_hours(hours_to_add))
-                    .is_equal_to(_time_test_value(expected_hour, expected_minute, expected_second, some_offset(0)))))).as_list()
+                    .is_equal_to(time_test_value(expected_hour, expected_minute, expected_second, some_offset(0)))))).as_list()
 
-fun _time_test_to_iso_8601(): List[TestCase] =
+private fun time_test_to_iso_8601(): List[TestCase] =
     ([
-        (_time_test_value(13, 47, 30, None {}), "13:47:30"),
-        (_time_test_value(13, 47, 30, some_offset(0)), "13:47:30Z"),
-        (_time_test_value(13, 47, 30, some_offset(90)), "13:47:30+01:30"),
-        (_time_test_value(13, 47, 30, some_offset(-300)), "13:47:30-05:00"),
+        (time_test_value(13, 47, 30, None {}), "13:47:30"),
+        (time_test_value(13, 47, 30, some_offset(0)), "13:47:30Z"),
+        (time_test_value(13, 47, 30, some_offset(90)), "13:47:30+01:30"),
+        (time_test_value(13, 47, 30, some_offset(-300)), "13:47:30-05:00"),
     ] | (time, expected) => test(
         "Time.to_iso_8601() should format {expected}",
         () => assert_that(time.to_iso_8601()).is_equal_to(expected))).as_list()
 
-fun _time_test_from_iso_8601_success(): List[TestCase] =
+private fun time_test_from_iso_8601_success(): List[TestCase] =
     ([
-        ("13:47:30", _time_test_value(13, 47, 30, None {})),
-        ("134730", _time_test_value(13, 47, 30, None {})),
-        ("T13:47:30", _time_test_value(13, 47, 30, None {})),
-        ("T134730", _time_test_value(13, 47, 30, None {})),
-        ("13:47:30Z", _time_test_value(13, 47, 30, some_offset(0))),
-        ("134730Z", _time_test_value(13, 47, 30, some_offset(0))),
-        ("13:47:30+00:00", _time_test_value(13, 47, 30, some_offset(0))),
-        ("134730+0000", _time_test_value(13, 47, 30, some_offset(0))),
-        ("13:47:30+00", _time_test_value(13, 47, 30, some_offset(0))),
-        ("13:47:30+01:30", _time_test_value(13, 47, 30, some_offset(90))),
-        ("134730+0130", _time_test_value(13, 47, 30, some_offset(90))),
-        ("13:47:30+14:00", _time_test_value(13, 47, 30, some_offset(840))),
-        ("13:47:30-05", _time_test_value(13, 47, 30, some_offset(-300))),
-        ("134730-1130", _time_test_value(13, 47, 30, some_offset(-690))),
-        ("T134730+02", _time_test_value(13, 47, 30, some_offset(120))),
+        ("13:47:30", time_test_value(13, 47, 30, None {})),
+        ("134730", time_test_value(13, 47, 30, None {})),
+        ("T13:47:30", time_test_value(13, 47, 30, None {})),
+        ("T134730", time_test_value(13, 47, 30, None {})),
+        ("13:47:30Z", time_test_value(13, 47, 30, some_offset(0))),
+        ("134730Z", time_test_value(13, 47, 30, some_offset(0))),
+        ("13:47:30+00:00", time_test_value(13, 47, 30, some_offset(0))),
+        ("134730+0000", time_test_value(13, 47, 30, some_offset(0))),
+        ("13:47:30+00", time_test_value(13, 47, 30, some_offset(0))),
+        ("13:47:30+01:30", time_test_value(13, 47, 30, some_offset(90))),
+        ("134730+0130", time_test_value(13, 47, 30, some_offset(90))),
+        ("13:47:30+14:00", time_test_value(13, 47, 30, some_offset(840))),
+        ("13:47:30-05", time_test_value(13, 47, 30, some_offset(-300))),
+        ("134730-1130", time_test_value(13, 47, 30, some_offset(-690))),
+        ("T134730+02", time_test_value(13, 47, 30, some_offset(120))),
     ] | (iso, expected) => test(
         "Time.from_iso_8601 should parse {iso}",
         () => assert_that(/capy/date_time/Time.from_iso_8601(iso)).succeeds(expected))).as_list()
 
-fun _time_test_from_iso_8601_failure(): List[TestCase] =
+private fun time_test_from_iso_8601_failure(): List[TestCase] =
     ([
         "24:00:00",
         "13:47",
@@ -263,7 +263,7 @@ fun _time_test_from_iso_8601_failure(): List[TestCase] =
         "Time.from_iso_8601 should fail for {iso}",
         () => assert_that(/capy/date_time/Time.from_iso_8601(iso)).fails())).as_list()
 
-fun _time_test_value(hour: int, minute: int, second: int, offset_minutes: Option[offset_minutes]): Time =
+private fun time_test_value(hour: int, minute: int, second: int, offset_minutes: Option[offset_minutes]): Time =
     match time_from_parts(hour, minute, second, offset_minutes) with
     case Success { value } -> value
     case Error -> MIDNIGHT

--- a/lib/capybara-lib/src/test/capybara/capy/lang/EffectTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/EffectTest.cfun
@@ -20,9 +20,9 @@ fun should_flat_map_value(): Assert =
     assert_that(pure(2).flat_map(x => pure(x + 4)).unsafe_run()).is_equal_to(6)
 
 fun should_bind_effects(): Assert =
-    assert_that(_bind_sum().unsafe_run()).is_equal_to(7)
+    assert_that(bind_sum().unsafe_run()).is_equal_to(7)
 
-fun _bind_sum(): Effect[int] =
+private fun bind_sum(): Effect[int] =
     let a <- pure(3)
     let b <- delay(() => 4)
     a + b

--- a/lib/capybara-lib/src/test/capybara/capy/lang/EitherTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/EitherTest.cfun
@@ -15,78 +15,78 @@ fun tests(): Effect[TestFile] =
         test("should convert to result", () => should_convert_to_result()),
     ])
 
-fun _left(message: String): Either[String, int] = Left { message }
+private fun make_left(message: String): Either[String, int] = Left { message }
 
-fun _right(value: int): Either[String, int] = Right { value }
+private fun make_right(value: int): Either[String, int] = Right { value }
 
-fun _plus_5(value: int): int = value + 5
+private fun plus_5(value: int): int = value + 5
 
 fun should_map_right(): Assert =
-    let either = _right(10)
-    assert_that(either.map_right(:_plus_5)).is_equal_to(Right { 15 })
+    let either = make_right(10)
+    assert_that(either.map_right(:plus_5)).is_equal_to(Right { 15 })
 
 fun should_keep_left_when_mapping_right(): Assert =
-    let either = _left("missing")
-    assert_that(either.map_right(:_plus_5)).is_equal_to(Left { "missing" })
+    let either = make_left("missing")
+    assert_that(either.map_right(:plus_5)).is_equal_to(Left { "missing" })
 
-fun _right_plus_5(value: int): Either[String, int] = Right { value + 5 }
+private fun right_plus_5(value: int): Either[String, int] = Right { value + 5 }
 
-fun _left_bad(value: int): Either[String, int] = Left { "bad " + value }
+private fun left_bad(value: int): Either[String, int] = Left { "bad " + value }
 
 fun should_flat_map_right(): Assert =
-    let either = _right(10)
-    let left = _left("missing")
+    let either = make_right(10)
+    let left = make_left("missing")
     assert_all([
-        assert_that(either.flat_map_right(:_right_plus_5)).is_equal_to(Right { 15 }),
-        assert_that(either.flat_map_right(:_left_bad)).is_equal_to(Left { "bad 10" }),
-        assert_that(left.flat_map_right(:_right_plus_5)).is_equal_to(Left { "missing" }),
+        assert_that(either.flat_map_right(:right_plus_5)).is_equal_to(Right { 15 }),
+        assert_that(either.flat_map_right(:left_bad)).is_equal_to(Left { "bad 10" }),
+        assert_that(left.flat_map_right(:right_plus_5)).is_equal_to(Left { "missing" }),
     ])
 
-fun _left_prefixed(message: String): Either[String, int] = Left { "handled " + message }
+private fun left_prefixed(message: String): Either[String, int] = Left { "handled " + message }
 
-fun _left_recovered(message: String): Either[String, int] = Right { 99 }
+private fun left_recovered(message: String): Either[String, int] = Right { 99 }
 
 fun should_flat_map_left(): Assert =
-    let either = _left("missing")
-    let right = _right(10)
+    let either = make_left("missing")
+    let right = make_right(10)
     assert_all([
-        assert_that(either.flat_map_left(:_left_prefixed)).is_equal_to(Left { "handled missing" }),
-        assert_that(either.flat_map_left(:_left_recovered)).is_equal_to(Right { 99 }),
-        assert_that(right.flat_map_left(:_left_prefixed)).is_equal_to(Right { 10 }),
+        assert_that(either.flat_map_left(:left_prefixed)).is_equal_to(Left { "handled missing" }),
+        assert_that(either.flat_map_left(:left_recovered)).is_equal_to(Right { 99 }),
+        assert_that(right.flat_map_left(:left_prefixed)).is_equal_to(Right { 10 }),
     ])
 
-fun _prefix_error(message: String): String = "error: " + message
+private fun prefix_error(message: String): String = "error: " + message
 
 fun should_map_left(): Assert =
-    let either = _left("missing")
-    assert_that(either.map_left(:_prefix_error)).is_equal_to(Left { "error: missing" })
+    let either = make_left("missing")
+    assert_that(either.map_left(:prefix_error)).is_equal_to(Left { "error: missing" })
 
 fun should_swap_branches(): Assert =
-    let left = _left("missing")
-    let right = _right(42)
+    let left = make_left("missing")
+    let right = make_right(42)
     assert_all([
         assert_that(left.swap()).is_equal_to(Right { "missing" }),
         assert_that(right.swap()).is_equal_to(Left { 42 }),
     ])
 
-fun _left_text(message: String): String = "left:" + message
+private fun left_text(message: String): String = "left:" + message
 
-fun _right_text(value: int): String = "right:" + value
+private fun right_text(value: int): String = "right:" + value
 
 fun should_reduce_branches(): Assert =
-    let left = _left("missing")
-    let right = _right(42)
-    let left_reduced: String = left.reduce(:_left_text, :_right_text)
-    let right_reduced: String = right.`|>`(:_left_text, :_right_text)
+    let left = make_left("missing")
+    let right = make_right(42)
+    let left_reduced: String = left.reduce(:left_text, :right_text)
+    let right_reduced: String = right.`|>`(:left_text, :right_text)
     assert_all([
         assert_that(left_reduced).is_equal_to("left:missing"),
         assert_that(right_reduced).is_equal_to("right:42"),
     ])
 
 fun should_convert_to_result(): Assert =
-    let left = _left("missing")
-    let right = _right(42)
+    let left = make_left("missing")
+    let right = make_right(42)
     assert_all([
-        assert_that(left.to_result(:_left_text)).fails("left:missing"),
-        assert_that(right.to_result(:_left_text)).succeeds(42),
+        assert_that(left.to_result(:left_text)).fails("left:missing"),
+        assert_that(right.to_result(:left_text)).succeeds(42),
     ])

--- a/lib/capybara-lib/src/test/capybara/capy/lang/MathTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/MathTest.cfun
@@ -28,7 +28,7 @@ fun tests(): Effect[TestFile] =
         // min int value
         (-2147483648, 10),
     ] | (number, expected) =>
-        test("digits(" + number + ") should return " + expected, () => _test_digits(number, expected))).as_list()
+        test("digits(" + number + ") should return " + expected, () => test_digits(number, expected))).as_list()
 
     let floor_div_cases = ([
         (7, 3, 2),
@@ -41,7 +41,7 @@ fun tests(): Effect[TestFile] =
         (-1, -3, 0),
         (-7, -3, 2),
     ] | (a, b, expected) =>
-        test("floor_div(" + a + ", " + b + ") should return " + expected, () => _test_floor_div(a, b, expected))).as_list()
+        test("floor_div(" + a + ", " + b + ") should return " + expected, () => test_floor_div(a, b, expected))).as_list()
 
     let floor_mod_cases = ([
         (7, 3, 1),
@@ -54,7 +54,7 @@ fun tests(): Effect[TestFile] =
         (-1, -3, -1),
         (-7, -3, -1),
     ] | (a, b, expected) =>
-        test("floor_mod(" + a + ", " + b + ") should return " + expected, () => _test_floor_mod(a, b, expected))).as_list()
+        test("floor_mod(" + a + ", " + b + ") should return " + expected, () => test_floor_mod(a, b, expected))).as_list()
 
     let min_int_cases = ([
         (1, 2, 1),
@@ -62,7 +62,7 @@ fun tests(): Effect[TestFile] =
         (-5, 3, -5),
         (4, 4, 4),
     ] | (a, b, expected) =>
-        test("min(" + a + ", " + b + ") should return " + expected, () => _test_min_int(a, b, expected))).as_list()
+        test("min(" + a + ", " + b + ") should return " + expected, () => test_min_int(a, b, expected))).as_list()
 
     let max_int_cases = ([
         (1, 2, 2),
@@ -70,7 +70,7 @@ fun tests(): Effect[TestFile] =
         (-5, 3, 3),
         (4, 4, 4),
     ] | (a, b, expected) =>
-        test("max(" + a + ", " + b + ") should return " + expected, () => _test_max_int(a, b, expected))).as_list()
+        test("max(" + a + ", " + b + ") should return " + expected, () => test_max_int(a, b, expected))).as_list()
 
     let min_long_cases = ([
         (1L, 2L, 1L),
@@ -78,7 +78,7 @@ fun tests(): Effect[TestFile] =
         (-5L, 3L, -5L),
         (4L, 4L, 4L),
     ] | (a, b, expected) =>
-        test("min(" + a + "L, " + b + "L) should return " + expected + "L", () => _test_min_long(a, b, expected))).as_list()
+        test("min(" + a + "L, " + b + "L) should return " + expected + "L", () => test_min_long(a, b, expected))).as_list()
 
     let max_long_cases = ([
         (1L, 2L, 2L),
@@ -86,32 +86,32 @@ fun tests(): Effect[TestFile] =
         (-5L, 3L, 3L),
         (4L, 4L, 4L),
     ] | (a, b, expected) =>
-        test("max(" + a + "L, " + b + "L) should return " + expected + "L", () => _test_max_long(a, b, expected))).as_list()
+        test("max(" + a + "L, " + b + "L) should return " + expected + "L", () => test_max_long(a, b, expected))).as_list()
 
     let list_int_cases = [
-        test("min([3, 1, 2]) should return Some { 1 }", () => _test_min_values_int(1)),
-        test("min([-3, -1, -2]) should return Some { -3 }", () => _test_min_negative_values_int(-3)),
-        test("min([]) should return None", () => _test_empty_min_int()),
-        test("max([3, 1, 2]) should return Some { 3 }", () => _test_max_values_int(3)),
-        test("max([-3, -1, -2]) should return Some { -1 }", () => _test_max_negative_values_int(-1)),
-        test("max([]) should return None", () => _test_empty_max_int()),
+        test("min([3, 1, 2]) should return Some { 1 }", () => test_min_values_int(1)),
+        test("min([-3, -1, -2]) should return Some { -3 }", () => test_min_negative_values_int(-3)),
+        test("min([]) should return None", () => test_empty_min_int()),
+        test("max([3, 1, 2]) should return Some { 3 }", () => test_max_values_int(3)),
+        test("max([-3, -1, -2]) should return Some { -1 }", () => test_max_negative_values_int(-1)),
+        test("max([]) should return None", () => test_empty_max_int()),
     ]
 
     let list_long_cases = [
-        test("min([3L, 1L, 2L]) should return Some { 1L }", () => _test_min_values_long(1L)),
-        test("min([-3L, -1L, -2L]) should return Some { -3L }", () => _test_min_negative_values_long(-3L)),
-        test("min([]: List[long]) should return None", () => _test_empty_min_long()),
-        test("max([3L, 1L, 2L]) should return Some { 3L }", () => _test_max_values_long(3L)),
-        test("max([-3L, -1L, -2L]) should return Some { -1L }", () => _test_max_negative_values_long(-1L)),
-        test("max([]: List[long]) should return None", () => _test_empty_max_long()),
+        test("min([3L, 1L, 2L]) should return Some { 1L }", () => test_min_values_long(1L)),
+        test("min([-3L, -1L, -2L]) should return Some { -3L }", () => test_min_negative_values_long(-3L)),
+        test("min([]: List[long]) should return None", () => test_empty_min_long()),
+        test("max([3L, 1L, 2L]) should return Some { 3L }", () => test_max_values_long(3L)),
+        test("max([-3L, -1L, -2L]) should return Some { -1L }", () => test_max_negative_values_long(-1L)),
+        test("max([]: List[long]) should return None", () => test_empty_max_long()),
     ]
 
     let round_cases = [
-        test("round FLOOR should round toward negative infinity", () => _test_round_floor()),
-        test("round CEILING should round toward positive infinity", () => _test_round_ceiling()),
-        test("round HALF_UP should round ties away from zero", () => _test_round_half_up()),
-        test("round HALF_DOWN should round ties toward zero", () => _test_round_half_down()),
-        test("round HALF_EVEN should round ties to even neighbor", () => _test_round_half_even()),
+        test("round FLOOR should round toward negative infinity", () => test_round_floor()),
+        test("round CEILING should round toward positive infinity", () => test_round_ceiling()),
+        test("round HALF_UP should round ties away from zero", () => test_round_half_up()),
+        test("round HALF_DOWN should round ties toward zero", () => test_round_half_down()),
+        test("round HALF_EVEN should round ties to even neighbor", () => test_round_half_even()),
     ]
 
     let all_cases = digits_test_cases
@@ -127,143 +127,143 @@ fun tests(): Effect[TestFile] =
 
     test_file("/capy/lang/Math.cfun", all_cases)
 
-fun _test_digits(number: int, expected: int): Assert = assert_that(digits(number)).is_equal_to(expected)
+private fun test_digits(number: int, expected: int): Assert = assert_that(digits(number)).is_equal_to(expected)
 
-fun _test_floor_div(a: int, b: int, expected: int): Assert =
+private fun test_floor_div(a: int, b: int, expected: int): Assert =
     assert_that(floor_div(a, b)).is_equal_to(expected)
 
-fun _test_floor_mod(a: int, b: int, expected: int): Assert =
+private fun test_floor_mod(a: int, b: int, expected: int): Assert =
     assert_that(floor_mod(a, b)).is_equal_to(expected)
 
-fun _test_min_int(a: int, b: int, expected: int): Assert =
+private fun test_min_int(a: int, b: int, expected: int): Assert =
     assert_that(min(a, b)).is_equal_to(expected)
 
-fun _test_max_int(a: int, b: int, expected: int): Assert =
+private fun test_max_int(a: int, b: int, expected: int): Assert =
     assert_that(max(a, b)).is_equal_to(expected)
 
-fun _test_min_long(a: long, b: long, expected: long): Assert =
+private fun test_min_long(a: long, b: long, expected: long): Assert =
     assert_that(min(a, b)).is_equal_to(expected)
 
-fun _test_max_long(a: long, b: long, expected: long): Assert =
+private fun test_max_long(a: long, b: long, expected: long): Assert =
     assert_that(max(a, b)).is_equal_to(expected)
 
 
 
-fun _test_min_values_int(expected: int): Assert =
-    assert_that(_min_ints()).contains(expected)
+private fun test_min_values_int(expected: int): Assert =
+    assert_that(min_ints()).contains(expected)
 
-fun _test_empty_min_int(): Assert =
-    assert_that(_min_empty_ints()).is_equal_to(None {})
+private fun test_empty_min_int(): Assert =
+    assert_that(min_empty_ints()).is_equal_to(None {})
 
-fun _test_max_values_int(expected: int): Assert =
-    assert_that(_max_ints()).contains(expected)
+private fun test_max_values_int(expected: int): Assert =
+    assert_that(max_ints()).contains(expected)
 
-fun _test_empty_max_int(): Assert =
-    assert_that(_max_empty_ints()).is_equal_to(None {})
+private fun test_empty_max_int(): Assert =
+    assert_that(max_empty_ints()).is_equal_to(None {})
 
-fun _test_min_negative_values_int(expected: int): Assert =
-    assert_that(_min_negative_ints()).contains(expected)
+private fun test_min_negative_values_int(expected: int): Assert =
+    assert_that(min_negative_ints()).contains(expected)
 
-fun _test_max_negative_values_int(expected: int): Assert =
-    assert_that(_max_negative_ints()).contains(expected)
+private fun test_max_negative_values_int(expected: int): Assert =
+    assert_that(max_negative_ints()).contains(expected)
 
 
-fun _test_min_values_long(expected: long): Assert =
-    assert_that(_min_longs()).contains(expected)
+private fun test_min_values_long(expected: long): Assert =
+    assert_that(min_longs()).contains(expected)
 
-fun _test_empty_min_long(): Assert =
-    assert_that(_min_empty_longs()).is_equal_to(None {})
+private fun test_empty_min_long(): Assert =
+    assert_that(min_empty_longs()).is_equal_to(None {})
 
-fun _test_max_values_long(expected: long): Assert =
-    assert_that(_max_longs()).contains(expected)
+private fun test_max_values_long(expected: long): Assert =
+    assert_that(max_longs()).contains(expected)
 
-fun _test_empty_max_long(): Assert =
-    assert_that(_max_empty_longs()).is_equal_to(None {})
+private fun test_empty_max_long(): Assert =
+    assert_that(max_empty_longs()).is_equal_to(None {})
 
-fun _test_min_negative_values_long(expected: long): Assert =
-    assert_that(_min_negative_longs()).contains(expected)
+private fun test_min_negative_values_long(expected: long): Assert =
+    assert_that(min_negative_longs()).contains(expected)
 
-fun _test_max_negative_values_long(expected: long): Assert =
-    assert_that(_max_negative_longs()).contains(expected)
+private fun test_max_negative_values_long(expected: long): Assert =
+    assert_that(max_negative_longs()).contains(expected)
 
-fun _test_round_floor(): Assert =
+private fun test_round_floor(): Assert =
     assert_all([
-        _assert_round(1.9, FLOOR, 1L),
-        _assert_round(2.0, FLOOR, 2L),
-        _assert_round(-1.1, FLOOR, -2L),
+        assert_round(1.9, FLOOR, 1L),
+        assert_round(2.0, FLOOR, 2L),
+        assert_round(-1.1, FLOOR, -2L),
     ])
 
-fun _test_round_ceiling(): Assert =
+private fun test_round_ceiling(): Assert =
     assert_all([
-        _assert_round(1.1, CEILING, 2L),
-        _assert_round(-1.9, CEILING, -1L),
-        _assert_round(-2.0, CEILING, -2L),
+        assert_round(1.1, CEILING, 2L),
+        assert_round(-1.9, CEILING, -1L),
+        assert_round(-2.0, CEILING, -2L),
     ])
 
-fun _test_round_half_up(): Assert =
+private fun test_round_half_up(): Assert =
     assert_all([
-        _assert_round(1.4, HALF_UP, 1L),
-        _assert_round(1.5, HALF_UP, 2L),
-        _assert_round(-1.4, HALF_UP, -1L),
-        _assert_round(-1.5, HALF_UP, -2L),
+        assert_round(1.4, HALF_UP, 1L),
+        assert_round(1.5, HALF_UP, 2L),
+        assert_round(-1.4, HALF_UP, -1L),
+        assert_round(-1.5, HALF_UP, -2L),
     ])
 
-fun _test_round_half_down(): Assert =
+private fun test_round_half_down(): Assert =
     assert_all([
-        _assert_round(1.5, HALF_DOWN, 1L),
-        _assert_round(1.6, HALF_DOWN, 2L),
-        _assert_round(-1.5, HALF_DOWN, -1L),
-        _assert_round(-1.6, HALF_DOWN, -2L),
+        assert_round(1.5, HALF_DOWN, 1L),
+        assert_round(1.6, HALF_DOWN, 2L),
+        assert_round(-1.5, HALF_DOWN, -1L),
+        assert_round(-1.6, HALF_DOWN, -2L),
     ])
 
-fun _test_round_half_even(): Assert =
+private fun test_round_half_even(): Assert =
     assert_all([
-        _assert_round(1.5, HALF_EVEN, 2L),
-        _assert_round(2.5, HALF_EVEN, 2L),
-        _assert_round(-1.5, HALF_EVEN, -2L),
-        _assert_round(-2.5, HALF_EVEN, -2L),
-        _assert_round(1.4, HALF_EVEN, 1L),
-        _assert_round(1.6, HALF_EVEN, 2L),
+        assert_round(1.5, HALF_EVEN, 2L),
+        assert_round(2.5, HALF_EVEN, 2L),
+        assert_round(-1.5, HALF_EVEN, -2L),
+        assert_round(-2.5, HALF_EVEN, -2L),
+        assert_round(1.4, HALF_EVEN, 1L),
+        assert_round(1.6, HALF_EVEN, 2L),
     ])
 
-private fun _assert_round(value: double, mode: RoundMode, expected: long): Assert =
+private fun assert_round(value: double, mode: RoundMode, expected: long): Assert =
     assert_that(round(value, mode)).is_equal_to(expected)
 
 
-fun _min_ints(): Option[int] = min(_ints())
+private fun min_ints(): Option[int] = min(ints())
 
-fun _min_empty_ints(): Option[int] = min(_empty_ints())
+private fun min_empty_ints(): Option[int] = min(empty_ints())
 
-fun _max_ints(): Option[int] = max(_ints())
+private fun max_ints(): Option[int] = max(ints())
 
-fun _max_empty_ints(): Option[int] = max(_empty_ints())
+private fun max_empty_ints(): Option[int] = max(empty_ints())
 
-fun _min_negative_ints(): Option[int] = min(_negative_ints())
+private fun min_negative_ints(): Option[int] = min(negative_ints())
 
-fun _max_negative_ints(): Option[int] = max(_negative_ints())
-
-
-fun _min_longs(): Option[long] = min(_longs())
-
-fun _min_empty_longs(): Option[long] = min(_empty_longs())
-
-fun _max_longs(): Option[long] = max(_longs())
-
-fun _max_empty_longs(): Option[long] = max(_empty_longs())
-
-fun _min_negative_longs(): Option[long] = min(_negative_longs())
-
-fun _max_negative_longs(): Option[long] = max(_negative_longs())
+private fun max_negative_ints(): Option[int] = max(negative_ints())
 
 
-fun _ints(): List[int] = [3, 1, 2]
+private fun min_longs(): Option[long] = min(longs())
 
-fun _longs(): List[long] = [3L, 1L, 2L]
+private fun min_empty_longs(): Option[long] = min(empty_longs())
 
-fun _negative_ints(): List[int] = [-3, -1, -2]
+private fun max_longs(): Option[long] = max(longs())
 
-fun _negative_longs(): List[long] = [-3L, -1L, -2L]
+private fun max_empty_longs(): Option[long] = max(empty_longs())
 
-fun _empty_ints(): List[int] = []
+private fun min_negative_longs(): Option[long] = min(negative_longs())
 
-fun _empty_longs(): List[long] = []
+private fun max_negative_longs(): Option[long] = max(negative_longs())
+
+
+private fun ints(): List[int] = [3, 1, 2]
+
+private fun longs(): List[long] = [3L, 1L, 2L]
+
+private fun negative_ints(): List[int] = [-3, -1, -2]
+
+private fun negative_longs(): List[long] = [-3L, -1L, -2L]
+
+private fun empty_ints(): List[int] = []
+
+private fun empty_longs(): List[long] = []

--- a/lib/capybara-lib/src/test/capybara/capy/lang/PrimitivesTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/PrimitivesTest.cfun
@@ -24,31 +24,31 @@ fun tests(): Effect[TestFile] =
         test("to_bool(\"true\") should succeed with true", () => assert_that(to_bool("true")).succeeds(true)),
         test("to_bool(\"false\") should succeed with false", () => assert_that(to_bool("false")).succeeds(false)),
         test("to_bool(\"abc\") should fail", () => assert_that(to_bool("abc")).fails("Cannot parse string to bool: abc")),
-        test("clamp_long_to_int(0L) should return 0", () => _should_clamp(0L, 0)),
-        test("clamp_long_to_int(1L) should return 1", () => _should_clamp(1L, 1)),
-        test("clamp_long_to_int(-1L) should return -1", () => _should_clamp(-1L, -1)),
-        test("clamp_long_to_int(MAX_INT_VALUE) should return MAX_INT_VALUE", () => _should_clamp(MAX_INT_VALUE, MAX_INT_VALUE)),
-        test("clamp_long_to_int(MIN_INT_VALUE) should return MIN_INT_VALUE", () => _should_clamp(MIN_INT_VALUE, MIN_INT_VALUE)),
-        test("clamp_long_to_int(2147483648L) should return MAX_INT_VALUE", () => _should_clamp(2147483648L, MAX_INT_VALUE)),
-        test("clamp_long_to_int(-2147483649L) should return MIN_INT_VALUE", () => _should_clamp(-2147483649L, MIN_INT_VALUE)),
-        test("clamp_long_to_int(MAX_LONG_VALUE) should return MAX_INT_VALUE", () => _should_clamp(MAX_LONG_VALUE, MAX_INT_VALUE)),
-        test("clamp_long_to_int(MIN_LONG_VALUE) should return MIN_INT_VALUE", () => _should_clamp(MIN_LONG_VALUE, MIN_INT_VALUE)),
-        test("safe_long_to_int(0L) should succeed with 0", () => _should_safely_convert(0L, 0)),
-        test("safe_long_to_int(1L) should succeed with 1", () => _should_safely_convert(1L, 1)),
-        test("safe_long_to_int(-1L) should succeed with -1", () => _should_safely_convert(-1L, -1)),
-        test("safe_long_to_int(MAX_INT_VALUE) should succeed with MAX_INT_VALUE", () => _should_safely_convert(MAX_INT_VALUE, MAX_INT_VALUE)),
-        test("safe_long_to_int(MIN_INT_VALUE) should succeed with MIN_INT_VALUE", () => _should_safely_convert(MIN_INT_VALUE, MIN_INT_VALUE)),
-        test("safe_long_to_int(2147483648L) should fail", () => _should_fail_safe_conversion(2147483648L, "long value `2147483648` is greater than max int value")),
-        test("safe_long_to_int(MAX_LONG_VALUE) should fail", () => _should_fail_safe_conversion(MAX_LONG_VALUE, "long value `9223372036854775807` is greater than max int value")),
-        test("safe_long_to_int(-2147483649L) should fail", () => _should_fail_safe_conversion(-2147483649L, "long value `-2147483649` is smaller than min int value")),
-        test("safe_long_to_int(MIN_LONG_VALUE) should fail", () => _should_fail_safe_conversion(MIN_LONG_VALUE, "long value `-9223372036854775808` is smaller than min int value")),
+        test("clamp_long_to_int(0L) should return 0", () => should_clamp(0L, 0)),
+        test("clamp_long_to_int(1L) should return 1", () => should_clamp(1L, 1)),
+        test("clamp_long_to_int(-1L) should return -1", () => should_clamp(-1L, -1)),
+        test("clamp_long_to_int(MAX_INT_VALUE) should return MAX_INT_VALUE", () => should_clamp(MAX_INT_VALUE, MAX_INT_VALUE)),
+        test("clamp_long_to_int(MIN_INT_VALUE) should return MIN_INT_VALUE", () => should_clamp(MIN_INT_VALUE, MIN_INT_VALUE)),
+        test("clamp_long_to_int(2147483648L) should return MAX_INT_VALUE", () => should_clamp(2147483648L, MAX_INT_VALUE)),
+        test("clamp_long_to_int(-2147483649L) should return MIN_INT_VALUE", () => should_clamp(-2147483649L, MIN_INT_VALUE)),
+        test("clamp_long_to_int(MAX_LONG_VALUE) should return MAX_INT_VALUE", () => should_clamp(MAX_LONG_VALUE, MAX_INT_VALUE)),
+        test("clamp_long_to_int(MIN_LONG_VALUE) should return MIN_INT_VALUE", () => should_clamp(MIN_LONG_VALUE, MIN_INT_VALUE)),
+        test("safe_long_to_int(0L) should succeed with 0", () => should_safely_convert(0L, 0)),
+        test("safe_long_to_int(1L) should succeed with 1", () => should_safely_convert(1L, 1)),
+        test("safe_long_to_int(-1L) should succeed with -1", () => should_safely_convert(-1L, -1)),
+        test("safe_long_to_int(MAX_INT_VALUE) should succeed with MAX_INT_VALUE", () => should_safely_convert(MAX_INT_VALUE, MAX_INT_VALUE)),
+        test("safe_long_to_int(MIN_INT_VALUE) should succeed with MIN_INT_VALUE", () => should_safely_convert(MIN_INT_VALUE, MIN_INT_VALUE)),
+        test("safe_long_to_int(2147483648L) should fail", () => should_fail_safe_conversion(2147483648L, "long value `2147483648` is greater than max int value")),
+        test("safe_long_to_int(MAX_LONG_VALUE) should fail", () => should_fail_safe_conversion(MAX_LONG_VALUE, "long value `9223372036854775807` is greater than max int value")),
+        test("safe_long_to_int(-2147483649L) should fail", () => should_fail_safe_conversion(-2147483649L, "long value `-2147483649` is smaller than min int value")),
+        test("safe_long_to_int(MIN_LONG_VALUE) should fail", () => should_fail_safe_conversion(MIN_LONG_VALUE, "long value `-9223372036854775808` is smaller than min int value")),
     ])
 
-fun _should_clamp(value: long, expected: int): Assert =
+private fun should_clamp(value: long, expected: int): Assert =
     assert_that(clamp_long_to_int(value)).is_equal_to(expected)
 
-fun _should_safely_convert(value: long, expected: int): Assert =
+private fun should_safely_convert(value: long, expected: int): Assert =
     assert_that(safe_long_to_int(value)).succeeds(expected)
 
-fun _should_fail_safe_conversion(value: long, expected_message: String): Assert =
+private fun should_fail_safe_conversion(value: long, expected_message: String): Assert =
     assert_that(safe_long_to_int(value)).fails(expected_message)

--- a/lib/capybara-lib/src/test/capybara/capy/lang/ResultTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/ResultTest.cfun
@@ -32,24 +32,24 @@ fun should_map_error(): Assert =
     let mapped = result | value => Success { "mapped_" + value }
     assert_that(mapped).fails("error message")
 
-fun _positive(x: int): Result[String] =
+private fun positive(x: int): Result[String] =
     if x > 0
     then Success { x + " is positive" }
     else Error { x + " is NOT positive" }
 
-fun _positive_not_zero(x: int): Result[Result[String]] =
+private fun positive_not_zero(x: int): Result[Result[String]] =
     if x != 0
-    then Success { _positive(x) }
+    then Success { positive(x) }
     else Error { "I don't like zero" }
 
 fun should_map_positive(): Assert =
     let result = Success { 420 }
-    let mapped = result | :_positive
+    let mapped = result | :positive
     assert_that(mapped).succeeds("420 is positive")
 
 fun should_map_negative(): Assert =
     let result = Success { -1337 }
-    let mapped = result | :_positive
+    let mapped = result | :positive
     assert_that(mapped).fails("-1337 is NOT positive")
 
 fun should_flatmap_success(): Assert =
@@ -64,17 +64,17 @@ fun should_flatmap_error(): Assert =
 
 fun should_flatmap_positive(): Assert =
     let result = Success { 420 }
-    let mapped = result |* :_positive_not_zero
+    let mapped = result |* :positive_not_zero
     assert_that(mapped).succeeds("420 is positive")
 
 fun should_flatmap_negative(): Assert =
     let result = Success { -1337 }
-    let mapped = result |* :_positive_not_zero
+    let mapped = result |* :positive_not_zero
     assert_that(mapped).fails("-1337 is NOT positive")
 
 fun should_flatmap_zero(): Assert =
     let result = Success { 0 }
-    let mapped = result |* :_positive_not_zero
+    let mapped = result |* :positive_not_zero
     assert_that(mapped).fails("I don't like zero")
 
 fun should_return_value_when_result_succeeded(): Assert =

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -120,7 +120,7 @@ fun should_convert_data_with_collection_fields_to_json_object(): Assert =
 
 fun should_convert_data_with_set_field_to_json_array(): Assert =
     assert_that(to_json(JsonSetSample { tags: {"red", "blue"} })).succeeds(obj =>
-        match _json_field(obj, "tags") with
+        match json_field(obj, "tags") with
         case Some { tags } -> {
             match tags with
             case JsonArray { values } ->
@@ -172,7 +172,7 @@ fun should_convert_enum_to_json_string(): Assert =
         status: PENDING,
         raw: JsonNull {}
     })).succeeds(obj =>
-        match _json_field(obj, "status") with
+        match json_field(obj, "status") with
         case Some { json } -> {
             match json with
             case JsonString { value } -> assert_that(value).is_equal_to("PENDING")
@@ -232,7 +232,7 @@ fun should_derive_jsonable_to_json_for_nested_and_collection_fields(): Assert =
         }
     })
 
-fun _json_field(json: JsonObject, name: String): Option[Json] =
+private fun json_field(json: JsonObject, name: String): Option[Json] =
     let initial: Option[Json] = None {}
     json.value |> initial, (acc, key, value) =>
         if key == name then Some { value } else acc


### PR DESCRIPTION
## What changed
- Removed legacy `_` / `__` prefixes from Capybara `.cfun` identifiers and kept declarations private by using the `private` keyword where needed.
- Relaxed parser handling for local type/data/const names so new plain local names compile while preserving generated internal names.
- Updated compiler, integration, and generated-library tests for the new names and duplicate-name diagnostics.

## Impacted modules
- `compiler`
- `capy`
- `lib/capybara-lib`

## Sample
```cfun
private fun escape_string(value: String): String = ...
private data Parse[T] { value: T, parsing_string: String }

fun parse(value: String): Result[Json] = ...
```

## Commands run
- `./gradlew :lib:capybara-lib:compileCapybara :lib:capybara-lib:testCapybara :capy:e2e-cfun`
- `./gradlew :compiler:test`
- `git diff --check`
- `/usr/bin/time -p ./gradlew clean check`

## Performance
- Baseline successful `clean check`: `real 380.51s` (`BUILD SUCCESSFUL in 6m 20s`).
- After changes: `real 305.60s` (`BUILD SUCCESSFUL in 5m 5s`).
- The final run was about `74.91s` faster in this environment, so no clean-check performance regression was observed.
