### PR TITLE
feat(#166): add qualified import statement

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/A.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/A.cfun
@@ -1,0 +1,5 @@
+data Value { amount: int }
+
+fun foo(x: int): int = x + 1
+
+fun value(x: int): Value = Value { amount: x + 10 }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/B.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/B.cfun
@@ -1,0 +1,5 @@
+data Value { amount: int }
+
+fun foo(x: int): int = x - 1
+
+fun value(x: int): Value = Value { amount: x - 10 }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/Main.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/imports/Main.cfun
@@ -1,6 +1,8 @@
 from Pck1 import { * }
 from Pck2 import { * } except { add }
 from /dev/capylang/capybara/imports2/Pck5 import { lvl_multiplier }
+import /dev/capylang/test/imports/A
+import /dev/capylang/test/imports/B
 
 from Types1 import { * }
 from Types2 import { * } except { T1 }
@@ -34,3 +36,9 @@ fun type5(x: int, y: int): /dev/capylang/capybara/imports2/Types3.T5 =
     if x > 0
     then /dev/capylang/capybara/imports2/Types3.D5_1 { x: x }
     else /dev/capylang/capybara/imports2/Types3.D5_2 { y: y }
+
+fun qualified_import_result(x: int): int = A.foo(x) + B.foo(x)
+
+fun qualified_import_data(x: int): A.Value = A.Value { amount: x }
+
+fun qualified_import_function_data(x: int): int = A.value(x).amount + B.value(x).amount

--- a/capy/src/e2e-cfun/java/dev/capylang/test/ImportsTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/ImportsTest.java
@@ -46,4 +46,17 @@ class ImportsTest {
         assertThat(nonPositive).isInstanceOf(dev.capylang.test.imports2.Types3.D52.class);
         assertThat(((dev.capylang.test.imports2.Types3.D52) nonPositive).y()).isEqualTo(7);
     }
+
+    @Test
+    void supportsQualifiedOnlyImports() {
+        assertThat(dev.capylang.test.imports.Main.qualifiedImportResult(10))
+                .isEqualTo(20);
+
+        var value = dev.capylang.test.imports.Main.qualifiedImportData(7);
+        assertThat(value).isInstanceOf(dev.capylang.test.imports.A.Value.class);
+        assertThat(value.amount()).isEqualTo(7);
+
+        assertThat(dev.capylang.test.imports.Main.qualifiedImportFunctionData(10))
+                .isEqualTo(20);
+    }
 }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -739,6 +739,22 @@ public class CompilationErrorTest {
                 () -> assertThat(error.message()).isEqualTo(finalErrorMessage));
     }
 
