### PR TITLE
feat(#167): allow docs on single declarations

### DIFF
--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -47,7 +47,7 @@ localTypeDeclaration: 'union' genericTypeDeclaration constructorClause? '=' gene
                     | 'union' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*;
 localDataDeclaration: 'data' genericTypeDeclaration '{' dataBody? '}' constructorClause?
                     | 'data' genericTypeDeclaration '=' '{' dataBody? '}' constructorClause?;
-localSingleDeclaration: 'single' TYPE;
+localSingleDeclaration: docComment* 'single' TYPE;
 localConstDeclaration: docComment* 'const' privateLocalConstName (':' type)? '=' expressionNoLet;
 privateLocalConstName: NAME | TYPE;
 functionNameDeclaration: identifier | methodOwnerDeclaration DOT declarationMethodIdentifier;
@@ -69,7 +69,7 @@ constructorClause: 'with' 'constructor' '{' expression '}';
 deriveClause: 'derive' TYPE (COMMA TYPE)* COMMA?;
 deriverDeclaration: docComment* VISIBILITY? 'deriver' TYPE '{' deriverMethodDeclaration+ '}';
 deriverMethodDeclaration: docComment* 'fun' identifier '(' parameters? ')' functionType '=' expression;
-singleDeclaration: 'single' TYPE;
+singleDeclaration: docComment* 'single' TYPE;
 constDeclaration: docComment* VISIBILITY? 'const' TYPE (':' type)? '=' expressionNoLet;
 fieldDeclarationList: fieldDeclaration (',' fieldDeclaration)* ','?;
 fieldDeclaration: identifier ':' type

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -6494,7 +6494,14 @@ public class CapybaraCompiler {
     }
 
     private Result<CompiledDataType> linkSingleDeclaration(SingleDeclaration singleDeclaration) {
-        return Result.success(new CompiledDataType(singleDeclaration.name(), List.of(), List.of(), List.of(), true));
+        return Result.success(new CompiledDataType(
+                singleDeclaration.name(),
+                List.of(),
+                List.of(),
+                List.of(),
+                singleDeclaration.comments(),
+                true
+        ));
     }
 
     private CompiledDataParentType linkEnumDeclaration(EnumDeclaration enumDeclaration) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -554,7 +554,13 @@ public class CapybaraParser {
     }
 
     private SingleDeclaration singleDeclaration(FunctionalParser.SingleDeclarationContext context) {
-        return new SingleDeclaration(context.TYPE().getText(), position(context));
+        return new SingleDeclaration(
+                context.TYPE().getText(),
+                context.docComment().stream()
+                        .map(comment -> stripDocComment(comment.getText()))
+                        .toList(),
+                position(context)
+        );
     }
 
     private Function constDeclaration(FunctionalParser.ConstDeclarationContext context) {
@@ -936,7 +942,13 @@ public class CapybaraParser {
         if (mappedSingleName == null) {
             throw new IllegalStateException("Unknown local single mapping for: " + localSingleName);
         }
-        return new SingleDeclaration(mappedSingleName, position(context));
+        return new SingleDeclaration(
+                mappedSingleName,
+                context.docComment().stream()
+                        .map(comment -> stripDocComment(comment.getText()))
+                        .toList(),
+                position(context)
+        );
     }
 
     private Expression rewriteLocalNames(

--- a/compiler/src/main/java/dev/capylang/compiler/parser/SingleDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/SingleDeclaration.java
@@ -1,6 +1,10 @@
 package dev.capylang.compiler.parser;
 
+import java.util.List;
 import java.util.Optional;
 
-public record SingleDeclaration(String name, Optional<SourcePosition> position) implements Definition {
+public record SingleDeclaration(String name, List<String> comments, Optional<SourcePosition> position) implements Definition {
+    public SingleDeclaration(String name, Optional<SourcePosition> position) {
+        this(name, List.of(), position);
+    }
 }

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -1637,7 +1637,7 @@ public class JavaAstBuilder {
         implementInterfaces.add(CAPYBARA_DATA_VALUE);
         return new JavaEnum(
                 buildClassName(type.name()),
-                List.of(),
+                type.comments(),
                 implementInterfaces,
                 List.of("INSTANCE"),
                 List.of(ReflectionValueInfoJava.dataValueInfo(type.name(), reflectionFallbackPackagePath, List.of()))

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -265,6 +265,9 @@ class JavaExpressionEvaluatorTest {
 
                 /// The result of comparing two values.
                 enum Ordering { LESS, EQUAL, GREATER }
+
+                /// Successful program completion
+                single Success
                 """);
 
         var generated = new JavaGenerator().generate(program).modules().stream()
@@ -279,6 +282,8 @@ class JavaExpressionEvaluatorTest {
         assertThat(generated).contains("/// Complete report");
         assertThat(generated).contains("/// Node type");
         assertThat(generated).contains("/// The result of comparing two values.");
+        assertThat(generated).contains("/// Successful program completion");
+        assertThat(generated).contains("public enum Success");
     }
 
     @Test

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -46,6 +46,7 @@ class CapybaraParserTest {
                     case EnumDeclaration enumDeclaration -> enumDeclaration.name().equals(name);
                     case PrimitiveBackedTypeDeclaration primitiveBackedTypeDeclaration ->
                             primitiveBackedTypeDeclaration.name().equals(name);
+                    case SingleDeclaration singleDeclaration -> singleDeclaration.name().equals(name);
                     default -> false;
                 })
                 .findAny()
@@ -709,6 +710,24 @@ class CapybaraParserTest {
         assertThat(data.comments()).containsExactly("See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml?tab=readme-ov-file#complete-junit-xml-example)");
         assertThat(type.comments()).containsExactly("Represents a single suite");
         assertThat(enumType.comments()).containsExactly("The result of comparing two values.");
+    }
+
+    @Test
+    @DisplayName("should parse line and doc comments for single declarations")
+    void parseSingleComments() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                union Program = Success | Failed
+
+                // Normal comments are skipped before singles.
+                /// Successful program completion
+                /// with exit code zero.
+                single Success
+
+                data Failed { exit_code: int }
+                """));
+
+        var single = findDefinition(SingleDeclaration.class, "Success", module.functional());
+        assertThat(single.comments()).containsExactly("Successful program completion", "with exit code zero.");
     }
 
     @Test

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Program.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Program.cfun
@@ -1,6 +1,7 @@
 /// Process result returned by an executable Capybara `main` function.
 union Program = Success | Failed
 
+/// Successful program completion with exit code `0`.
 single Success
 
 /// Failed program completion with a non-zero exit code.


### PR DESCRIPTION
## What changed
- Allow `docComment*` before top-level and local `single` declarations.
- Preserve single declaration docs through parsing/linking and emit them for generated Java singleton enums.
- Document `/capy/lang/Program.Success` in the standard library.

## Impacted modules
- compiler
- lib/capybara-lib

## Verification
- `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest --tests dev.capylang.generator.java.JavaExpressionEvaluatorTest`
- `./gradlew clean check`

Closes #167