### PR TITLE
chore(#159): add release automation workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,31 @@ on:
   push:
     branches:
       - "**"
+    paths:
+      - ".github/workflows/**"
+      - "build-tool/**"
+      - "buildSrc/**"
+      - "capy/**"
+      - "compiler/**"
+      - "gradle/**"
+      - "lib/**"
+      - "settings.gradle"
+      - "gradle.properties"
+      - "gradlew"
+      - "gradlew.bat"
   pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "build-tool/**"
+      - "buildSrc/**"
+      - "capy/**"
+      - "compiler/**"
+      - "gradle/**"
+      - "lib/**"
+      - "settings.gradle"
+      - "gradle.properties"
+      - "gradlew"
+      - "gradlew.bat"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,16 +1,17 @@
-name: Test
+name: Build & Check
 
 on:
   push:
     branches:
       - "**"
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  build-check:
     runs-on: ubuntu-latest
 
     steps:
@@ -29,5 +30,5 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Run tests
+      - name: Run Gradle check
         run: ./gradlew clean check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,3 +34,14 @@ jobs:
 
       - name: Run Gradle check
         run: ./gradlew clean check --no-daemon
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-check-test-reports
+          path: |
+            **/build/reports/tests/**
+            **/build/test-results/**/*.xml
+          if-no-files-found: ignore
+          retention-days: 5

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,4 +31,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run Gradle check
-        run: ./gradlew clean check
+        run: ./gradlew clean check --no-daemon

--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -1,12 +1,20 @@
 name: Merge Back
 
 on:
-  push:
-    branches:
-      - "release/**"
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: Release branch to merge back, for example release/1.2.x.
+        required: true
+        type: string
 
 permissions:
+  actions: write
   contents: write
+
+concurrency:
+  group: merge-back-${{ github.event.repository.default_branch }}
+  cancel-in-progress: false
 
 jobs:
   merge-back:
@@ -17,19 +25,59 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Configure git user
         run: |
-          git config user.name "CapyAutomata"
-          git config user.email "CapyAutomata@capylang.dev"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Merge release branch into default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          RELEASE_BRANCH="${GITHUB_REF_NAME}"
+          RELEASE_BRANCH="${{ inputs.release_branch || github.ref_name }}"
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
-          git fetch origin "${RELEASE_BRANCH}" "${DEFAULT_BRANCH}"
-          git checkout "${DEFAULT_BRANCH}"
-          git merge --no-ff "origin/${RELEASE_BRANCH}" -m "merge: ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}"
-          git push origin "${DEFAULT_BRANCH}"
+          if [[ ! "${RELEASE_BRANCH}" =~ ^release/[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::Merge Back requires a release/{major}.{minor}.x branch, got '${RELEASE_BRANCH}'."
+            exit 1
+          fi
 
+          git fetch origin "${RELEASE_BRANCH}:${RELEASE_BRANCH}" "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
+          git checkout "${DEFAULT_BRANCH}"
+
+          set +e
+          git merge --no-ff --no-commit "${RELEASE_BRANCH}"
+          MERGE_STATUS=$?
+          set -e
+
+          if [[ "${MERGE_STATUS}" -ne 0 ]]; then
+            CONFLICTS="$(git diff --name-only --diff-filter=U)"
+            if [[ "${CONFLICTS}" == "gradle.properties" ]]; then
+              git checkout --ours gradle.properties
+              git add gradle.properties
+            else
+              echo "::error::Merge conflict outside gradle.properties. Conflicting files:"
+              printf '%s\n' "${CONFLICTS}"
+              exit 1
+            fi
+          fi
+
+          if [[ -z "$(git diff --name-only --diff-filter=U)" ]]; then
+            if git rev-parse -q --verify MERGE_HEAD >/dev/null; then
+              git commit -m "merge: ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}"
+              git push origin "HEAD:${DEFAULT_BRANCH}"
+              gh workflow run check.yml --ref "${DEFAULT_BRANCH}"
+            else
+              echo "Default branch already contains ${RELEASE_BRANCH}."
+            fi
+          fi

--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -33,11 +33,13 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Configure git user
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "CapyAutomata"
+          git config user.email "CapyAutomata@capylang.dev"
 
       - name: Merge release branch into default branch
         env:

--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -1,12 +1,11 @@
 name: Merge Back
 
 on:
-  workflow_dispatch:
-    inputs:
-      release_branch:
-        description: Release branch to merge back, for example release/1.2.x.
-        required: true
-        type: string
+  push:
+    branches:
+      - "release/*"
+    paths:
+      - "gradle.properties"
 
 permissions:
   actions: write
@@ -47,7 +46,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          RELEASE_BRANCH="${{ inputs.release_branch || github.ref_name }}"
+          RELEASE_BRANCH="${GITHUB_REF_NAME}"
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
           if [[ ! "${RELEASE_BRANCH}" =~ ^release/[0-9]+\.[0-9]+\.x$ ]]; then
             echo "::error::Merge Back requires a release/{major}.{minor}.x branch, got '${RELEASE_BRANCH}'."

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Validate default branch
         shell: bash
@@ -69,8 +71,8 @@ jobs:
 
       - name: Configure git user
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "CapyAutomata"
+          git config user.email "CapyAutomata@capylang.dev"
 
       - name: Create release branch
         shell: bash

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,116 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: prepare-release-${{ github.event.repository.default_branch }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Validate default branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          if [[ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" ]]; then
+            echo "::error::Prepare Release must be run from '${DEFAULT_BRANCH}', got '${GITHUB_REF_NAME}'."
+            exit 1
+          fi
+
+      - name: Prepare release branch metadata
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(awk -F= '/^version[[:space:]]*=/ { v=$2; gsub(/\r/, "", v); gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); print v }' gradle.properties)"
+          if [[ ! "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-SNAPSHOT$ ]]; then
+            echo "::error::Default branch version must be x.y.z-SNAPSHOT, got '${VERSION}'."
+            exit 1
+          fi
+
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          NEXT_MINOR_VERSION="${MAJOR}.$((MINOR + 1)).0-SNAPSHOT"
+          RELEASE_BRANCH="release/${MAJOR}.${MINOR}.x"
+
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Release branch '${RELEASE_BRANCH}' already exists."
+            exit 1
+          fi
+
+          {
+            echo "release_branch=${RELEASE_BRANCH}"
+            echo "next_minor_version=${NEXT_MINOR_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_BRANCH="${{ steps.version.outputs.release_branch }}"
+          git branch "${RELEASE_BRANCH}"
+          git push origin "${RELEASE_BRANCH}"
+
+      - name: Dispatch Build & Check for release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run check.yml --ref "${{ steps.version.outputs.release_branch }}"
+
+      - name: Dispatch Verify Version for release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run verify_version.yml --ref "${{ steps.version.outputs.release_branch }}"
+
+      - name: Bump minor on default branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          NEXT_MINOR_VERSION="${{ steps.version.outputs.next_minor_version }}"
+          sed -i "s/^version=.*/version=${NEXT_MINOR_VERSION}/" gradle.properties
+          git add gradle.properties
+          git commit -m "chore: bump version to ${NEXT_MINOR_VERSION}"
+          git push origin "HEAD:${DEFAULT_BRANCH}"
+
+      - name: Dispatch Build & Check for default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run check.yml --ref "${{ github.event.repository.default_branch }}"

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   prepare-release:
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -83,22 +83,6 @@ jobs:
           git branch "${RELEASE_BRANCH}"
           git push origin "${RELEASE_BRANCH}"
 
-      - name: Dispatch Build & Check for release branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          gh workflow run check.yml --ref "${{ steps.version.outputs.release_branch }}"
-
-      - name: Dispatch Verify Version for release branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          gh workflow run verify_version.yml --ref "${{ steps.version.outputs.release_branch }}"
-
       - name: Bump minor on default branch
         shell: bash
         run: |
@@ -109,11 +93,3 @@ jobs:
           git add gradle.properties
           git commit -m "chore: bump version to ${NEXT_MINOR_VERSION}"
           git push origin "HEAD:${DEFAULT_BRANCH}"
-
-      - name: Dispatch Build & Check for default branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          gh workflow run check.yml --ref "${{ github.event.repository.default_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,39 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - "release/*"
+    paths-ignore:
+      - "gradle.properties"
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   packages: write
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
-  prepare-release:
+  release-metadata:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.meta.outputs.version }}
-      tag: ${{ steps.meta.outputs.tag }}
-      release_branch: ${{ steps.meta.outputs.release_branch }}
+      release_version: ${{ steps.version.outputs.release_version }}
+      next_patch_version: ${{ steps.version.outputs.next_patch_version }}
+      tag: ${{ steps.version.outputs.tag }}
+      release_branch: ${{ steps.version.outputs.release_branch }}
+      default_branch: ${{ steps.version.outputs.default_branch }}
+      trigger_sha: ${{ steps.version.outputs.trigger_sha }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Validate branch trigger
-        run: |
-          if [[ "${GITHUB_REF}" != "refs/heads/master" ]]; then
-            echo "Release workflow must be run from master."
-            exit 1
-          fi
-
       - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
@@ -36,102 +43,111 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Make Gradle wrapper executable
-        run: chmod +x gradlew
-
-      - name: Run full verification
-        run: ./gradlew clean test check --no-daemon
-
-      - name: Prepare release metadata
-        id: meta
+      - name: Validate release branch
         shell: bash
         run: |
           set -euo pipefail
-          CURRENT_VERSION="$(grep '^version=' gradle.properties | cut -d= -f2)"
-          RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
-          if [[ "$RELEASE_VERSION" == "$CURRENT_VERSION" ]]; then
-            echo "Version is not a -SNAPSHOT version: $CURRENT_VERSION"
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^release/[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::Release workflow must be run from a release/{major}.{minor}.x branch."
             exit 1
           fi
 
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_VERSION"
-          NEXT_PATCH=$((PATCH + 1))
-          NEXT_PATCH_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
-          NEXT_MINOR=$((MINOR + 1))
-          NEXT_MINOR_VERSION="${MAJOR}.${NEXT_MINOR}.0-SNAPSHOT"
-
-          RELEASE_BRANCH="release/${RELEASE_VERSION}"
-          TAG="v${RELEASE_VERSION}"
-
-          echo "version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "release_branch=${RELEASE_BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "next_patch_version=${NEXT_PATCH_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "next_minor_version=${NEXT_MINOR_VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Configure git user
-        run: |
-          git config user.name "CapyAutomata"
-          git config user.email "CapyAutomata@capylang.dev"
-
-      - name: Commit release version
+      - name: Read release metadata
+        id: version
         shell: bash
         run: |
           set -euo pipefail
-          RELEASE_VERSION="${{ steps.meta.outputs.version }}"
-          sed -i "s/^version=.*/version=${RELEASE_VERSION}/" gradle.properties
-          git add gradle.properties
-          git commit -m "release: ${RELEASE_VERSION}"
+          VERSION="$(awk -F= '/^version[[:space:]]*=/ { v=$2; gsub(/\r/, "", v); gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); print v }' gradle.properties)"
+          if [[ ! "${VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-SNAPSHOT$ ]]; then
+            echo "::error::Release branch version must be x.y.z-SNAPSHOT, got '${VERSION}'."
+            exit 1
+          fi
 
-      - name: Create release branch and tag
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+          EXPECTED_BRANCH="release/${MAJOR}.${MINOR}.x"
+          if [[ "${GITHUB_REF_NAME}" != "${EXPECTED_BRANCH}" ]]; then
+            echo "::error::Branch '${GITHUB_REF_NAME}' does not match version '${VERSION}'. Expected '${EXPECTED_BRANCH}'."
+            exit 1
+          fi
+
+          RELEASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          NEXT_PATCH_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
+          TAG="release/${RELEASE_VERSION}"
+
+          {
+            echo "release_version=${RELEASE_VERSION}"
+            echo "next_patch_version=${NEXT_PATCH_VERSION}"
+            echo "tag=${TAG}"
+            echo "release_branch=${GITHUB_REF_NAME}"
+            echo "default_branch=${{ github.event.repository.default_branch }}"
+            echo "trigger_sha=${GITHUB_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x gradlew
+
+      - name: Ensure Build & Check succeeded
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          RELEASE_BRANCH="${{ steps.meta.outputs.release_branch }}"
-          TAG="${{ steps.meta.outputs.tag }}"
-          git branch "${RELEASE_BRANCH}"
-          git tag "${TAG}"
-          git push origin "${RELEASE_BRANCH}"
-          git push origin "${TAG}"
+          BRANCH="${GITHUB_REF_NAME}"
+          SHA="${GITHUB_SHA}"
+          WORKFLOW="check.yml"
 
-      - name: Bump patch on release branch
-        shell: bash
-        run: |
-          set -euo pipefail
-          RELEASE_BRANCH="${{ steps.meta.outputs.release_branch }}"
-          NEXT_PATCH_VERSION="${{ steps.meta.outputs.next_patch_version }}"
-          git checkout "${RELEASE_BRANCH}"
-          sed -i "s/^version=.*/version=${NEXT_PATCH_VERSION}/" gradle.properties
-          git add gradle.properties
-          git commit -m "chore: bump version to ${NEXT_PATCH_VERSION}"
-          git push origin "${RELEASE_BRANCH}"
+          find_run() {
+            gh run list \
+              --workflow "${WORKFLOW}" \
+              --branch "${BRANCH}" \
+              --commit "${SHA}" \
+              --json databaseId,status,conclusion,url \
+              --limit 10 \
+              --jq '.[0] // empty'
+          }
 
-      - name: Bump minor on master branch
-        shell: bash
-        run: |
-          set -euo pipefail
-          NEXT_MINOR_VERSION="${{ steps.meta.outputs.next_minor_version }}"
-          git checkout master
-          sed -i "s/^version=.*/version=${NEXT_MINOR_VERSION}/" gradle.properties
-          git add gradle.properties
-          git commit -m "chore: bump version to ${NEXT_MINOR_VERSION}"
-          git push origin master
+          RUN="$(find_run)"
+          RUN_ID="$(jq -r '.databaseId // empty' <<< "${RUN}")"
+          if [[ -z "${RUN_ID}" ]]; then
+            for _ in {1..30}; do
+              sleep 10
+              RUN="$(find_run)"
+              RUN_ID="$(jq -r '.databaseId // empty' <<< "${RUN}")"
+              if [[ -n "${RUN_ID}" ]]; then
+                break
+              fi
+            done
+          fi
+
+          if [[ -z "${RUN_ID}" ]]; then
+            echo "::error::No Build & Check run found for ${BRANCH} at ${SHA}."
+            exit 1
+          fi
+
+          RUN_URL="$(jq -r '.url' <<< "${RUN}")"
+          echo "Watching Build & Check run ${RUN_ID}: ${RUN_URL}"
+          gh run watch "${RUN_ID}" --exit-status
 
   build-linux:
     runs-on: ubuntu-latest
-    needs: prepare-release
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: refs/tags/${{ needs.prepare-release.outputs.tag }}
+    needs: release-metadata
 
-      - name: Set up GraalVM (Java 21 + Native Image)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set release version
+        shell: bash
+        run: sed -i "s/^version=.*/version=${{ needs.release-metadata.outputs.release_version }}/" gradle.properties
+
+      - name: Set up GraalVM 21
         uses: graalvm/setup-graalvm@v1
         with:
           distribution: graalvm-community
           java-version: "21"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           native-image-job-reports: "false"
 
       - name: Set up Gradle
@@ -140,80 +156,85 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Build Linux native binary
+      - name: Build project without tests
+        run: ./gradlew clean assemble --no-daemon
+
+      - name: Build Linux native CLI
         run: ./gradlew :capy:nativeCompile --no-daemon
 
-      - name: Build CLI jar
-        run: ./gradlew :capy:jar --no-daemon
-
-      - name: Collect artifacts
+      - name: Collect Linux artifacts
         shell: bash
         run: |
           set -euo pipefail
-          VERSION="${{ needs.prepare-release.outputs.version }}"
+          VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
+          find capy compiler lib build-tool -path '*/build/libs/*.jar' -type f -exec cp {} dist/ \;
+          find capy -path '*/build/distributions/*' -type f -exec cp {} dist/ \;
           cp "capy/build/native/nativeCompile/capyc-${VERSION}" "dist/capyc-${VERSION}-linux-x64"
-          cp "capy/build/libs/capy-${VERSION}.jar" "dist/capyc-${VERSION}.jar"
+          tar -czf "dist/capyc-${VERSION}-linux-x64.tar.gz" -C "capy/build/native/nativeCompile" "capyc-${VERSION}"
 
-      - name: Upload Linux native artifact
+      - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: capyc-linux
-          path: dist/capyc-*-linux-x64
-          if-no-files-found: error
-
-      - name: Upload CLI jar artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: capyc-jar
-          path: dist/capyc-*.jar
+          name: release-linux
+          path: dist/*
           if-no-files-found: error
 
   build-windows:
     runs-on: windows-latest
-    needs: prepare-release
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: refs/tags/${{ needs.prepare-release.outputs.tag }}
+    needs: release-metadata
 
-      - name: Set up GraalVM (Java 21 + Native Image)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set release version
+        shell: pwsh
+        run: |
+          $version = "${{ needs.release-metadata.outputs.release_version }}"
+          (Get-Content gradle.properties) -replace '^version=.*', "version=$version" | Set-Content gradle.properties
+
+      - name: Set up GraalVM 21
         uses: graalvm/setup-graalvm@v1
         with:
           distribution: graalvm-community
           java-version: "21"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           native-image-job-reports: "false"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build Windows native binary
+      - name: Build Windows native CLI
         run: .\gradlew.bat :capy:nativeCompile --no-daemon
 
-      - name: Collect artifact
+      - name: Collect Windows artifacts
         shell: pwsh
         run: |
-          $version = "${{ needs.prepare-release.outputs.version }}"
+          $version = "${{ needs.release-metadata.outputs.release_version }}"
           New-Item -ItemType Directory -Path dist -Force | Out-Null
           Copy-Item "capy/build/native/nativeCompile/capyc-$version.exe" "dist/capyc-$version-windows-x64.exe"
 
-      - name: Upload Windows native artifact
+      - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: capyc-windows
-          path: dist/capyc-*-windows-x64.exe
+          name: release-windows
+          path: dist/*
           if-no-files-found: error
 
-  publish-gradle-plugin:
+  publish-release:
     runs-on: ubuntu-latest
-    needs: prepare-release
+    needs:
+      - release-metadata
+      - build-linux
+      - build-windows
+
     steps:
-      - name: Checkout release tag
+      - name: Checkout release branch
         uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ needs.prepare-release.outputs.tag }}
+          fetch-depth: 0
+          ref: ${{ needs.release-metadata.outputs.trigger_sha }}
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -227,33 +248,110 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Publish Gradle plugin to GitHub Packages
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure release branch has not moved
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="${{ needs.release-metadata.outputs.release_branch }}"
+          EXPECTED_SHA="${{ needs.release-metadata.outputs.trigger_sha }}"
+          REMOTE_SHA="$(git ls-remote --heads origin "${BRANCH}" | awk '{ print $1 }')"
+          if [[ "${REMOTE_SHA}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::Release branch ${BRANCH} moved from ${EXPECTED_SHA} to ${REMOTE_SHA}. Re-run Release from the current branch head."
+            exit 1
+          fi
+
+      - name: Commit release version and tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${{ needs.release-metadata.outputs.release_version }}"
+          TAG="${{ needs.release-metadata.outputs.tag }}"
+          sed -i "s/^version=.*/version=${RELEASE_VERSION}/" gradle.properties
+          git add gradle.properties
+          if ! git diff --cached --quiet; then
+            git commit -m "release: ${RELEASE_VERSION}"
+          else
+            echo "Release version commit already exists."
+          fi
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists locally."
+          else
+            git tag "${TAG}"
+          fi
+
+      - name: Publish Java artifacts to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew :build-tool:gradle:publish --no-daemon
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository --no-daemon
 
-  publish-release:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare-release
-      - build-linux
-      - build-windows
-      - publish-gradle-plugin
-    steps:
-      - name: Download artifacts
+      - name: Bump patch version
+        shell: bash
+        run: |
+          set -euo pipefail
+          NEXT_PATCH_VERSION="${{ needs.release-metadata.outputs.next_patch_version }}"
+          sed -i "s/^version=.*/version=${NEXT_PATCH_VERSION}/" gradle.properties
+          git add gradle.properties
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: bump version to ${NEXT_PATCH_VERSION}"
+          else
+            echo "Patch version bump commit already exists."
+          fi
+
+      - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
 
-      - name: Create GitHub release and upload assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.prepare-release.outputs.tag }}
-          name: capyc ${{ needs.prepare-release.outputs.version }}
-          files: |
-            dist/capyc-*.jar
-            dist/capyc-*-windows-x64.exe
-            dist/capyc-*-linux-x64
+      - name: Push release commits and tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="${{ needs.release-metadata.outputs.release_branch }}"
+          TAG="${{ needs.release-metadata.outputs.tag }}"
+          git push origin "HEAD:${BRANCH}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} is already pushed."
+          else
+            git push origin "${TAG}"
+          fi
 
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          TAG="${{ needs.release-metadata.outputs.tag }}"
+          VERSION="${{ needs.release-metadata.outputs.release_version }}"
+          ASSETS=(dist/*)
+          if (( ${#ASSETS[@]} == 0 )); then
+            echo "::error::No release artifacts were downloaded."
+            exit 1
+          fi
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release upload "${TAG}" "${ASSETS[@]}" --clobber
+          else
+            gh release create "${TAG}" "${ASSETS[@]}" \
+              --verify-tag \
+              --title "Capybara ${VERSION}" \
+              --notes "Release ${VERSION}"
+          fi
+
+      - name: Dispatch merge back
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run merge_back.yml \
+            --ref "${{ needs.release-metadata.outputs.default_branch }}" \
+            -f release_branch="${{ needs.release-metadata.outputs.release_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -341,7 +341,22 @@ jobs:
             exit 1
           fi
           if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release upload "${TAG}" "${ASSETS[@]}" --clobber
+            mapfile -t EXISTING_ASSETS < <(gh release view "${TAG}" --json assets --jq '.assets[].name')
+            MISSING_ASSETS=()
+            for asset in "${ASSETS[@]}"; do
+              asset_name="$(basename "${asset}")"
+              if printf '%s\n' "${EXISTING_ASSETS[@]}" | grep -Fxq "${asset_name}"; then
+                echo "Release asset ${asset_name} already exists; skipping upload."
+              else
+                MISSING_ASSETS+=("${asset}")
+              fi
+            done
+
+            if (( ${#MISSING_ASSETS[@]} > 0 )); then
+              gh release upload "${TAG}" "${MISSING_ASSETS[@]}"
+            else
+              echo "All release assets already exist."
+            fi
           else
             gh release create "${TAG}" "${ASSETS[@]}" \
               --verify-tag \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Validate release branch
         shell: bash
@@ -152,6 +154,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
@@ -204,6 +208,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Build Windows native CLI
         run: .\gradlew.bat :capy:nativeCompile --no-daemon
@@ -244,14 +250,16 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
       - name: Configure git user
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "CapyAutomata"
+          git config user.email "CapyAutomata@capylang.dev"
 
       - name: Ensure release branch has not moved
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,13 +353,3 @@ jobs:
               --title "Capybara ${VERSION}" \
               --notes "Release ${VERSION}"
           fi
-
-      - name: Dispatch merge back
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          gh workflow run merge_back.yml \
-            --ref "${{ needs.release-metadata.outputs.default_branch }}" \
-            -f release_branch="${{ needs.release-metadata.outputs.release_branch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - "release/*"
-    paths-ignore:
-      - "gradle.properties"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/verify_version.yml
+++ b/.github/workflows/verify_version.yml
@@ -1,0 +1,48 @@
+name: Verify Version
+
+on:
+  push:
+    branches:
+      - "release/*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Verify release branch version
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="${GITHUB_REF_NAME}"
+          if [[ ! "${BRANCH}" =~ ^release/([0-9]+)\.([0-9]+)\.x$ ]]; then
+            echo "::error::Verify Version must run on a release/{major}.{minor}.x branch, got '${BRANCH}'."
+            exit 1
+          fi
+
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          VERSION="$(awk -F= '/^version[[:space:]]*=/ { v=$2; gsub(/\r/, "", v); gsub(/^[[:space:]]+|[[:space:]]+$/, "", v); print v }' gradle.properties)"
+
+          if [[ ! "${VERSION}" =~ ^${MAJOR}\.${MINOR}\.[0-9]+-SNAPSHOT$ ]]; then
+            echo "::error::Branch '${BRANCH}' requires version '${MAJOR}.${MINOR}.?-SNAPSHOT', got '${VERSION}'."
+            exit 1
+          fi
+
+          echo "Verified ${BRANCH} matches version ${VERSION}."

--- a/.github/workflows/verify_version.yml
+++ b/.github/workflows/verify_version.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: false
 
       - name: Verify release branch version
         shell: bash

--- a/build-tool/gradle/README.md
+++ b/build-tool/gradle/README.md
@@ -6,7 +6,7 @@ This module publishes the Gradle plugin `dev.capylang`.
 
 The plugin is published as Maven artifacts to GitHub Packages for this repository:
 
-- repository: `https://maven.pkg.github.com/grzeslowski/capybara`
+- repository: `https://maven.pkg.github.com/magx2/Capybara`
 - plugin id: `dev.capylang`
 
 Local publishing requires credentials with `write:packages`.
@@ -23,6 +23,7 @@ or in `~/.gradle/gradle.properties`:
 ```properties
 gpr.user=<github-user>
 gpr.key=<github-token>
+gpr.repository=magx2/Capybara
 ```
 
 Then publish with:
@@ -42,7 +43,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven {
-            url = uri("https://maven.pkg.github.com/grzeslowski/capybara")
+            url = uri("https://maven.pkg.github.com/magx2/Capybara")
             credentials {
                 username = providers.gradleProperty("gpr.user").get()
                 password = providers.gradleProperty("gpr.key").get()
@@ -71,4 +72,4 @@ gpr.key=<github-token>
 
 ## Release Workflow
 
-The GitHub release workflow publishes the plugin automatically for release tags.
+The GitHub release workflow publishes the plugin and Java libraries automatically from `release/*` branches.

--- a/build-tool/gradle/README.md
+++ b/build-tool/gradle/README.md
@@ -29,7 +29,7 @@ gpr.repository=magx2/Capybara
 Then publish with:
 
 ```powershell
-./gradlew.bat :build-tool:gradle:publish
+./gradlew.bat :build-tool:gradle:publish --no-daemon
 ```
 
 ## Use In Another Gradle Project

--- a/build-tool/gradle/build.gradle.kts
+++ b/build-tool/gradle/build.gradle.kts
@@ -10,6 +10,9 @@ val githubPackagesUser = providers.environmentVariable("GITHUB_ACTOR")
     .orElse(providers.gradleProperty("gpr.user"))
 val githubPackagesKey = providers.environmentVariable("GITHUB_TOKEN")
     .orElse(providers.gradleProperty("gpr.key"))
+val githubPackagesRepository = providers.environmentVariable("GITHUB_REPOSITORY")
+    .orElse(providers.gradleProperty("gpr.repository"))
+    .orElse("magx2/Capybara")
 
 repositories {
     mavenCentral()
@@ -42,7 +45,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/grzeslowski/capybara")
+            url = uri("https://maven.pkg.github.com/${githubPackagesRepository.get()}")
             credentials {
                 username = githubPackagesUser.orNull
                 password = githubPackagesKey.orNull

--- a/buildSrc/src/main/groovy/buildlogic.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/buildlogic.java-library-conventions.gradle
@@ -8,4 +8,34 @@ plugins {
 
     // Apply the java-library plugin for API and implementation separation.
     id 'java-library'
+
+    // Publish Java libraries to GitHub Packages during release automation.
+    id 'maven-publish'
+}
+
+def githubPackagesRepository = providers.environmentVariable('GITHUB_REPOSITORY')
+        .orElse(providers.gradleProperty('gpr.repository'))
+        .orElse('magx2/Capybara')
+def githubPackagesUser = providers.environmentVariable('GITHUB_ACTOR')
+        .orElse(providers.gradleProperty('gpr.user'))
+def githubPackagesKey = providers.environmentVariable('GITHUB_TOKEN')
+        .orElse(providers.gradleProperty('gpr.key'))
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'GitHubPackages'
+            url = uri("https://maven.pkg.github.com/${githubPackagesRepository.get()}")
+            credentials {
+                username = githubPackagesUser.orNull
+                password = githubPackagesKey.orNull
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #159

## Summary
- rename the check workflow to Build & Check and keep it running `./gradlew clean check`
- add Prepare Release, Release, Merge Back, and Verify Version workflows for the release branch lifecycle
- publish Java libraries and the Gradle plugin to GitHub Packages through Gradle-native publishing tasks
- add release safety checks for branch/version matching, Build & Check gating, pinned release commits, rerunnable tags/releases, and merge-back conflict handling

## Testing
- YAML parse for all `.github/workflows/*.yml`
- `git diff --check`
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew publishAllPublicationsToGitHubPackagesRepository --dry-run --no-daemon`
- `env GRADLE_USER_HOME=/tmp/gradle-home ./gradlew clean check --no-daemon`
- local shell smoke test for Verify Version branch/version matching