+    @Test
+    void qualifiedImportReportsUnknownModule() {
+        var errors = compileProgram("""
+                import /foo/missing/Nope
+
+                fun value(): int = 1
+                """, "unknown_qualified_import");
+
+        assertThat(errors).hasSize(1);
+        var error = errors.first();
+        assertAll("Assertions on error",
+                () -> assertThat(error.file()).isEqualTo("/foo/boo/unknown_qualified_import.cfun"),
+                () -> assertThat(error.message())
+                        .contains("Module `unknown_qualified_import` imports unknown module `/foo/missing/Nope`"));
+    }
+
     @SuppressWarnings("unchecked")
     static Stream<Arguments> compilationError() {
         return concat(simpleCompilationError(), multilineCompilationError(), infixOperations(), bitwiseOperations(), matchCompilationErrors());
@@ -1911,6 +1927,9 @@ public class CompilationErrorTest {
         return normalized.substring(normalized.lastIndexOf('/') + 1, normalized.length() - ".cfun".length());
     }
     private static String toImportLine(ImportDeclaration importDeclaration) {
+        if (importDeclaration.qualifiedOnly()) {
+            return "import %s".formatted(importDeclaration.moduleName());
+        }
         var base = "from %s import { %s }".formatted(importDeclaration.moduleName(), String.join(", ", importDeclaration.symbols()));
         if (importDeclaration.excludedSymbols().isEmpty()) {
             return base;

--- a/capy/src/e2e-cfun/js/dev/capylang/test/Imports.test.js
+++ b/capy/src/e2e-cfun/js/dev/capylang/test/Imports.test.js
@@ -9,4 +9,7 @@ test('Imports', () => {
     assert.equal(importsMain.xyz(1, 2, 3).xyz, '123');
     assert.equal(importsMain.type5(5, 2).__capybaraType, 'D51');
     assert.equal(importsMain.type5(0, 7).__capybaraType, 'D52');
+    assert.equal(importsMain.qualifiedImportResult(10), 20);
+    assert.equal(importsMain.qualifiedImportData(7).amount, 7);
+    assert.equal(importsMain.qualifiedImportFunctionData(10), 20);
 });

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -354,6 +354,7 @@ public class CapybaraCompiler {
                     ((Result.Success<List<CapybaraExpressionCompiler.FunctionSignature>>) availableConstructorSignatures).value(),
                     signaturesByModule,
                     moduleClassNameByModuleName,
+                    qualifiedImportAliases(module, moduleLinkIndex),
                     getModuleEntry(visibleConstructorsByModule, moduleRef),
                     sourceFile,
                     compileCache
@@ -557,6 +558,21 @@ public class CapybaraCompiler {
         return qualified != null ? qualified : source.get(moduleRef.name());
     }
 
+    private Map<String, String> qualifiedImportAliases(Module module, ModuleLinkIndex moduleLinkIndex) {
+        var aliases = new LinkedHashMap<String, String>();
+        for (var importDeclaration : module.imports()) {
+            if (!importDeclaration.qualifiedOnly()) {
+                continue;
+            }
+            var importedModule = resolveImportedModule(importDeclaration.moduleName(), moduleLinkIndex);
+            if (importedModule == null) {
+                continue;
+            }
+            aliases.put(importedModule.name(), qualifiedModuleName(importedModule));
+        }
+        return Map.copyOf(aliases);
+    }
+
     private void addQualifiedConstructorAliases(
             Map<String, CapybaraExpressionCompiler.ProtectedConstructorRef> all,
             ModuleRef module,
@@ -644,7 +660,7 @@ public class CapybaraCompiler {
             return withFile(new Result.Error<>(error.errors()), moduleSourceFile);
         }
         var initialSignatures = ((Result.Success<List<CapybaraExpressionCompiler.FunctionSignature>>) availableSignatures).value();
-        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), dataTypes, localTypeNames, initialSignatures, signaturesByModule, moduleClassNameByModuleName, protectedConstructorsByType, moduleSourceFile, compileCache), moduleSourceFile);
+        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), dataTypes, localTypeNames, initialSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, moduleSourceFile, compileCache), moduleSourceFile);
     }
 
     private Result<CompiledModule> linkModule(
@@ -672,7 +688,7 @@ public class CapybaraCompiler {
             return withFile(new Result.Error<>(error.errors()), moduleSourceFile);
         }
         var initialSignatures = ((Result.Success<List<CapybaraExpressionCompiler.FunctionSignature>>) availableSignatures).value();
-        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), initialSignatures, signaturesByModule, moduleClassNameByModuleName, protectedConstructorsByType, moduleSourceFile, compileCache)
+        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), initialSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, moduleSourceFile, compileCache)
                 .flatMap(firstPassFunctions -> {
                     var moduleSignatures = getModuleEntry(signaturesByModule, moduleRef);
                     var refinedSignatures = mergeSignatures(
@@ -691,7 +707,7 @@ public class CapybaraCompiler {
                         ));
                     }
                     var refinedAvailableSignatures = mergeSignatures(initialSignatures, refinedSignatures);
-                    return linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), refinedAvailableSignatures, signaturesByModule, moduleClassNameByModuleName, protectedConstructorsByType, moduleSourceFile, compileCache)
+                    return linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), refinedAvailableSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, moduleSourceFile, compileCache)
                             .map(linkedFunctions -> new CompiledModule(
                                     module.name(),
                                     module.path(),
@@ -877,6 +893,20 @@ public class CapybaraCompiler {
                 knownModule,
                 visibleTypes(module.path(), knownModule, getModuleEntry(linkedTypesByModule, knownModule), compileCache)
         ));
+        for (var importDeclaration : module.imports()) {
+            if (!importDeclaration.qualifiedOnly()) {
+                continue;
+            }
+            var importedModule = resolveImportedModule(importDeclaration.moduleName(), moduleLinkIndex);
+            if (importedModule == null) {
+                continue;
+            }
+            addQualifiedTypeAliases(
+                    all,
+                    importedModule,
+                    visibleTypes(module.path(), importedModule, getModuleEntry(linkedTypesByModule, importedModule), compileCache)
+            );
+        }
         resolveQualifiedExternalFieldTypes(all);
         return Result.success(Map.copyOf(all));
     }
@@ -2497,6 +2527,21 @@ public class CapybaraCompiler {
             addQualifiedParentConstructorAliases(parentConstructors, knownModule, knownParentConstructors);
             addQualifiedDataOwnerAliases(dataOwners, knownModule, knownDataOwners);
         });
+        for (var importDeclaration : module.imports()) {
+            if (!importDeclaration.qualifiedOnly()) {
+                continue;
+            }
+            var importedModule = resolveImportedModule(importDeclaration.moduleName(), moduleLinkIndex);
+            if (importedModule == null) {
+                continue;
+            }
+            var importedConstructors = Optional.ofNullable(getModuleEntry(constructorCatalog.constructorsByModule(), importedModule)).orElse(Map.of());
+            var importedParentConstructors = Optional.ofNullable(getModuleEntry(constructorCatalog.parentConstructorsByModule(), importedModule)).orElse(Map.of());
+            var importedDataOwners = Optional.ofNullable(getModuleEntry(constructorCatalog.dataOwnersByModule(), importedModule)).orElse(Map.of());
+            addQualifiedConstructorAliases(constructors, importedModule, importedConstructors);
+            addQualifiedParentConstructorAliases(parentConstructors, importedModule, importedParentConstructors);
+            addQualifiedDataOwnerAliases(dataOwners, importedModule, importedDataOwners);
+        }
         return new CapybaraExpressionCompiler.ConstructorRegistry(Map.copyOf(constructors), Map.copyOf(parentConstructors), Map.copyOf(dataOwners));
     }
 
@@ -3012,6 +3057,7 @@ public class CapybaraCompiler {
             List<CapybaraExpressionCompiler.FunctionSignature> signatures,
             Map<String, List<CapybaraExpressionCompiler.FunctionSignature>> signaturesByModule,
             Map<String, String> moduleClassNameByModuleName,
+            Map<String, String> qualifiedModuleAliases,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
             String moduleSourceFile,
             CompileCache compileCache
@@ -3021,7 +3067,7 @@ public class CapybaraCompiler {
                 CapybaraExpressionCompiler.LinkCache::new
         );
         return functions.stream()
-                .map(f -> linkFunction(f, dataTypes, localTypeNames, signatures, signaturesByModule, moduleClassNameByModuleName, protectedConstructorsByType, moduleSourceFile, linkCache, compileCache))
+                .map(f -> linkFunction(f, dataTypes, localTypeNames, signatures, signaturesByModule, moduleClassNameByModuleName, qualifiedModuleAliases, protectedConstructorsByType, moduleSourceFile, linkCache, compileCache))
                 .collect(new ResultCollectionCollector<>());
     }
 
@@ -3032,6 +3078,7 @@ public class CapybaraCompiler {
             List<CapybaraExpressionCompiler.FunctionSignature> signatures,
             Map<String, List<CapybaraExpressionCompiler.FunctionSignature>> signaturesByModule,
             Map<String, String> moduleClassNameByModuleName,
+            Map<String, String> qualifiedModuleAliases,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
             String moduleSourceFile,
             CapybaraExpressionCompiler.LinkCache linkCache,
@@ -3055,6 +3102,7 @@ public class CapybaraCompiler {
                         signatures,
                         signaturesByModule,
                         moduleClassNameByModuleName,
+                        qualifiedModuleAliases,
                         protectedConstructorsByType,
                         linkCache
                 ).flatMap(ex -> validateConstructorReturnType(function, ex, dataTypes, functionGenericTypeNames, compileCache)
@@ -3424,6 +3472,7 @@ public class CapybaraCompiler {
             List<CapybaraExpressionCompiler.FunctionSignature> signatures,
             Map<String, List<CapybaraExpressionCompiler.FunctionSignature>> signaturesByModule,
             Map<String, String> moduleClassNameByModuleName,
+            Map<String, String> qualifiedModuleAliases,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
             CapybaraExpressionCompiler.LinkCache linkCache
     ) {
@@ -3433,6 +3482,7 @@ public class CapybaraCompiler {
                 signatures,
                 signaturesByModule,
                 moduleClassNameByModuleName,
+                qualifiedModuleAliases,
                 protectedConstructorsByType,
                 linkCache,
                 Optional.of(qualifiedModuleNameFromSourceFile(moduleSourceFile)),
@@ -3483,6 +3533,7 @@ public class CapybaraCompiler {
                     selfSignatureAsNothing,
                     signaturesByModule,
                     moduleClassNameByModuleName,
+                    qualifiedModuleAliases,
                     protectedConstructorsByType,
                     linkCache,
                     Optional.of(qualifiedModuleNameFromSourceFile(moduleSourceFile)),

--- a/compiler/src/main/java/dev/capylang/compiler/ImportDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/ImportDeclaration.java
@@ -5,7 +5,15 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public record ImportDeclaration(String moduleName, List<String> symbols, List<String> excludedSymbols) {
+public record ImportDeclaration(String moduleName, List<String> symbols, List<String> excludedSymbols, boolean qualifiedOnly) {
+    public ImportDeclaration(String moduleName, List<String> symbols, List<String> excludedSymbols) {
+        this(moduleName, symbols, excludedSymbols, false);
+    }
+
+    public static ImportDeclaration qualified(String moduleName) {
+        return new ImportDeclaration(moduleName, List.of(), List.of(), true);
+    }
+
     public boolean isStarImport() {
         return symbols.contains("*");
     }

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -123,6 +123,7 @@ public class CapybaraExpressionCompiler {
     private final List<FunctionSignature> functionSignatures;
     private final Map<String, List<FunctionSignature>> functionSignaturesByModule;
     private final Map<String, String> moduleClassNameByModuleName;
+    private final Map<String, String> qualifiedModuleAliases;
     private final ConstructorRegistry constructorRegistry;
     private final Optional<String> currentSourceModuleName;
     private final Optional<String> currentConstructorTypeName;
@@ -161,7 +162,22 @@ public class CapybaraExpressionCompiler {
             Optional<String> currentSourceModuleName,
             Optional<String> currentConstructorTypeName
     ) {
-        this(parameters, dataTypes, functionSignatures, functionSignaturesByModule, moduleClassNameByModuleName, constructorRegistry, linkCache, currentSourceModuleName, currentConstructorTypeName, true);
+        this(parameters, dataTypes, functionSignatures, functionSignaturesByModule, moduleClassNameByModuleName, Map.of(), constructorRegistry, linkCache, currentSourceModuleName, currentConstructorTypeName, true);
+    }
+
+    public CapybaraExpressionCompiler(
+            List<CompiledFunction.CompiledFunctionParameter> parameters,
+            Map<String, GenericDataType> dataTypes,
+            List<FunctionSignature> functionSignatures,
+            Map<String, List<FunctionSignature>> functionSignaturesByModule,
+            Map<String, String> moduleClassNameByModuleName,
+            Map<String, String> qualifiedModuleAliases,
+            ConstructorRegistry constructorRegistry,
+            LinkCache linkCache,
+            Optional<String> currentSourceModuleName,
+            Optional<String> currentConstructorTypeName
+    ) {
+        this(parameters, dataTypes, functionSignatures, functionSignaturesByModule, moduleClassNameByModuleName, qualifiedModuleAliases, constructorRegistry, linkCache, currentSourceModuleName, currentConstructorTypeName, true);
     }
 
     private CapybaraExpressionCompiler(
@@ -170,6 +186,7 @@ public class CapybaraExpressionCompiler {
             List<FunctionSignature> functionSignatures,
             Map<String, List<FunctionSignature>> functionSignaturesByModule,
             Map<String, String> moduleClassNameByModuleName,
+            Map<String, String> qualifiedModuleAliases,
             ConstructorRegistry constructorRegistry,
             LinkCache linkCache,
             Optional<String> currentSourceModuleName,
@@ -182,6 +199,7 @@ public class CapybaraExpressionCompiler {
         this.functionSignatures = functionSignatures;
         this.functionSignaturesByModule = functionSignaturesByModule;
         this.moduleClassNameByModuleName = moduleClassNameByModuleName;
+        this.qualifiedModuleAliases = Map.copyOf(qualifiedModuleAliases);
         this.constructorRegistry = constructorRegistry;
         this.currentSourceModuleName = currentSourceModuleName;
         this.currentConstructorTypeName = currentConstructorTypeName;
@@ -274,6 +292,7 @@ public class CapybaraExpressionCompiler {
                 functionSignatures,
                 functionSignaturesByModule,
                 moduleClassNameByModuleName,
+                qualifiedModuleAliases,
                 constructorRegistry,
                 linkCache,
                 currentSourceModuleName,
@@ -966,12 +985,16 @@ public class CapybaraExpressionCompiler {
     }
 
     private ResolvedModule resolveQualifiedModule(String normalizedModuleName) {
-        var direct = functionSignaturesByModule.get(normalizedModuleName);
+        var aliasedModuleName = qualifiedModuleAliases.get(normalizedModuleName);
+        if (aliasedModuleName != null) {
+            var aliased = resolveQualifiedModuleDirect(aliasedModuleName);
+            if (aliased != null) {
+                return aliased;
+            }
+        }
+        var direct = resolveQualifiedModuleDirect(normalizedModuleName);
         if (direct != null) {
-            return new ResolvedModule(
-                    moduleClassNameByModuleName.getOrDefault(normalizedModuleName, normalizedModuleName),
-                    direct
-            );
+            return direct;
         }
         var lastSlash = normalizedModuleName.lastIndexOf('/');
         if (lastSlash >= 0 && lastSlash < normalizedModuleName.length() - 1) {
@@ -992,11 +1015,21 @@ public class CapybaraExpressionCompiler {
         return null;
     }
 
+    private ResolvedModule resolveQualifiedModuleDirect(String normalizedModuleName) {
+        var direct = functionSignaturesByModule.get(normalizedModuleName);
+        if (direct != null) {
+            return new ResolvedModule(
+                    moduleClassNameByModuleName.getOrDefault(normalizedModuleName, normalizedModuleName),
+                    direct
+            );
+        }
+        return null;
+    }
+
     private String normalizeQualifiedModuleName(String moduleName) {
         var normalized = moduleName.replace('\\', '/');
         if (normalized.startsWith("/")) {
-            normalized = normalized.substring(1);
-            return normalized.replace("/", ".");
+            return normalized.substring(1);
         }
         return normalized;
     }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -26,8 +26,12 @@ public class CapybaraParser {
     private static final Pattern MISMATCHED_INPUT_PATTERN = Pattern.compile("mismatched input '(.+)' expecting '(.+)'");
     private static final Pattern CONST_NAME_PATTERN = Pattern.compile("^_?[A-Z_][A-Z0-9_]*$");
     private static final Pattern ENUM_VALUE_NAME_PATTERN = Pattern.compile("^[A-Z]+(?:_[A-Z]+)*$");
-    private static final Pattern IMPORT_PATTERN = Pattern.compile(
-            "^\\s*from\\s+([A-Za-z_][A-Za-z0-9_]*|/[A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)+)\\s+import\\s*\\{\\s*([^}]*)\\s*}(?:\\s+except\\s*\\{\\s*([^}]*)\\s*})?\\s*$"
+    private static final String MODULE_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9_]*|/[A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)+";
+    private static final Pattern FROM_IMPORT_PATTERN = Pattern.compile(
+            "^\\s*from\\s+(" + MODULE_NAME_PATTERN + ")\\s+import\\s*\\{\\s*([^}]*)\\s*}(?:\\s+except\\s*\\{\\s*([^}]*)\\s*})?\\s*$"
+    );
+    private static final Pattern QUALIFIED_IMPORT_PATTERN = Pattern.compile(
+            "^\\s*import\\s+(" + MODULE_NAME_PATTERN + ")\\s*$"
     );
     private final List<Result.Error.SingleError> parserErrors = new ArrayList<>();
     private RawModule currentModule;
@@ -122,7 +126,8 @@ public class CapybaraParser {
         var imports = new ArrayList<ImportDeclaration>();
         var bodyLines = new ArrayList<String>();
         for (var line : source.split("\\R", -1)) {
-            var matcher = IMPORT_PATTERN.matcher(line);
+            var matcher = FROM_IMPORT_PATTERN.matcher(line);
+            var qualifiedMatcher = QUALIFIED_IMPORT_PATTERN.matcher(line);
             if (matcher.matches()) {
                 var module = matcher.group(1);
                 var symbols = Stream.of(matcher.group(2).split(","))
@@ -136,6 +141,10 @@ public class CapybaraParser {
                                 .filter(symbol -> !symbol.isBlank())
                                 .toList();
                 imports.add(new ImportDeclaration(module, symbols, excludedSymbols));
+                // Keep source line numbers stable for parser/linker diagnostics.
+                bodyLines.add("");
+            } else if (qualifiedMatcher.matches()) {
+                imports.add(ImportDeclaration.qualified(qualifiedMatcher.group(1)));
                 // Keep source line numbers stable for parser/linker diagnostics.
                 bodyLines.add("");
             } else {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/ObjectOrientedParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/ObjectOrientedParser.java
@@ -16,8 +16,12 @@ import java.util.stream.Stream;
 
 public final class ObjectOrientedParser {
     public static final ObjectOrientedParser INSTANCE = new ObjectOrientedParser();
-    private static final Pattern IMPORT_PATTERN = Pattern.compile(
-            "^\\s*from\\s+([A-Za-z_][A-Za-z0-9_]*|/[A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)+)\\s+import\\s*\\{\\s*([^}]*)\\s*}(?:\\s+except\\s*\\{\\s*([^}]*)\\s*})?\\s*$"
+    private static final String MODULE_NAME_PATTERN = "[A-Za-z_][A-Za-z0-9_]*|/[A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)+";
+    private static final Pattern FROM_IMPORT_PATTERN = Pattern.compile(
+            "^\\s*from\\s+(" + MODULE_NAME_PATTERN + ")\\s+import\\s*\\{\\s*([^}]*)\\s*}(?:\\s+except\\s*\\{\\s*([^}]*)\\s*})?\\s*$"
+    );
+    private static final Pattern QUALIFIED_IMPORT_PATTERN = Pattern.compile(
+            "^\\s*import\\s+(" + MODULE_NAME_PATTERN + ")\\s*$"
     );
 
     public Result<ObjectOrientedModule> parseModule(RawModule module) {
@@ -83,7 +87,8 @@ public final class ObjectOrientedParser {
         var imports = new ArrayList<ImportDeclaration>();
         var bodyLines = new ArrayList<String>();
         for (var line : source.split("\\R", -1)) {
-            var matcher = IMPORT_PATTERN.matcher(line);
+            var matcher = FROM_IMPORT_PATTERN.matcher(line);
+            var qualifiedMatcher = QUALIFIED_IMPORT_PATTERN.matcher(line);
             if (matcher.matches()) {
                 var module = matcher.group(1);
                 var symbols = Stream.of(matcher.group(2).split(","))
@@ -97,6 +102,9 @@ public final class ObjectOrientedParser {
                                 .filter(symbol -> !symbol.isBlank())
                                 .toList();
                 imports.add(new ImportDeclaration(module, symbols, excludedSymbols));
+                bodyLines.add("");
+            } else if (qualifiedMatcher.matches()) {
+                imports.add(ImportDeclaration.qualified(qualifiedMatcher.group(1)));
                 bodyLines.add("");
             } else {
                 bodyLines.add(line);

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Optional;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.stream.Stream;
 
 import dev.capylang.compiler.Result;
@@ -50,6 +51,18 @@ class CapybaraParserTest {
                 })
                 .findAny()
                 .orElseThrow(() -> new AssertionError(type.getSimpleName() + " " + name + " not found"));
+    }
+
+    @Test
+    void parsesQualifiedImport() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                import /foo/A
+
+                fun value(): int = A.foo(1)
+                """));
+
+        assertThat(module.imports())
+                .containsExactly(new dev.capylang.compiler.ImportDeclaration("/foo/A", List.of(), List.of(), true));
     }
 
     private static dev.capylang.compiler.parser.Module parseSuccess(RawModule module) {


### PR DESCRIPTION
## Summary
- add `import /path/Module` qualified-only imports for functional and OO source pre-parsing
- resolve qualified imported module aliases for function calls, types, and constructors
- add parser, e2e, and compilation-error coverage for qualified imports

## Tests
- `./gradlew clean check`