### PR TITLE
feat(#177): add declaration annotations

### DIFF
--- a/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
+++ b/Intellij/Capybara.tmBundle/Syntaxes/Capybara.tmLanguage
@@ -60,7 +60,7 @@
         <dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict>
       </array>
     </dict>
-    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|type|union|enum|data|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
+    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|def|type|union|enum|data|const|derive|deriver|annotation|on|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
     <dict><key>name</key><string>keyword.operator.constructor.capybara</string><key>match</key><string>(?&lt;=\bconstructor\s*\{[^\n]*)\*(?=\s*\{)</string></dict>
     <dict><key>name</key><string>keyword.other.capybara</string><key>match</key><string>\\b(is_empty|size|to_int|to_long|to_double|to_float|to_bool|reflection)\\b</string></dict>
     <dict><key>name</key><string>support.type.primitive.capybara</string><key>match</key><string>\b(byte|int|long|float|double|bool|string|any|data|void|list|set|dict|tuple)(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
@@ -70,8 +70,61 @@
     <dict><key>name</key><string>constant.language.native.capybara</string><key>match</key><string>&lt;native&gt;</string></dict>
     <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
+      <key>name</key><string>meta.annotation.usage.capybara</string>
+      <key>begin</key><string>(^\s*)(@)(\s*)((?:/?[A-Za-z_][A-Za-z0-9_]*(?:[/.][A-Za-z_][A-Za-z0-9_]*)*))(\s*)(\()</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>2</key><dict><key>name</key><string>punctuation.definition.annotation.begin.capybara</string></dict>
+        <key>4</key><dict><key>name</key><string>entity.name.type.annotation.capybara</string></dict>
+        <key>6</key><dict><key>name</key><string>punctuation.section.annotation.arguments.begin.capybara</string></dict>
+      </dict>
+      <key>end</key><string>\)</string>
+      <key>endCaptures</key>
+      <dict>
+        <key>0</key><dict><key>name</key><string>punctuation.section.annotation.arguments.end.capybara</string></dict>
+      </dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>name</key><string>meta.annotation.argument.capybara</string>
+          <key>match</key><string>\b([A-Za-z_][A-Za-z0-9_]*)(\s*:)</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key><dict><key>name</key><string>variable.parameter.annotation.capybara</string></dict>
+            <key>2</key><dict><key>name</key><string>punctuation.separator.key-value.annotation.capybara</string></dict>
+          </dict>
+        </dict>
+        <dict><key>name</key><string>string.quoted.double.capybara</string><key>begin</key><string>"</string><key>end</key><string>"</string><key>patterns</key><array><dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict></array></dict>
+        <dict><key>name</key><string>string.quoted.single.capybara</string><key>begin</key><string>'</string><key>end</key><string>'</string><key>patterns</key><array><dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict></array></dict>
+        <dict><key>name</key><string>constant.numeric.capybara</string><key>match</key><string>\b(?:0[xX][0-9a-fA-F]+|\d+[lL]|\d+\.\d*(?:[eE][+\-]?\d+)?[fFdD]?|\d+[eE][+\-]?\d+[fFdD]?|\d+)\b</string></dict>
+        <dict><key>name</key><string>constant.language.boolean.capybara</string><key>match</key><string>\b(true|false)\b</string></dict>
+        <dict><key>name</key><string>constant.language.unimplemented.capybara</string><key>match</key><string>\?\?\?</string></dict>
+        <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
+      </array>
+    </dict>
+    <dict>
+      <key>name</key><string>meta.annotation.usage.marker.capybara</string>
+      <key>match</key><string>(^\s*)(@)(\s*)((?:/?[A-Za-z_][A-Za-z0-9_]*(?:[/.][A-Za-z_][A-Za-z0-9_]*)*))(?!\s*\()</string>
+      <key>captures</key>
+      <dict>
+        <key>2</key><dict><key>name</key><string>punctuation.definition.annotation.begin.capybara</string></dict>
+        <key>4</key><dict><key>name</key><string>entity.name.type.annotation.capybara</string></dict>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key><string>meta.annotation.definition.capybara</string>
+      <key>match</key><string>\b(annotation)(\s+)(_*[A-Z][A-Za-z0-9_]*)(\s+)(on)\b</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key><dict><key>name</key><string>keyword.control.capybara</string></dict>
+        <key>3</key><dict><key>name</key><string>entity.name.type.annotation.capybara</string></dict>
+        <key>5</key><dict><key>name</key><string>keyword.control.capybara</string></dict>
+      </dict>
+    </dict>
+    <dict><key>name</key><string>support.type.annotation-target.capybara</string><key>match</key><string>\b(fun|method|const|data|union|enum|type|deriver|class|interface|trait|field|init)\b(?=\s*(?:,|\{))</string></dict>
+    <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)(__[A-Za-z0-9_]+)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)(__[A-Za-z0-9_]+)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -81,7 +134,7 @@
     </dict>
     <dict>
       <key>name</key><string>meta.function.documented.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -111,12 +164,12 @@
       </dict>
     </dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
-    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(union|enum|data|deriver|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(union|enum|data|deriver|annotation|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b(class|trait|interface)\s+(_*[A-Z][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+(__[A-Za-z0-9_]+)</string></dict>
-    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun\s+(__[A-Za-z0-9_]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:(__[A-Za-z0-9_]+)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(__[A-Za-z0-9_]+)\s*(?=\()</string></dict>

--- a/Intellij/syntaxes/Capybara.tmLanguage
+++ b/Intellij/syntaxes/Capybara.tmLanguage
@@ -60,7 +60,7 @@
         <dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict>
       </array>
     </dict>
-    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|rec|def|type|union|enum|data|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
+    <dict><key>name</key><string>keyword.control.capybara</string><key>match</key><string>\b(fun|def|type|union|enum|data|const|derive|deriver|annotation|on|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\b</string></dict>
     <dict><key>name</key><string>keyword.operator.constructor.capybara</string><key>match</key><string>(?&lt;=\bconstructor\s*\{[^\n]*)\*(?=\s*\{)</string></dict>
     <dict><key>name</key><string>keyword.other.capybara</string><key>match</key><string>\\b(is_empty|size|to_int|to_long|to_double|to_float|to_bool|reflection)\\b</string></dict>
     <dict><key>name</key><string>support.type.primitive.capybara</string><key>match</key><string>\b(byte|int|long|float|double|bool|String|any|data|void|List|Set|Dict|Tuple)(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
@@ -70,8 +70,61 @@
     <dict><key>name</key><string>constant.language.native.capybara</string><key>match</key><string>&lt;native&gt;</string></dict>
     <dict><key>name</key><string>punctuation.separator.local-definitions.capybara</string><key>match</key><string>---</string></dict>
     <dict>
+      <key>name</key><string>meta.annotation.usage.capybara</string>
+      <key>begin</key><string>(^\s*)(@)(\s*)((?:/?[A-Za-z_][A-Za-z0-9_]*(?:[/.][A-Za-z_][A-Za-z0-9_]*)*))(\s*)(\()</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>2</key><dict><key>name</key><string>punctuation.definition.annotation.begin.capybara</string></dict>
+        <key>4</key><dict><key>name</key><string>entity.name.type.annotation.capybara</string></dict>
+        <key>6</key><dict><key>name</key><string>punctuation.section.annotation.arguments.begin.capybara</string></dict>
+      </dict>
+      <key>end</key><string>\)</string>
+      <key>endCaptures</key>
+      <dict>
+        <key>0</key><dict><key>name</key><string>punctuation.section.annotation.arguments.end.capybara</string></dict>
+      </dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>name</key><string>meta.annotation.argument.capybara</string>
+          <key>match</key><string>\b([A-Za-z_][A-Za-z0-9_]*)(\s*:)</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key><dict><key>name</key><string>variable.parameter.annotation.capybara</string></dict>
+            <key>2</key><dict><key>name</key><string>punctuation.separator.key-value.annotation.capybara</string></dict>
+          </dict>
+        </dict>
+        <dict><key>name</key><string>string.quoted.double.capybara</string><key>begin</key><string>"</string><key>end</key><string>"</string><key>patterns</key><array><dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict></array></dict>
+        <dict><key>name</key><string>string.quoted.single.capybara</string><key>begin</key><string>'</string><key>end</key><string>'</string><key>patterns</key><array><dict><key>name</key><string>constant.character.escape.capybara</string><key>match</key><string>\\.</string></dict></array></dict>
+        <dict><key>name</key><string>constant.numeric.capybara</string><key>match</key><string>\b(?:0[xX][0-9a-fA-F]+|\d+[lL]|\d+\.\d*(?:[eE][+\-]?\d+)?[fFdD]?|\d+[eE][+\-]?\d+[fFdD]?|\d+)\b</string></dict>
+        <dict><key>name</key><string>constant.language.boolean.capybara</string><key>match</key><string>\b(true|false)\b</string></dict>
+        <dict><key>name</key><string>constant.language.unimplemented.capybara</string><key>match</key><string>\?\?\?</string></dict>
+        <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
+      </array>
+    </dict>
+    <dict>
+      <key>name</key><string>meta.annotation.usage.marker.capybara</string>
+      <key>match</key><string>(^\s*)(@)(\s*)((?:/?[A-Za-z_][A-Za-z0-9_]*(?:[/.][A-Za-z_][A-Za-z0-9_]*)*))(?!\s*\()</string>
+      <key>captures</key>
+      <dict>
+        <key>2</key><dict><key>name</key><string>punctuation.definition.annotation.begin.capybara</string></dict>
+        <key>4</key><dict><key>name</key><string>entity.name.type.annotation.capybara</string></dict>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key><string>meta.annotation.definition.capybara</string>
+      <key>match</key><string>\b(annotation)(\s+)(_*[A-Z][A-Za-z0-9_]*)(\s+)(on)\b</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key><dict><key>name</key><string>keyword.control.capybara</string></dict>
+        <key>3</key><dict><key>name</key><string>entity.name.type.annotation.capybara</string></dict>
+        <key>5</key><dict><key>name</key><string>keyword.control.capybara</string></dict>
+      </dict>
+    </dict>
+    <dict><key>name</key><string>support.type.annotation-target.capybara</string><key>match</key><string>\b(fun|method|const|data|union|enum|type|deriver|class|interface|trait|field|init)\b(?=\s*(?:,|\{))</string></dict>
+    <dict>
       <key>name</key><string>meta.function.documented.private.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)(__[A-Za-z0-9_]+)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)(__[A-Za-z0-9_]+)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -81,7 +134,7 @@
     </dict>
     <dict>
       <key>name</key><string>meta.function.documented.capybara</string>
-      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun(?:\s+rec)?|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
+      <key>match</key><string>((?:^\s*///.*\r?\n)+)(\s*)((?:fun|def))(\s+)([A-Za-z_][A-Za-z0-9_]*)</string>
       <key>captures</key>
       <dict>
         <key>1</key><dict><key>name</key><string>comment.block.documentation.capybara</string></dict>
@@ -111,12 +164,12 @@
       </dict>
     </dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b_*[A-Z][A-Za-z0-9_]*(?:\[\])*(?=\b|[^A-Za-z0-9_])</string></dict>
-    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(union|enum|data|deriver|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>entity.name.type.private.capybara</string><key>match</key><string>\b(union|enum|data|deriver|annotation|class|trait|interface)\s+(__[A-Za-z0-9_]*)</string></dict>
     <dict><key>name</key><string>entity.name.type.capybara</string><key>match</key><string>\b(class|trait|interface)\s+(_*[A-Z][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+(__[A-Za-z0-9_]+)</string></dict>
-    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun(?:\s+rec)?\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
-    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun(?:\s+rec)?)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\bfun\s+(__[A-Za-z0-9_]+)</string></dict>
+    <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>\bfun\s+([A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-generic.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*\[[^\]]+\])\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)</string></dict>
+    <dict><key>name</key><string>meta.function.owner-infix.capybara</string><key>match</key><string>\b(fun)\s+(_*[A-Z][A-Za-z0-9_]*)\.([^]+)</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>:(__[A-Za-z0-9_]+)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.capybara</string><key>match</key><string>:([A-Za-z_][A-Za-z0-9_]*)\b</string></dict>
     <dict><key>name</key><string>entity.name.function.private.capybara</string><key>match</key><string>\b(__[A-Za-z0-9_]+)\s*(?=\()</string></dict>

--- a/Intellij/syntaxes/capybara.tmLanguage.json
+++ b/Intellij/syntaxes/capybara.tmLanguage.json
@@ -130,7 +130,7 @@
       "patterns": [
         {
           "name": "keyword.control.capybara",
-          "match": "\\b(fun|rec|def|type|union|enum|data|const|derive|deriver|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\\b"
+          "match": "\\b(fun|def|type|union|enum|data|const|derive|deriver|annotation|on|local|match|with|constructor|case|when|if|then|else|let|return|throw|try|catch|this|receiver|from|import|except|class|trait|interface|field|open|abstract|override|final|private|public|init|super|while|do|for|foreach|in)\\b"
         },
         {
           "name": "keyword.operator.constructor.capybara",
@@ -165,8 +165,87 @@
     "typesAndFunctions": {
       "patterns": [
         {
+          "name": "meta.annotation.usage.capybara",
+          "begin": "(^\\s*)(@)(\\s*)((?:/?[A-Za-z_][A-Za-z0-9_]*(?:[/.][A-Za-z_][A-Za-z0-9_]*)*))(\\s*)(\\()",
+          "beginCaptures": {
+            "2": {
+              "name": "punctuation.definition.annotation.begin.capybara"
+            },
+            "4": {
+              "name": "entity.name.type.annotation.capybara"
+            },
+            "6": {
+              "name": "punctuation.section.annotation.arguments.begin.capybara"
+            }
+          },
+          "end": "\\)",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.annotation.arguments.end.capybara"
+            }
+          },
+          "patterns": [
+            {
+              "name": "meta.annotation.argument.capybara",
+              "match": "\\b([A-Za-z_][A-Za-z0-9_]*)(\\s*:)",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.annotation.capybara"
+                },
+                "2": {
+                  "name": "punctuation.separator.key-value.annotation.capybara"
+                }
+              }
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#numbers"
+            },
+            {
+              "include": "#keywords"
+            },
+            {
+              "name": "entity.name.type.capybara",
+              "match": "\\b_*[A-Z][A-Za-z0-9_]*(?:\\[\\])*(?=\\b|[^A-Za-z0-9_])"
+            }
+          ]
+        },
+        {
+          "name": "meta.annotation.usage.marker.capybara",
+          "match": "(^\\s*)(@)(\\s*)((?:/?[A-Za-z_][A-Za-z0-9_]*(?:[/.][A-Za-z_][A-Za-z0-9_]*)*))(?!\\s*\\()",
+          "captures": {
+            "2": {
+              "name": "punctuation.definition.annotation.begin.capybara"
+            },
+            "4": {
+              "name": "entity.name.type.annotation.capybara"
+            }
+          }
+        },
+        {
+          "name": "meta.annotation.definition.capybara",
+          "match": "\\b(annotation)(\\s+)(_*[A-Z][A-Za-z0-9_]*)(\\s+)(on)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.capybara"
+            },
+            "3": {
+              "name": "entity.name.type.annotation.capybara"
+            },
+            "5": {
+              "name": "keyword.control.capybara"
+            }
+          }
+        },
+        {
+          "name": "support.type.annotation-target.capybara",
+          "match": "\\b(fun|method|const|data|union|enum|type|deriver|class|interface|trait|field|init)\\b(?=\\s*(?:,|\\{))"
+        },
+        {
           "name": "meta.function.documented.private.capybara",
-          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun(?:\\s+rec)?|def))(\\s+)(__[A-Za-z0-9_]+)",
+          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun|def))(\\s+)(__[A-Za-z0-9_]+)",
           "captures": {
             "1": {
               "name": "comment.block.documentation.capybara"
@@ -181,7 +260,7 @@
         },
         {
           "name": "meta.function.documented.capybara",
-          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun(?:\\s+rec)?|def))(\\s+)([A-Za-z_][A-Za-z0-9_]*)",
+          "match": "((?:^\\s*///.*\\r?\\n)+)(\\s*)((?:fun|def))(\\s+)([A-Za-z_][A-Za-z0-9_]*)",
           "captures": {
             "1": {
               "name": "comment.block.documentation.capybara"
@@ -234,7 +313,7 @@
         },
         {
           "name": "entity.name.type.private.capybara",
-          "match": "\\b(union|enum|data|deriver|class|trait|interface)\\s+(__[A-Za-z0-9_]*)"
+          "match": "\\b(union|enum|data|deriver|annotation|class|trait|interface)\\s+(__[A-Za-z0-9_]*)"
         },
         {
           "name": "entity.name.type.capybara",
@@ -242,19 +321,19 @@
         },
         {
           "name": "entity.name.function.private.capybara",
-          "match": "\\bfun(?:\\s+rec)?\\s+(__[A-Za-z0-9_]+)"
+          "match": "\\bfun\\s+(__[A-Za-z0-9_]+)"
         },
         {
           "name": "entity.name.function.capybara",
-          "match": "\\bfun(?:\\s+rec)?\\s+([A-Za-z_][A-Za-z0-9_]*)"
+          "match": "\\bfun\\s+([A-Za-z_][A-Za-z0-9_]*)"
         },
         {
           "name": "meta.function.owner-generic.capybara",
-          "match": "\\b(fun(?:\\s+rec)?)\\s+(_*[A-Z][A-Za-z0-9_]*\\[[^\\]]+\\])\\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)"
+          "match": "\\b(fun)\\s+(_*[A-Z][A-Za-z0-9_]*\\[[^\\]]+\\])\\.(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)"
         },
         {
           "name": "meta.function.owner-infix.capybara",
-          "match": "\\b(fun(?:\\s+rec)?)\\s+(_*[A-Z][A-Za-z0-9_]*)\\.([^]+)"
+          "match": "\\b(fun)\\s+(_*[A-Z][A-Za-z0-9_]*)\\.([^]+)"
         },
         {
           "name": "entity.name.function.private.capybara",

--- a/README.md
+++ b/README.md
@@ -286,17 +286,20 @@ receiver types.
 
 ### Recursion
 
-Recursive functions are allowed. `fun rec` is a compiler-checked direct
-tail-recursion contract:
+Recursive functions are allowed. The standard `Recursive` annotation is a
+compiler-checked direct tail-recursion contract:
 
 ```cfun
-fun rec sum_to(n: int, acc: int): int =
+from /capy/meta_prog/Recursive import { Recursive }
+
+@Recursive
+fun sum_to(n: int, acc: int): int =
     if n <= 0 then acc else sum_to(n - 1, acc + n)
 ```
 
-If a `fun rec` self-call is not in tail position, compilation fails. Unmarked
-recursive functions remain valid, but `fun rec` documents and verifies the
-tail-recursive shape.
+If a `@Recursive` self-call is not in tail position, compilation fails.
+Unmarked recursive functions remain valid, but `@Recursive` documents and
+verifies the tail-recursive shape.
 
 ### Derive And Reflection
 
@@ -322,6 +325,71 @@ fun show_account(): String =
 The generated receiver is named `receiver` inside a deriver method. Reflection
 v1 is intentionally small: it supports `.cfun` data value metadata, derive use
 cases, shallow runtime type patterns, and static `.coo` type metadata.
+
+### Declaration Annotations
+
+Annotations are source-level metadata prefixes for declarations. Annotation
+definitions are top-level `.cfun` declarations; `.coo` sources can import and
+use those definitions.
+
+```cfun
+annotation JsonName on field {
+    value: String
+}
+
+annotation Internal on data, class, method {}
+```
+
+Use one annotation prefix before the declaration it describes.
+Multiple prefixes preserve source order. Arguments are named with `key: value`;
+annotations with no explicit arguments may omit empty parentheses.
+
+```cfun
+@Internal
+data User {
+    @JsonName(value: "user_id")
+    id: String
+}
+```
+
+The standard library provides `Deprecated` from
+`/capy/meta_prog/Annotations`. It requires `message: String` and defaults
+`since: String` to `""`:
+
+```cfun
+from /capy/meta_prog/Annotations import { Deprecated }
+
+@Deprecated(message: "use parse_v2", since: "1.4")
+fun parse(raw: String): Result[User] = ...
+```
+
+Supported targets are `fun`, `method`, `const`, `data`, `union`, `enum`,
+`type`, `deriver`, `class`, `interface`, `trait`, `field`, and `init`.
+Validation checks that annotation definitions are visible through normal import
+rules, the target is allowed, required arguments are provided, argument keys are
+unique and known, and argument values match the declared field types.
+Comma-separated prefixes such as `@A, @B` or `@A(), @B()` and positional arguments are not
+valid.
+
+Reflection exposes annotation metadata for supported reflected declarations:
+
+```cfun
+from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+
+annotation Label on data {
+    value: String
+}
+
+@Label(value: "account")
+data Account { id: String }
+
+fun account_info(account: Account): DataValueInfo =
+    reflection(account)
+```
+
+Annotations are metadata only. They are not macros, decorators, retention
+policies, runtime execution hooks, or a way to replace explicit language
+features such as `derive`, `override`, visibility, or constructors.
 
 ### Effects And Programs
 
@@ -513,7 +581,8 @@ Keep these boundaries in mind when changing code or examples:
   pipe-prefixed match branch examples.
 - Match branches use `case Pattern -> expression`.
 - `.cfun` methods are declared on the receiver type with dotted method syntax.
-- `fun rec` is a tail-recursion assertion, not a general recursion keyword.
+- `@Recursive` is the compiler-recognized standard tail-recursion annotation,
+  not a general recursion keyword.
 - `* { ... }` is constructor-local raw construction.
 - `DataName! { ... }` is an unsafe same-module constructor bypass for
   `Result`-returning constructors.

--- a/adr/ADR-2026-04-29-cfun-rec-tail-recursion.md
+++ b/adr/ADR-2026-04-29-cfun-rec-tail-recursion.md
@@ -1,25 +1,45 @@
-# ADR-2026-04-29: `.cfun` `fun rec` Tail-Recursion Contract
+# ADR-2026-04-29: `.cfun` `@Recursive` Tail-Recursion Contract
 
 - Status: accepted
 - Deciders: Codex, repository maintainers
 - Date: 2026-04-29
+- Amended: 2026-05-24, replacing the `fun rec` keyword form with the standard
+  `@Recursive` annotation form.
 
 ## Context
 
-Issue #100 introduces `.cfun` `fun rec` as an explicit recursion form with compiler checks and backend consequences.
+Issue #100 introduced `.cfun` `fun rec` as an explicit recursion form with
+compiler checks and backend consequences. Declaration annotations now provide a
+single prefix syntax for declaration-level markers, so the recursion contract is
+expressed as the standard `@Recursive` annotation instead of a dedicated
+keyword.
 
 Without a dedicated marker, recursive intent and optimization expectations are implicit. That makes it hard to guarantee predictable lowering and diagnostics for recursion-heavy code.
 
 ## Decision
 
-Capybara detects direct self-recursion for every function. It treats `fun rec` as a compiler-verified direct tail-recursion contract.
+Capybara detects direct self-recursion for every function. It treats the
+standard `/capy/meta_prog/Recursive` annotation as a compiler-verified direct
+tail-recursion contract.
 
-- `rec` is declaration-local and only meaningful with `fun`.
+- `Recursive` is declared in the standard library as
+  `/capy/meta_prog/Recursive.Recursive` and must be visible through normal
+  imports.
+- User annotations named `Recursive` are ordinary metadata and do not trigger
+  the tail-recursion contract.
+- `@Recursive` is declaration-local and only meaningful on `.cfun` function
+  declarations.
+- `@Recursive` may be used on top-level functions and local functions.
+- `@Recursive` is not supported on `.cfun` type methods or `.coo` methods.
 - The compiler records whether each function is directly recursive.
-- Functions whose direct self-recursive calls are all in tail position may use loop-style Java lowering, even without the `rec` marker.
-- `fun rec` validates direct tail-recursive shape for the declared function body.
-- `fun rec` violations are rejected at compile time instead of silently compiling as ordinary recursion.
-- Non-tail recursive functions without `rec` remain valid recursive functions and keep ordinary call-style Java lowering.
+- Functions whose direct self-recursive calls are all in tail position may use
+  loop-style Java lowering, even without the `@Recursive` marker.
+- `@Recursive` validates direct tail-recursive shape for the declared function
+  body.
+- `@Recursive` violations are rejected at compile time instead of silently
+  compiling as ordinary recursion.
+- Non-tail recursive functions without `@Recursive` remain valid recursive
+  functions and keep ordinary call-style Java lowering.
 
 ## Consequences
 
@@ -27,4 +47,6 @@ Recursive performance intent is explicit in source, and invalid non-tail forms f
 
 Java backend behavior becomes more predictable for tail-recursive functions, with stack usage aligned to loop lowering when the compiler can prove the direct self-recursive shape.
 
-This ADR does not broaden recursion semantics beyond direct self-recursion. The `rec` keyword remains the source-level assertion that recursion must be tail-recursive.
+This ADR does not broaden recursion semantics beyond direct self-recursion.
+`@Recursive` is the source-level assertion that recursion must be
+tail-recursive.

--- a/adr/ADR-2026-05-07-cfun-derive-v1.md
+++ b/adr/ADR-2026-05-07-cfun-derive-v1.md
@@ -12,7 +12,7 @@ Accepted.
 
 Capybara has parser AST declarations, linked type metadata, compiler intrinsics for reflection, and backend-independent functional IR, but it has no source-level way to ask the compiler to generate declarations from type metadata.
 
-General procedural macros, compiler plugins, or arbitrary compile-time execution would require a larger evaluator, hygiene model, sandboxing story, incremental-compilation contract, and linked-artifact format. Existing ADRs cover explicit compile-time contracts such as `fun rec` and unsafe constructor bypass, but none covers metaprogramming or derive expansion.
+General procedural macros, compiler plugins, or arbitrary compile-time execution would require a larger evaluator, hygiene model, sandboxing story, incremental-compilation contract, and linked-artifact format. Existing ADRs cover explicit compile-time contracts such as `@Recursive` and unsafe constructor bypass, but none covers metaprogramming or derive expansion.
 
 ## Decision
 

--- a/adr/ADR-2026-05-24-declaration-annotations-v1.md
+++ b/adr/ADR-2026-05-24-declaration-annotations-v1.md
@@ -1,0 +1,280 @@
+# ADR-2026-05-24: Declaration Annotations v1
+
+- Status: accepted
+- Deciders: Codex workflow, repository maintainers
+- Date: 2026-05-24
+
+## Context
+
+Issue #177 introduces declaration annotations as public language syntax and as
+metadata exposed through reflection. Because annotations affect source
+compatibility, linked artifacts, and runtime-facing metadata, the v1 contract
+must be fixed before grammar, linker, validator, reflection, or backend work
+starts.
+
+Existing decisions remain the baseline:
+
+- `ADR-2026-05-07-cfun-derive-v1.md` defines explicit derive expansion and keeps
+  arbitrary compile-time execution out of scope.
+- `ADR-2026-05-08-reflection-v1.md` defines reflection as the official metadata
+  surface.
+- `ADR-2026-04-14-capybara-oo-v1.md` defines the OO frontend boundary and OO
+  override validation as explicit language behavior.
+- `ADR-2026-04-29-cfun-rec-tail-recursion.md` defines the built-in
+  `@Recursive` annotation as an explicit recursion contract.
+
+No earlier ADR defines declaration annotations.
+
+## Decision
+
+Capybara v1 declaration annotations are source-level declaration prefixes that
+attach validated metadata to the declaration that immediately follows them.
+
+Example usage:
+
+```cfun
+@Deprecated(message: "use parse_v2", since: "1.4")
+fun parse(raw: String): Result[User] = ...
+
+@Test(name: "parses user")
+fun should_parse_user(): bool = true
+```
+
+```coo
+@Entity(table: "users")
+class User(name: String) {
+    @JsonName(value: "user_name")
+    field name: String = name
+}
+```
+
+Annotation definitions are top-level `.cfun` declarations:
+
+```cfun
+annotation Deprecated on fun, method, const, data, union, enum, type, deriver, class, interface, trait, field, init {
+    message: String
+    since: String = ""
+}
+
+annotation JsonName on field {
+    value: String
+}
+
+annotation Internal on fun, data, class {}
+```
+
+The standard library provides `Deprecated` from `/capy/meta_prog/Annotations`
+with the same shape. It is ordinary metadata, not a compiler-special annotation.
+Reflection exposes it on declaration kinds that have a reflection surface; uses
+on other valid targets remain linked metadata for compiler and tooling
+consumers.
+
+V1 rules:
+
+- Annotation usage is declaration-prefix only. An annotation attaches to the next
+  declaration and is invalid on expressions, statements, parameters, local
+  variables, or other non-declaration positions.
+- Exactly one annotation is allowed per annotation prefix.
+- Comma-separated forms such as `@A, @B` or `@A(), @B()` are invalid because each prefix
+  holds one annotation.
+- Multiple annotations are written as multiple prefixes and preserve source
+  order in linked metadata and reflection:
+
+  ```cfun
+  @Internal
+  @Deprecated(message: "use parse_v2")
+  fun parse(raw: String): Result[User] = ...
+  ```
+
+- Annotation arguments are named only: `key: value`.
+- Positional arguments, shorthand arguments, spread arguments, and mixed
+  positional/named forms are invalid.
+- Annotations with no explicit arguments may omit empty parentheses: `@Internal`.
+  `@Internal()` remains valid for compatibility.
+- Annotation definitions are declared only in top-level `.cfun` source. `.coo`
+  declarations may use visible `.cfun` annotation definitions, but `.coo`
+  annotation definitions are not part of v1.
+- Annotation definitions participate in normal module visibility and import
+  rules. Unknown or unimported annotation names are compile errors.
+- Unknown keys, duplicate keys, missing required keys, wrong value types, and
+  invalid targets are compile errors.
+- Defaulted annotation fields are included in the effective metadata returned by
+  reflection.
+- V1 annotations are metadata and validation only.
+- V1 annotations must not execute code, run macros, perform IO, mutate compiler
+  state, or transform declarations.
+- Ordinary user-defined annotations do not replace explicit language features:
+  `derive Show`, OO `override`, visibility or mutability modifiers, and other
+  source keywords keep their existing semantics.
+- `@Recursive` is the one standard v1 annotation with compiler behavior. It is
+  declared as `/capy/meta_prog/Recursive.Recursive`, must be visible through
+  normal imports, and replaces the old `fun rec` keyword form.
+- `@Recursive` may be used on top-level and local `.cfun` functions only. It
+  is invalid on `.cfun` type methods and `.coo` methods.
+- User-defined annotations remain invalid on local definitions; local functions
+  accept only the standard `/capy/meta_prog/Recursive` marker.
+- `@Override()` must not satisfy OO override semantics. If an OO declaration
+  requires the real override marker or modifier, an annotation named `Override`
+  is only metadata.
+- Reflection is the first official runtime-facing consumer of annotation
+  metadata.
+- Annotation metadata must not affect value equality, object identity,
+  stringification, generated `show` behavior, or derived JSON/string output
+  unless a future explicit feature says otherwise.
+
+## Targets
+
+V1 annotation target identifiers are exactly:
+
+- `fun`
+- `method`
+- `const`
+- `data`
+- `union`
+- `enum`
+- `type`
+- `deriver`
+- `class`
+- `interface`
+- `trait`
+- `field`
+- `init`
+
+The target matrix is:
+
+| Source | Target | V1 target identifier |
+| --- | --- | --- |
+| `.cfun` | top-level functions | `fun` |
+| `.cfun` | functional methods written as `fun Type.method` | `method` |
+| `.cfun` | constants | `const` |
+| `.cfun` | data declarations | `data` |
+| `.cfun` | data fields | `field` |
+| `.cfun` | union declarations | `union` |
+| `.cfun` | union case fields | `field` |
+| `.cfun` | enum declarations | `enum` |
+| `.cfun` | primitive-backed `type` declarations | `type` |
+| `.cfun` | deriver declarations | `deriver` |
+| `.cfun` | deriver methods | `method` |
+| `.coo` | classes | `class` |
+| `.coo` | interfaces | `interface` |
+| `.coo` | traits | `trait` |
+| `.coo` | fields | `field` |
+| `.coo` | class and trait methods | `method` |
+| `.coo` | interface methods | `method` |
+| `.coo` | `init` blocks | `init` |
+
+The following targets are postponed and invalid in v1:
+
+- parameters
+- local variables
+- local `.cfun` definitions
+- `.coo` local methods
+- expressions
+- statements
+
+Future ADRs may split method subtargets or add finer-grained targets. V1 keeps a
+small target set so the grammar, linker, diagnostics, reflection model, and all
+backends can agree on one portable contract.
+
+## Annotation Values
+
+V1 annotation values are a closed metadata value set:
+
+- string literals
+- integer literals
+- long literals
+- float literals
+- double literals
+- boolean literals
+- `???`
+- type references as metadata-only type-name values
+
+Type-name values are written as bare type references using the same type-token
+forms accepted in type positions, for example `String`, `User`, `Result[User]`,
+or a fully qualified type name when the language supports one. An identifier in
+annotation value position is metadata only. It is not a local variable,
+function, enum case, field, or computed expression.
+
+Reflection exposes type-name values as `AnnotationTypeName` metadata whose
+`value` field is the parsed type-reference text. Backends must not lower
+type-name values to runtime class objects in v1.
+
+`???` is allowed as an annotation value only as metadata. Reflection exposes it
+as a distinct unknown annotation value, not as a thrown exception or executable
+placeholder.
+
+The following values are invalid in v1:
+
+- full expressions
+- lambdas
+- lists
+- sets
+- dicts
+- tuples
+- function calls
+- member access used as a value expression
+- arithmetic, boolean, comparison, or pipeline expressions
+- computed values of any kind
+
+## Reflection Contract
+
+Reflection v1 is extended with annotation metadata without changing the core
+reflection decision in `ADR-2026-05-08-reflection-v1.md`.
+
+Every reflected declaration kind that can be annotated must expose its
+annotations in source order. A declaration without annotations exposes an empty
+annotation list.
+
+Each reflected annotation entry must include:
+
+- the annotation's source name
+- the annotation definition's owner package
+- the effective named arguments, including defaults
+- each argument value as one of the closed v1 annotation value variants
+
+Reflection consumers must observe the same metadata whether annotations are
+written in the current module or come from imported linked artifacts.
+
+Annotation metadata is descriptive. It must not affect declaration identity,
+runtime equality, hashing, stringification, or existing reflection fields other
+than the added annotation metadata fields.
+
+## Backend Parity
+
+All supported backends for a reflected declaration kind must preserve the same
+validated annotation metadata and source order. A backend may choose its native
+metadata representation, but the public reflection API must expose equivalent
+annotation names, owner packages, arguments, defaults, type-name values, and
+unknown values.
+
+Backends must not silently drop annotations for declarations that reflection can
+observe. If a backend cannot provide equivalent annotation metadata for a
+supported reflection path, that path must remain unsupported or fail explicitly
+until parity is implemented.
+
+Because annotations do not transform declarations in v1, ordinary generated code
+for non-reflection behavior should be unchanged except for whatever metadata
+storage is required by reflection.
+
+## Non-goals
+
+V1 does not introduce macros, compiler plugins, custom derive replacement,
+conditional compilation, retention policies, runtime annotation classes, Java
+annotation interop, dependency injection hooks, test discovery behavior, or
+backend-specific code generation hooks.
+
+Derive remains the explicit compile-time generation mechanism described by
+`ADR-2026-05-07-cfun-derive-v1.md`. Except for the reserved built-in
+`@Recursive` contract, OO override validation and other language features
+remain explicit source constructs rather than annotations.
+
+## Consequences
+
+Annotations become a stable cross-frontend metadata feature without making the
+compiler execute user code or making annotations a replacement for existing
+language syntax.
+
+The narrow value set keeps parsing, linked metadata, diagnostics, and backend
+reflection portable. Future annotation features can add targets or value forms
+through new ADRs without changing the v1 meaning of annotation prefixes or named
+arguments.

--- a/adr/README.md
+++ b/adr/README.md
@@ -3,6 +3,7 @@
 - [ADR-2026-05-07: `.cfun` Compile-Time Derive v1](ADR-2026-05-07-cfun-derive-v1.md)
 - [ADR-2026-05-08: Reflection v1](ADR-2026-05-08-reflection-v1.md)
 - [ADR-2026-05-21: `.cfun` Empty Data v1](ADR-2026-05-21-cfun-empty-data-v1.md)
+- [ADR-2026-05-24: Declaration Annotations v1](ADR-2026-05-24-declaration-annotations-v1.md)
 - [ADR-2026-04-14: Capybara OO v1 Frontend Boundary](ADR-2026-04-14-capybara-oo-v1.md)
-- [ADR-2026-04-29: `.cfun` `fun rec` Tail-Recursion Contract](ADR-2026-04-29-cfun-rec-tail-recursion.md)
+- [ADR-2026-04-29: `.cfun` `@Recursive` Tail-Recursion Contract](ADR-2026-04-29-cfun-rec-tail-recursion.md)
 - [ADR-2026-04-12: Unsafe Constructor Bypass](2026-04-12-unsafe-constructor-bypass.md)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationQualifiedImportReflection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationQualifiedImportReflection.cfun
@@ -1,0 +1,11 @@
+from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+import AnnotationReflectionDefinitions
+
+@AnnotationReflectionDefinitions.ImportedDataLabel(label: "qualified-import", order: 11)
+data QualifiedImportCustomer {
+    @AnnotationReflectionDefinitions.ImportedFieldName(value: "qualified_id")
+    id: String
+}
+
+fun qualified_import_annotation_reflection_sample(): DataValueInfo =
+    reflection(QualifiedImportCustomer { id: "Q-1" })

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflection.cfun
@@ -1,0 +1,32 @@
+from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+from AnnotationReflectionDefinitions import { ImportedAnnotationMarker, ImportedDataLabel, ImportedFieldName, ImportedFunctionLabel, ImportedMethodLabel }
+
+annotation LocalDataLabel on data {
+    label: String
+}
+
+annotation LocalFieldMarker on field {}
+
+@ImportedAnnotationMarker
+@LocalDataLabel(label: "local")
+@ImportedDataLabel(label: "imported", order: 5)
+data AnnotatedCustomer {
+    @ImportedAnnotationMarker
+    @ImportedFieldName(value: "customer_id")
+    id: String,
+    @LocalFieldMarker
+    display: String
+}
+
+@ImportedFunctionLabel(value: "factory")
+fun make_annotated_customer(id: String, display: String): AnnotatedCustomer =
+    AnnotatedCustomer { id, display }
+
+@ImportedMethodLabel(value: "display")
+fun AnnotatedCustomer.display_name(): String = this.display
+
+fun annotation_reflection_sample(): DataValueInfo =
+    reflection(AnnotatedCustomer { id: "C-1", display: "Ada" })
+
+fun annotation_reflection_data(customer: AnnotatedCustomer): DataValueInfo =
+    reflection(customer)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflectionDefinitions.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflectionDefinitions.cfun
@@ -1,0 +1,19 @@
+annotation ImportedAnnotationMarker on data, field, fun, method {}
+
+annotation ImportedDataLabel on data {
+    label: String
+    order: int = 1
+    active: bool = true
+}
+
+annotation ImportedFieldName on field {
+    value: String
+}
+
+annotation ImportedFunctionLabel on fun {
+    value: String
+}
+
+annotation ImportedMethodLabel on method {
+    value: String
+}

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/DeprecatedAnnotationReflection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/DeprecatedAnnotationReflection.cfun
@@ -1,0 +1,17 @@
+from /capy/meta_prog/Annotations import { Deprecated }
+from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+
+@Deprecated(message: "use CurrentCustomer", since: "2.0")
+data DeprecatedCustomer {
+    @Deprecated(message: "use display_name")
+    name: String
+}
+
+@Deprecated(message: "use CurrentStatus", since: "2.2")
+enum DeprecatedStatus { DEPRECATED_READY, DEPRECATED_DONE }
+
+fun deprecated_annotation_reflection_sample(): DataValueInfo =
+    reflection(DeprecatedCustomer { name: "Ada" })
+
+fun deprecated_enum_annotation_reflection_sample(): DataValueInfo =
+    reflection(DeprecatedStatus.DEPRECATED_READY)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/RecFunctions.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/RecFunctions.cfun
@@ -1,26 +1,32 @@
 from /capy/lang/Result import { Result, Success, Error }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
-fun rec sum(n: int, acc: int): int =
+@Recursive
+fun sum(n: int, acc: int): int =
     if n <= 0 then acc else sum(n - 1, acc + n)
 
 fun sum_inner(n: int): int =
-    fun rec sum(n: int, acc: int): int =
+    @Recursive
+    fun sum(n: int, acc: int): int =
         if n <= 0 then acc else sum(n - 1, acc + n)
     ---
     sum(n, 0)
 
-fun rec sum_with_let(n: int, acc: int): int =
+@Recursive
+fun sum_with_let(n: int, acc: int): int =
     let next_n = n - 1
     let next_acc = acc + n
     if n <= 0 then acc else sum_with_let(next_n, next_acc)
 
-fun rec sum_with_match(n: int, acc: int): int =
+@Recursive
+fun sum_with_match(n: int, acc: int): int =
     match n <= 0 with
     case true -> acc
     case false -> sum_with_match(n - 1, acc + n)
 
-fun rec factorial_large(n: int, acc: int): int =
+@Recursive
+fun factorial_large(n: int, acc: int): int =
     if n <= 1 then acc else factorial_large(n - 1, acc * n)
 
 fun unmarked_tail_sum(n: int, acc: int): int =
@@ -44,7 +50,8 @@ fun unmarked_local_tail_factorial_large(n: int): int =
 fun unmarked_non_tail_sum(n: int): int =
     if n <= 0 then 0 else n + unmarked_non_tail_sum(n - 1)
 
-fun rec sum_present_values(values: List[int], acc: int): int =
+@Recursive
+fun sum_present_values(values: List[int], acc: int): int =
     match values[0] with
     case Some { value } -> sum_present_values(values[1:], acc + value)
     case None -> acc
@@ -54,7 +61,8 @@ private fun parse_length(value: String): Result[int] =
     then Error { message: "bad length" }
     else Success { value: value.size() }
 
-fun rec sum_lengths_until_error(values: List[String], acc: int): String =
+@Recursive
+fun sum_lengths_until_error(values: List[String], acc: int): String =
     match values[0] with
     case Some { value } ->
         {

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ReflectionFeature.cfun
@@ -3,15 +3,34 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 
+annotation ReflectionDataMarker on data {
+    label: String
+    order: int = 1
+    active: bool = true
+}
+
+annotation ReflectionFieldMarker on field {
+    value: String
+}
+
 union Letter { name: String } = A | B
 data A { a: int }
 data B { b: List[String] }
 data ReflectedEmpty {}
 data ReflectedEntity { id: String }
 data ReflectedEmployee { department: String, active: bool, ...ReflectedEntity }
+@ReflectionDataMarker(label: "singleton", order: 2)
 data ReflectedSingleton {}
 enum ReflectedStatus { REFLECTED_READY, REFLECTED_DONE }
 data ReflectedEnvelope { label: String, payload: A }
+
+@ReflectionDataMarker(label: "user", order: 7)
+data ReflectedAnnotatedUser {
+    @ReflectionFieldMarker(value: "identifier")
+    id: String,
+    @ReflectionFieldMarker(value: "display")
+    display: String
+}
 
 union ReflectedJson = ReflectedJsonObject | ReflectedJsonString | ReflectedJsonNumber | ReflectedJsonBool | ReflectedJsonNull
 data ReflectedJsonObject { value: Dict[ReflectedJson] }
@@ -26,6 +45,8 @@ fun reflection_data_b(b: B): DataValueInfo = reflection(b)
 fun reflection_data_empty(): DataValueInfo = reflection(ReflectedEmpty {})
 
 fun reflection_data_employee(employee: ReflectedEmployee): DataValueInfo = reflection(employee)
+
+fun reflection_data_annotated_user(user: ReflectedAnnotatedUser): DataValueInfo = reflection(user)
 
 fun reflection_data(obj: data): DataValueInfo = reflection(obj)
 

--- a/capy/src/e2e-cfun/java/dev/capylang/test/AnnotationReflectionTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/AnnotationReflectionTest.java
@@ -1,0 +1,123 @@
+package dev.capylang.test;
+
+import capy.metaProg.Reflection;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnnotationReflectionTest {
+    @Test
+    void reflectsFunctionalDeclarationAnnotations() {
+        var info = AnnotationReflection.annotationReflectionSample();
+
+        assertThat(info.name()).isEqualTo("AnnotatedCustomer");
+        assertThat(info.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ImportedAnnotationMarker", "LocalDataLabel", "ImportedDataLabel");
+        assertThat(info.annotations().get(0).arguments()).isEmpty();
+        assertThat(info.annotations().get(0).pkg().name())
+                .isEqualTo("AnnotationReflectionDefinitions");
+        assertThat(annotationString(info.annotations().get(1), "label")).isEqualTo("local");
+        assertThat(annotationString(info.annotations().get(2), "label")).isEqualTo("imported");
+        assertThat(annotationInt(info.annotations().get(2), "order")).isEqualTo(5);
+        assertThat(annotationBool(info.annotations().get(2), "active")).isTrue();
+    }
+
+    @Test
+    void reflectsFunctionalFieldAnnotations() {
+        var info = AnnotationReflection.annotationReflectionData(
+                new AnnotationReflection.AnnotatedCustomer("C-2", "Bea"));
+
+        assertThat(info.fields()).extracting(Reflection.FieldValueInfo::name)
+                .containsExactly("id", "display");
+        assertThat(info.fields().get(0).annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ImportedAnnotationMarker", "ImportedFieldName");
+        assertThat(info.fields().get(0).annotations().get(0).arguments()).isEmpty();
+        assertThat(annotationString(info.fields().get(0).annotations().get(1), "value"))
+                .isEqualTo("customer_id");
+        assertThat(info.fields().get(1).annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("LocalFieldMarker");
+        assertThat(info.fields().get(1).value()).isEqualTo("Bea");
+    }
+
+    @Test
+    void reflectsAnnotationsImportedWithQualifiedImportSyntax() {
+        var info = AnnotationQualifiedImportReflection.qualifiedImportAnnotationReflectionSample();
+
+        assertThat(info.name()).isEqualTo("QualifiedImportCustomer");
+        assertThat(info.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ImportedDataLabel");
+        assertThat(info.annotations().getFirst().pkg().name())
+                .isEqualTo("AnnotationReflectionDefinitions");
+        assertThat(annotationString(info.annotations().getFirst(), "label"))
+                .isEqualTo("qualified-import");
+        assertThat(annotationInt(info.annotations().getFirst(), "order"))
+                .isEqualTo(11);
+        assertThat(annotationBool(info.annotations().getFirst(), "active"))
+                .isTrue();
+        assertThat(info.fields().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ImportedFieldName");
+        assertThat(annotationString(info.fields().getFirst().annotations().getFirst(), "value"))
+                .isEqualTo("qualified_id");
+    }
+
+    @Test
+    void reflectsStandardDeprecatedAnnotation() {
+        var info = DeprecatedAnnotationReflection.deprecatedAnnotationReflectionSample();
+
+        assertThat(info.name()).isEqualTo("DeprecatedCustomer");
+        assertThat(info.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("Deprecated");
+        assertThat(info.annotations().getFirst().pkg().name()).isEqualTo("Annotations");
+        assertThat(info.annotations().getFirst().pkg().path()).isEqualTo("capy/meta_prog");
+        assertThat(annotationString(info.annotations().getFirst(), "message"))
+                .isEqualTo("use CurrentCustomer");
+        assertThat(annotationString(info.annotations().getFirst(), "since"))
+                .isEqualTo("2.0");
+
+        assertThat(info.fields().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("Deprecated");
+        assertThat(annotationString(info.fields().getFirst().annotations().getFirst(), "message"))
+                .isEqualTo("use display_name");
+        assertThat(annotationString(info.fields().getFirst().annotations().getFirst(), "since"))
+                .isEmpty();
+    }
+
+    @Test
+    void reflectsStandardDeprecatedAnnotationOnEnumValues() {
+        var info = DeprecatedAnnotationReflection.deprecatedEnumAnnotationReflectionSample();
+
+        assertThat(info.name()).isEqualTo("DEPRECATED_READY");
+        assertThat(info.fields()).isEmpty();
+        assertThat(info.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("Deprecated");
+        assertThat(info.annotations().getFirst().pkg().name()).isEqualTo("Annotations");
+        assertThat(annotationString(info.annotations().getFirst(), "message"))
+                .isEqualTo("use CurrentStatus");
+        assertThat(annotationString(info.annotations().getFirst(), "since"))
+                .isEqualTo("2.2");
+    }
+
+    private static String annotationString(Reflection.AnnotationInfo annotation, String name) {
+        return annotation.arguments().stream()
+                .filter(argument -> argument.name().equals(name))
+                .map(argument -> ((Reflection.AnnotationString) argument.value()).value())
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static int annotationInt(Reflection.AnnotationInfo annotation, String name) {
+        return annotation.arguments().stream()
+                .filter(argument -> argument.name().equals(name))
+                .map(argument -> ((Reflection.AnnotationInt) argument.value()).value())
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static boolean annotationBool(Reflection.AnnotationInfo annotation, String name) {
+        return annotation.arguments().stream()
+                .filter(argument -> argument.name().equals(name))
+                .map(argument -> ((Reflection.AnnotationBool) argument.value()).value())
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/capy/src/e2e-cfun/java/dev/capylang/test/ReflectionFeatureTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/ReflectionFeatureTest.java
@@ -55,6 +55,44 @@ class ReflectionFeatureTest {
     }
 
     @Test
+    void reflectsFunctionalDataValueAnnotations() {
+        var user = ReflectionFeature.reflectionDataAnnotatedUser(
+                new ReflectionFeature.ReflectedAnnotatedUser("U-1", "Ada"));
+
+        assertThat(user.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ReflectionDataMarker");
+        var marker = user.annotations().getFirst();
+        assertThat(marker.pkg().name()).isEqualTo("ReflectionFeature");
+        assertThat(marker.arguments()).extracting(Reflection.AnnotationArgumentInfo::name)
+                .containsExactly("label", "order", "active");
+        assertThat(((Reflection.AnnotationString) marker.arguments().get(0).value()).value()).isEqualTo("user");
+        assertThat(((Reflection.AnnotationInt) marker.arguments().get(1).value()).value()).isEqualTo(7);
+        assertThat(((Reflection.AnnotationBool) marker.arguments().get(2).value()).value()).isTrue();
+    }
+
+    @Test
+    void reflectsFunctionalDataFieldAnnotations() {
+        var user = ReflectionFeature.reflectionDataAnnotatedUser(
+                new ReflectionFeature.ReflectedAnnotatedUser("U-1", "Ada"));
+
+        assertThat(user.fields()).extracting(Reflection.FieldValueInfo::name).containsExactly("id", "display");
+        assertThat(user.fields().get(0).annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ReflectionFieldMarker");
+        var idMarker = user.fields().get(0).annotations().getFirst();
+        assertThat(idMarker.arguments()).extracting(Reflection.AnnotationArgumentInfo::name).containsExactly("value");
+        assertThat(((Reflection.AnnotationString) idMarker.arguments().getFirst().value()).value()).isEqualTo("identifier");
+    }
+
+    @Test
+    void functionalDataAnnotationsDoNotAffectEqualityOrToString() {
+        var first = new ReflectionFeature.ReflectedAnnotatedUser("U-1", "Ada");
+        var second = new ReflectionFeature.ReflectedAnnotatedUser("U-1", "Ada");
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first.toString()).isEqualTo("ReflectedAnnotatedUser { \"id\": \"U-1\", \"display\": \"Ada\" }");
+    }
+
+    @Test
     void reflectionDataPreservesDataInfoMetadataSurface() {
         var a = ReflectionFeature.reflectionDataA(new ReflectionFeature.A("letter-a", 1));
 
@@ -129,6 +167,10 @@ class ReflectionFeatureTest {
 
         assertThat(singleton.name()).isEqualTo("ReflectedSingleton");
         assertThat(singleton.fields()).isEmpty();
+        assertThat(singleton.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("ReflectionDataMarker");
+        assertThat(((Reflection.AnnotationString) singleton.annotations().getFirst().arguments().getFirst().value()).value())
+                .isEqualTo("singleton");
         assertThat(enumValue.name()).isEqualTo("REFLECTED_READY");
         assertThat(enumValue.fields()).isEmpty();
     }

--- a/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
+++ b/capy/src/e2e-cfun/java/dev/capylang/test/compilation_error/CompilationErrorTest.java
@@ -347,6 +347,169 @@ public class CompilationErrorTest {
     }
 
     @Test
+    void shouldRejectMissingAnnotationArgument() {
+        var errors = compileProgram("""
+                        annotation Test on fun {
+                            name: String
+                        }
+
+                        @Test()
+                        fun should_run(): bool = true
+                        """,
+                "annotation_missing_argument");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Missing required annotation argument name for Test"));
+    }
+
+    @Test
+    void shouldRejectUnknownAnnotationArgumentAndWrongAnnotationValueType() {
+        var errors = compileProgram("""
+                        annotation Retry on fun {
+                            retries: int
+                        }
+
+                        @Retry(retries: "three", label: "bad")
+                        fun should_run(): bool = true
+                        """,
+                "annotation_bad_arguments");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Annotation argument retries for Retry expects int, got String"));
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Unknown annotation argument label for Retry"));
+    }
+
+    @Test
+    void shouldRejectDuplicateAnnotationArgument() {
+        var errors = compileProgram("""
+                        annotation Retry on fun {
+                            retries: int = 1
+                        }
+
+                        @Retry(retries: 1, retries: 2)
+                        fun should_run(): bool = true
+                        """,
+                "annotation_duplicate_argument");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Duplicate annotation argument retries for Retry"));
+    }
+
+    @Test
+    void shouldRejectUnknownFunctionalAnnotation() {
+        var errors = compileProgram("""
+                        @Missing()
+                        fun should_run(): bool = true
+                        """,
+                "annotation_unknown");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Unknown annotation Missing"));
+    }
+
+    @Test
+    void shouldRejectUnimportedAnnotation() {
+        var result = CapybaraCompiler.INSTANCE.compile(List.of(
+                new RawModule("Annotations", "/foo/meta", "annotation Test on fun {}"),
+                new RawModule("Tests", "/foo/boo", """
+                        @Test()
+                        fun should_run(): bool = true
+                        """)
+        ), new TreeSet<>());
+
+        assertThat(result).isInstanceOf(Result.Error.class);
+        assertThat(((Result.Error<?>) result).errors())
+                .anySatisfy(error -> assertThat(error.message()).contains("Unknown annotation Test"));
+    }
+
+    @Test
+    void shouldRejectFunctionalAnnotationTargetMismatch() {
+        var errors = compileProgram("""
+                        annotation MethodOnly on method {}
+
+                        @MethodOnly()
+                        fun should_run(): bool = true
+                        """,
+                "annotation_invalid_function_target");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Annotation MethodOnly is not valid on function declarations"));
+    }
+
+    @Test
+    void shouldRejectUnimportedRecursiveAnnotation() {
+        var errors = compileProgram("""
+                        @Recursive
+                        fun should_run(): bool = true
+                        """,
+                "annotation_recursive_unimported");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Unknown annotation Recursive"));
+    }
+
+    @Test
+    void shouldRejectRecursiveAnnotationOnFunctionalMethod() {
+        var errors = compileProgram("""
+                        from /capy/meta_prog/Recursive import { Recursive }
+
+                        data Counter { value: int }
+
+                        @Recursive
+                        fun Counter.count_down(): int = this.count_down()
+                        """,
+                "annotation_recursive_functional_method");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("`@Recursive` is supported for functions, not method declarations"));
+    }
+
+    @Test
+    void shouldRejectUserDefinedAnnotationOnLocalFunction() {
+        var errors = compileProgram("""
+                        annotation LocalMarker on fun {}
+
+                        fun run(): int =
+                            @LocalMarker()
+                            fun __local(): int = 1
+                            ---
+                            __local()
+                        """,
+                "annotation_local_function");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Only `@Recursive` is supported on local function declarations"));
+    }
+
+    @Test
+    void shouldRejectOldRecFunctionKeywordSyntax() {
+        var errors = compileProgram("""
+                        fun rec sum(n: int): int = sum(n - 1)
+                        """,
+                "rec_keyword_removed");
+
+        assertThat(errors).isNotEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidFunctionalAnnotationSyntax")
+    void shouldRejectInvalidFunctionalAnnotationSyntax(String moduleName, String source) {
+        var errors = compileProgram(source, moduleName);
+
+        assertThat(errors).isNotEmpty();
+    }
+
+    @Test
     void shouldRejectUnknownDeriver() {
         var errors = compileProgram("""
                         data User { name: String } derive Missing
@@ -499,7 +662,10 @@ public class CompilationErrorTest {
     @Test
     void shouldRejectRecFunctionWithNonTailRecursiveCall() {
         var errors = compileProgram("""
-                        fun rec sum(n: int): int = n + sum(n - 1)
+                        from /capy/meta_prog/Recursive import { Recursive }
+
+                        @Recursive
+                        fun sum(n: int): int = n + sum(n - 1)
                         """,
                 "rec_function_non_tail_call");
 
@@ -511,20 +677,26 @@ public class CompilationErrorTest {
     @Test
     void shouldRejectRecFunctionWithoutSelfCall() {
         var errors = compileProgram("""
-                        fun rec sum(n: int): int = n - 1
+                        from /capy/meta_prog/Recursive import { Recursive }
+
+                        @Recursive
+                        fun sum(n: int): int = n - 1
                         """,
                 "rec_function_without_self_call");
 
         assertThat(errors).hasSize(1);
         assertThat(errors.first().message())
-                .contains("`fun rec` function `sum` must call itself in tail position");
+                .contains("`@Recursive` function `sum` must call itself in tail position");
     }
 
     @Test
     void shouldRejectRecLocalFunctionWithNonTailRecursiveCall() {
         var errors = compileProgram("""
+                        from /capy/meta_prog/Recursive import { Recursive }
+
                         fun sum(n: int): int =
-                            fun rec __sum(n: int): int = n + __sum(n - 1)
+                            @Recursive
+                            fun __sum(n: int): int = n + __sum(n - 1)
                             ---
                             __sum(n)
                         """,
@@ -539,8 +711,11 @@ public class CompilationErrorTest {
     @Test
     void shouldRejectRecLocalFunctionWithoutSelfCall() {
         var errors = compileProgram("""
+                        from /capy/meta_prog/Recursive import { Recursive }
+
                         fun sum(n: int): int =
-                            fun rec __sum(n: int): int = n - 1
+                            @Recursive
+                            fun __sum(n: int): int = n - 1
                             ---
                             __sum(n)
                         """,
@@ -548,7 +723,7 @@ public class CompilationErrorTest {
 
         assertThat(errors).hasSize(1);
         assertThat(errors.first().message())
-                .contains("`fun rec` function `sum` must call itself in tail position")
+                .contains("`@Recursive` function `sum` must call itself in tail position")
                 .doesNotContain("__local_fun_");
     }
 
@@ -1820,6 +1995,44 @@ public class CompilationErrorTest {
         );
     }
 
+    private static Stream<Arguments> invalidFunctionalAnnotationSyntax() {
+        return Stream.of(
+                Arguments.of(
+                        "annotation_empty_call",
+                        """
+                                @()
+                                fun broken(): bool = true
+                                """
+                ),
+                Arguments.of(
+                        "annotation_comma_separated_prefix",
+                        """
+                                @A(), @B()
+                                fun broken(): bool = true
+                                """
+                ),
+                Arguments.of(
+                        "annotation_positional_argument",
+                        """
+                                annotation Label on fun {
+                                    value: String
+                                }
+
+                                @Label("bad")
+                                fun broken(): bool = true
+                                """
+                ),
+                Arguments.of(
+                        "annotation_after_declaration_start",
+                        """
+                                annotation Label on fun {}
+
+                                fun @Label() broken(): bool = true
+                                """
+                )
+        );
+    }
+
 
     private static SortedSet<Result.Error.SingleError> compileProgram(String fun, String moduleName) {
         return compileProgram(fun, moduleName, List.of());
@@ -1847,6 +2060,9 @@ public class CompilationErrorTest {
                     union Name[T] = Foo[T] | Boo
                     data Foo[T] { value: T }
                     data Boo { message: String }
+                    """),
+            new RawModule("Recursive", "/capy/meta_prog", """
+                    annotation Recursive on fun {}
                     """)
     );
 

--- a/capy/src/e2e-cfun/js/dev/capylang/test/AnnotationReflection.test.js
+++ b/capy/src/e2e-cfun/js/dev/capylang/test/AnnotationReflection.test.js
@@ -1,0 +1,84 @@
+const test = require('node:test');
+const { assert, generatedModule } = require('./_support');
+
+test('reflects functional declaration annotations', () => {
+    const annotations = generatedModule('dev/capylang/test/AnnotationReflection.js');
+    const info = annotations.annotationReflectionSample();
+
+    assert.equal(info.name, 'AnnotatedCustomer');
+    assert.deepEqual(info.annotations.map(annotation => annotation.name), [
+        'ImportedAnnotationMarker',
+        'LocalDataLabel',
+        'ImportedDataLabel',
+    ]);
+    assert.deepEqual(info.annotations[0].arguments, []);
+    assert.equal(info.annotations[0].pkg.name, 'AnnotationReflectionDefinitions');
+    assert.equal(annotationArgument(info.annotations[1], 'label').value.value, 'local');
+    assert.equal(annotationArgument(info.annotations[2], 'label').value.value, 'imported');
+    assert.equal(annotationArgument(info.annotations[2], 'order').value.value, 5);
+    assert.equal(annotationArgument(info.annotations[2], 'active').value.value, true);
+});
+
+test('reflects functional field annotations', () => {
+    const annotations = generatedModule('dev/capylang/test/AnnotationReflection.js');
+    const info = annotations.annotationReflectionData(new annotations.AnnotatedCustomer({
+        id: 'C-2',
+        display: 'Bea',
+    }));
+
+    assert.deepEqual(info.fields.map(field => field.name), ['id', 'display']);
+    assert.deepEqual(info.fields[0].annotations.map(annotation => annotation.name), [
+        'ImportedAnnotationMarker',
+        'ImportedFieldName',
+    ]);
+    assert.deepEqual(info.fields[0].annotations[0].arguments, []);
+    assert.equal(annotationArgument(info.fields[0].annotations[1], 'value').value.value, 'customer_id');
+    assert.deepEqual(info.fields[1].annotations.map(annotation => annotation.name), ['LocalFieldMarker']);
+    assert.equal(info.fields[1].value, 'Bea');
+});
+
+test('reflects annotations imported with qualified import syntax', () => {
+    const annotations = generatedModule('dev/capylang/test/AnnotationQualifiedImportReflection.js');
+    const info = annotations.qualifiedImportAnnotationReflectionSample();
+
+    assert.equal(info.name, 'QualifiedImportCustomer');
+    assert.deepEqual(info.annotations.map(annotation => annotation.name), ['ImportedDataLabel']);
+    assert.equal(info.annotations[0].pkg.name, 'AnnotationReflectionDefinitions');
+    assert.equal(annotationArgument(info.annotations[0], 'label').value.value, 'qualified-import');
+    assert.equal(annotationArgument(info.annotations[0], 'order').value.value, 11);
+    assert.equal(annotationArgument(info.annotations[0], 'active').value.value, true);
+    assert.deepEqual(info.fields[0].annotations.map(annotation => annotation.name), ['ImportedFieldName']);
+    assert.equal(annotationArgument(info.fields[0].annotations[0], 'value').value.value, 'qualified_id');
+});
+
+test('reflects standard Deprecated annotation', () => {
+    const annotations = generatedModule('dev/capylang/test/DeprecatedAnnotationReflection.js');
+    const info = annotations.deprecatedAnnotationReflectionSample();
+
+    assert.equal(info.name, 'DeprecatedCustomer');
+    assert.deepEqual(info.annotations.map(annotation => annotation.name), ['Deprecated']);
+    assert.equal(info.annotations[0].pkg.name, 'Annotations');
+    assert.equal(info.annotations[0].pkg.path, 'capy/meta_prog');
+    assert.equal(annotationArgument(info.annotations[0], 'message').value.value, 'use CurrentCustomer');
+    assert.equal(annotationArgument(info.annotations[0], 'since').value.value, '2.0');
+
+    assert.deepEqual(info.fields[0].annotations.map(annotation => annotation.name), ['Deprecated']);
+    assert.equal(annotationArgument(info.fields[0].annotations[0], 'message').value.value, 'use display_name');
+    assert.equal(annotationArgument(info.fields[0].annotations[0], 'since').value.value, '');
+});
+
+test('reflects standard Deprecated annotation on enum values', () => {
+    const annotations = generatedModule('dev/capylang/test/DeprecatedAnnotationReflection.js');
+    const info = annotations.deprecatedEnumAnnotationReflectionSample();
+
+    assert.equal(info.name, 'DEPRECATED_READY');
+    assert.deepEqual(info.fields, []);
+    assert.deepEqual(info.annotations.map(annotation => annotation.name), ['Deprecated']);
+    assert.equal(info.annotations[0].pkg.name, 'Annotations');
+    assert.equal(annotationArgument(info.annotations[0], 'message').value.value, 'use CurrentStatus');
+    assert.equal(annotationArgument(info.annotations[0], 'since').value.value, '2.2');
+});
+
+function annotationArgument(annotation, name) {
+    return annotation.arguments.find(argument => argument.name === name);
+}

--- a/capy/src/e2e-cfun/js/dev/capylang/test/ReflectionFeature.test.js
+++ b/capy/src/e2e-cfun/js/dev/capylang/test/ReflectionFeature.test.js
@@ -16,6 +16,10 @@ test('ReflectionFeature', () => {
     const employee = reflection.reflectionDataEmployee(new reflection.ReflectedEmployee({ id: 'E-1', department: 'R&D', active: true }));
     assert.deepEqual(employee.fields.map(field => field.name), ['id', 'department', 'active']);
     assert.deepEqual(employee.fields.map(field => field.value), ['E-1', 'R&D', true]);
+    const singleton = reflection.reflectionData(reflection.ReflectedSingleton);
+    assert.equal(singleton.name, 'ReflectedSingleton');
+    assert.deepEqual(singleton.annotations.map(annotation => annotation.name), ['ReflectionDataMarker']);
+    assert.equal(annotationArgument(singleton.annotations[0], 'label').value.value, 'singleton');
     const json = reflection.reflectionJsonShape(new reflection.ReflectedEnvelope({
         label: 'outer',
         payload: new reflection.A({ name: 'inner', a: 7 }),
@@ -24,3 +28,27 @@ test('ReflectionFeature', () => {
     assert.equal(json.value.get('payload').value.get('name').value, 'inner');
     assert.equal(json.value.get('payload').value.get('a').value, 7);
 });
+
+test('reflects functional data and field annotations', () => {
+    const reflection = generatedModule('dev/capylang/test/ReflectionFeature.js');
+    const reflected = reflection.reflectionDataAnnotatedUser(new reflection.ReflectedAnnotatedUser({
+        id: 'U-1',
+        display: 'Ada',
+    }));
+
+    assert.deepEqual(reflected.annotations.map(annotation => annotation.name), ['ReflectionDataMarker']);
+    assert.equal(annotationArgument(reflected.annotations[0], 'label').value.value, 'user');
+    assert.equal(annotationArgument(reflected.annotations[0], 'label').value.kind, 'string');
+    assert.equal(annotationArgument(reflected.annotations[0], 'order').value.value, 7);
+    assert.equal(annotationArgument(reflected.annotations[0], 'active').value.value, true);
+    assert.equal(reflected.pkg.path, 'dev/capylang/test/ReflectionFeature');
+
+    assert.deepEqual(reflected.fields.map(field => field.annotations[0].name), ['ReflectionFieldMarker', 'ReflectionFieldMarker']);
+    assert.equal(annotationArgument(reflected.fields[0].annotations[0], 'value').value.value, 'identifier');
+    assert.equal(annotationArgument(reflected.fields[1].annotations[0], 'value').value.value, 'display');
+    assert.deepEqual(reflected.fields.map(field => field.type.name), ['String', 'String']);
+});
+
+function annotationArgument(annotation, name) {
+    return annotation.arguments.find(argument => argument.name === name);
+}

--- a/capy/src/e2e-cfun/py/dev/capylang/test/annotation_reflection_test.py
+++ b/capy/src/e2e-cfun/py/dev/capylang/test/annotation_reflection_test.py
@@ -1,0 +1,85 @@
+import os
+import pathlib
+import sys
+import unittest
+
+
+generated_dir = pathlib.Path(os.environ["CAPY_E2E_CFUN_PY_GENERATED_DIR"])
+sys.path.insert(0, str(generated_dir))
+
+import dev.capylang.test.AnnotationReflection as annotations
+import dev.capylang.test.AnnotationQualifiedImportReflection as qualified_import_annotations
+import dev.capylang.test.DeprecatedAnnotationReflection as deprecated_annotations
+
+
+def annotation_argument(annotation, name):
+    return next(argument for argument in annotation.arguments if argument.name == name)
+
+
+class AnnotationReflectionPythonE2ETest(unittest.TestCase):
+    def test_reflects_functional_declaration_annotations(self):
+        info = annotations.annotationReflectionSample()
+
+        self.assertEqual(info.name, "AnnotatedCustomer")
+        self.assertEqual(
+            [annotation.name for annotation in info.annotations],
+            ["ImportedAnnotationMarker", "LocalDataLabel", "ImportedDataLabel"],
+        )
+        self.assertEqual(info.annotations[0].arguments, [])
+        self.assertEqual(info.annotations[0].pkg.name, "AnnotationReflectionDefinitions")
+        self.assertEqual(annotation_argument(info.annotations[1], "label").value.value, "local")
+        self.assertEqual(annotation_argument(info.annotations[2], "label").value.value, "imported")
+        self.assertEqual(annotation_argument(info.annotations[2], "order").value.value, 5)
+        self.assertEqual(annotation_argument(info.annotations[2], "active").value.value, True)
+
+    def test_reflects_functional_field_annotations(self):
+        info = annotations.annotationReflectionData(annotations.AnnotatedCustomer({
+            "id": "C-2",
+            "display": "Bea",
+        }))
+
+        self.assertEqual([field.name for field in info.fields], ["id", "display"])
+        self.assertEqual(
+            [annotation.name for annotation in info.fields[0].annotations],
+            ["ImportedAnnotationMarker", "ImportedFieldName"],
+        )
+        self.assertEqual(info.fields[0].annotations[0].arguments, [])
+        self.assertEqual(annotation_argument(info.fields[0].annotations[1], "value").value.value, "customer_id")
+        self.assertEqual([annotation.name for annotation in info.fields[1].annotations], ["LocalFieldMarker"])
+        self.assertEqual(info.fields[1].value, "Bea")
+
+    def test_reflects_annotations_imported_with_qualified_import_syntax(self):
+        info = qualified_import_annotations.qualifiedImportAnnotationReflectionSample()
+
+        self.assertEqual(info.name, "QualifiedImportCustomer")
+        self.assertEqual([annotation.name for annotation in info.annotations], ["ImportedDataLabel"])
+        self.assertEqual(info.annotations[0].pkg.name, "AnnotationReflectionDefinitions")
+        self.assertEqual(annotation_argument(info.annotations[0], "label").value.value, "qualified-import")
+        self.assertEqual(annotation_argument(info.annotations[0], "order").value.value, 11)
+        self.assertEqual(annotation_argument(info.annotations[0], "active").value.value, True)
+        self.assertEqual([annotation.name for annotation in info.fields[0].annotations], ["ImportedFieldName"])
+        self.assertEqual(annotation_argument(info.fields[0].annotations[0], "value").value.value, "qualified_id")
+
+    def test_reflects_standard_deprecated_annotation(self):
+        info = deprecated_annotations.deprecatedAnnotationReflectionSample()
+
+        self.assertEqual(info.name, "DeprecatedCustomer")
+        self.assertEqual([annotation.name for annotation in info.annotations], ["Deprecated"])
+        self.assertEqual(info.annotations[0].pkg.name, "Annotations")
+        self.assertEqual(info.annotations[0].pkg.path, "capy/meta_prog")
+        self.assertEqual(annotation_argument(info.annotations[0], "message").value.value, "use CurrentCustomer")
+        self.assertEqual(annotation_argument(info.annotations[0], "since").value.value, "2.0")
+
+        self.assertEqual([annotation.name for annotation in info.fields[0].annotations], ["Deprecated"])
+        self.assertEqual(annotation_argument(info.fields[0].annotations[0], "message").value.value, "use display_name")
+        self.assertEqual(annotation_argument(info.fields[0].annotations[0], "since").value.value, "")
+
+    def test_reflects_standard_deprecated_annotation_on_enum_values(self):
+        info = deprecated_annotations.deprecatedEnumAnnotationReflectionSample()
+
+        self.assertEqual(info.name, "DEPRECATED_READY")
+        self.assertEqual(info.fields, [])
+        self.assertEqual([annotation.name for annotation in info.annotations], ["Deprecated"])
+        self.assertEqual(info.annotations[0].pkg.name, "Annotations")
+        self.assertEqual(annotation_argument(info.annotations[0], "message").value.value, "use CurrentStatus")
+        self.assertEqual(annotation_argument(info.annotations[0], "since").value.value, "2.2")

--- a/capy/src/e2e-cfun/py/dev/capylang/test/reflection_feature_test.py
+++ b/capy/src/e2e-cfun/py/dev/capylang/test/reflection_feature_test.py
@@ -1,0 +1,44 @@
+import os
+import pathlib
+import sys
+import unittest
+
+
+generated_dir = pathlib.Path(os.environ["CAPY_E2E_CFUN_PY_GENERATED_DIR"])
+sys.path.insert(0, str(generated_dir))
+
+import dev.capylang.test.ReflectionFeature as reflection
+
+
+def annotation_argument(annotation, name):
+    return next(argument for argument in annotation.arguments if argument.name == name)
+
+
+class ReflectionFeaturePythonE2ETest(unittest.TestCase):
+    def test_reflection_returns_data_value_fields(self):
+        reflected = reflection.reflectionDataA(reflection.A({"name": "letter-a", "a": 1}))
+
+        self.assertEqual(reflected.name, "A")
+        self.assertEqual([field.name for field in reflected.fields], ["name", "a"])
+        self.assertEqual([field.value for field in reflected.fields], ["letter-a", 1])
+
+    def test_reflection_returns_functional_data_and_field_annotations(self):
+        reflected = reflection.reflectionDataAnnotatedUser(reflection.ReflectedAnnotatedUser({
+            "id": "U-1",
+            "display": "Ada",
+        }))
+
+        self.assertEqual([annotation.name for annotation in reflected.annotations], ["ReflectionDataMarker"])
+        self.assertEqual(annotation_argument(reflected.annotations[0], "label").value.kind, "string")
+        self.assertEqual(annotation_argument(reflected.annotations[0], "label").value.value, "user")
+        self.assertEqual(annotation_argument(reflected.annotations[0], "order").value.value, 7)
+        self.assertEqual(annotation_argument(reflected.annotations[0], "active").value.value, True)
+        self.assertEqual(reflected.pkg.path, "dev/capylang/test/ReflectionFeature")
+
+        self.assertEqual(
+            [field.annotations[0].name for field in reflected.fields],
+            ["ReflectionFieldMarker", "ReflectionFieldMarker"],
+        )
+        self.assertEqual(annotation_argument(reflected.fields[0].annotations[0], "value").value.value, "identifier")
+        self.assertEqual(annotation_argument(reflected.fields[1].annotations[0], "value").value.value, "display")
+        self.assertEqual([field.type.name for field in reflected.fields], ["String", "String"])

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotationDefinitions.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotationDefinitions.cfun
@@ -1,0 +1,13 @@
+annotation OoAnnotationMarker on class, interface, trait, field, method {}
+
+annotation OoTypeLabel on class, interface, trait {
+    label: String
+}
+
+annotation OoFieldName on field {
+    value: String
+}
+
+annotation OoMethodName on method {
+    value: String
+}

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotations.coo
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotations.coo
@@ -1,0 +1,32 @@
+from /dev/capylang/test/ObjectOrientedAnnotationDefinitions import { OoAnnotationMarker, OoTypeLabel, OoFieldName, OoMethodName }
+from /capy/meta_prog/Annotations import { Deprecated }
+
+@OoAnnotationMarker
+@OoTypeLabel(label: "contract")
+@Deprecated(message: "use AnnotatedContractV2")
+interface AnnotatedContract {
+    @OoMethodName(value: "render")
+    def render(): String
+}
+
+@OoAnnotationMarker
+@OoTypeLabel(label: "mixin")
+@Deprecated(message: "use AnnotatedNamingV2", since: "3.0")
+trait AnnotatedNaming {
+    @OoMethodName(value: "prefix")
+    def prefix(value: String): String = "@" + value
+}
+
+@OoAnnotationMarker
+@OoTypeLabel(label: "entity")
+@Deprecated(message: "use AnnotatedView", since: "3.0")
+class AnnotatedWidget(name: String): AnnotatedContract, AnnotatedNaming {
+    @OoAnnotationMarker
+    @OoFieldName(value: "display_name")
+    @Deprecated(message: "use label")
+    field name: String = name
+
+    @OoMethodName(value: "render")
+    @Deprecated(message: "use render_label", since: "3.1")
+    override def render(): String = this.prefix(this.name)
+}

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedFpInterop.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedFpInterop.cfun
@@ -1,3 +1,5 @@
+from /capy/meta_prog/Recursive import { Recursive }
+
 union InteropPet = InteropDog | InteropCat
 data InteropDog { name: String }
 data InteropCat { age: int }
@@ -27,5 +29,6 @@ fun maybe_text(value: InteropMaybe): String =
 
 fun RecInteropValue.step(delta: int): int = this.value + delta
 
-fun rec step(n: int, value: RecInteropValue, acc: int): int =
+@Recursive
+fun step(n: int, value: RecInteropValue, acc: int): int =
     if n <= 0 then acc else step(n - 1, value, acc + value.step(n))

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedReflection.coo
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedReflection.coo
@@ -1,15 +1,25 @@
+from /dev/capylang/test/ObjectOrientedReflectionAnnotations import { CooTypeMarker, CooFieldMarker, CooMethodMarker }
+
+@CooTypeMarker(label: "contract")
 interface X {
+    @CooMethodMarker(value: "print")
     def print(): String
 }
 
+@CooTypeMarker(label: "mixin")
 trait Y {
+    @CooMethodMarker(value: "bracket")
     def bracket(name: String): String = "[" + name + "]"
 }
 
+@CooTypeMarker(label: "entity")
 class Z(name: String): X, Y {
+    @CooFieldMarker(value: "display_name")
     field name: String = name
 
+    @CooMethodMarker(value: "greet")
     def greet(): String = this.bracket(this.name)
 
+    @CooMethodMarker(value: "print")
     override def print(): String = this.greet()
 }

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedReflectionAnnotations.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedReflectionAnnotations.cfun
@@ -1,0 +1,11 @@
+annotation CooTypeMarker on class, interface, trait {
+    label: String
+}
+
+annotation CooFieldMarker on field {
+    value: String
+}
+
+annotation CooMethodMarker on method {
+    value: String
+}

--- a/capy/src/e2e-coo/java/dev/capylang/test/ObjectOrientedAnnotationsTest.java
+++ b/capy/src/e2e-coo/java/dev/capylang/test/ObjectOrientedAnnotationsTest.java
@@ -1,0 +1,75 @@
+package dev.capylang.test;
+
+import capy.metaProg.Reflection;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectOrientedAnnotationsTest {
+    @Test
+    void reflectsInterfaceAndTraitAnnotations() {
+        var contract = AnnotatedContract.type();
+        var naming = AnnotatedNaming.type();
+
+        assertThat(contract.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("OoAnnotationMarker", "OoTypeLabel", "Deprecated");
+        assertThat(contract.annotations().getFirst().arguments()).isEmpty();
+        assertThat(contract.annotations().getFirst().pkg().name())
+                .isEqualTo("ObjectOrientedAnnotationDefinitions");
+        assertThat(annotationString(contract.annotations().get(1), "label")).isEqualTo("contract");
+        assertThat(annotationString(contract.annotations().get(2), "message")).isEqualTo("use AnnotatedContractV2");
+        assertThat(annotationString(contract.annotations().get(2), "since")).isEmpty();
+        assertThat(contract.methods()).extracting(Reflection.MethodInfo::name).containsExactly("render");
+        assertThat(contract.methods().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("OoMethodName");
+
+        assertThat(naming.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("OoAnnotationMarker", "OoTypeLabel", "Deprecated");
+        assertThat(annotationString(naming.annotations().get(1), "label")).isEqualTo("mixin");
+        assertThat(annotationString(naming.annotations().get(2), "message")).isEqualTo("use AnnotatedNamingV2");
+        assertThat(annotationString(naming.annotations().get(2), "since")).isEqualTo("3.0");
+        assertThat(naming.methods()).extracting(Reflection.MethodInfo::name).containsExactly("prefix");
+    }
+
+    @Test
+    void reflectsClassFieldAndMethodAnnotations() {
+        var widget = AnnotatedWidget.type();
+
+        assertThat(widget.annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("OoAnnotationMarker", "OoTypeLabel", "Deprecated");
+        assertThat(annotationString(widget.annotations().get(1), "label")).isEqualTo("entity");
+        assertThat(widget.annotations().get(2).pkg().name()).isEqualTo("Annotations");
+        assertThat(widget.annotations().get(2).pkg().path()).isEqualTo("capy/meta_prog");
+        assertThat(annotationString(widget.annotations().get(2), "message")).isEqualTo("use AnnotatedView");
+        assertThat(annotationString(widget.annotations().get(2), "since")).isEqualTo("3.0");
+        assertThat(widget.parents()).extracting(parent -> ((Reflection.AnyInfo) parent).name())
+                .containsExactlyInAnyOrder("AnnotatedContract", "AnnotatedNaming");
+        assertThat(widget.fields()).extracting(Reflection.FieldInfo::name).containsExactly("name");
+        assertThat(widget.fields().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("OoAnnotationMarker", "OoFieldName", "Deprecated");
+        assertThat(widget.fields().getFirst().annotations().getFirst().arguments()).isEmpty();
+        assertThat(annotationString(widget.fields().getFirst().annotations().get(1), "value"))
+                .isEqualTo("display_name");
+        assertThat(annotationString(widget.fields().getFirst().annotations().get(2), "message"))
+                .isEqualTo("use label");
+        assertThat(annotationString(widget.fields().getFirst().annotations().get(2), "since"))
+                .isEmpty();
+        assertThat(widget.methods()).extracting(Reflection.MethodInfo::name).containsExactly("render");
+        assertThat(widget.methods().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("OoMethodName", "Deprecated");
+        assertThat(annotationString(widget.methods().getFirst().annotations().getFirst(), "value"))
+                .isEqualTo("render");
+        assertThat(annotationString(widget.methods().getFirst().annotations().get(1), "message"))
+                .isEqualTo("use render_label");
+        assertThat(annotationString(widget.methods().getFirst().annotations().get(1), "since"))
+                .isEqualTo("3.1");
+    }
+
+    private static String annotationString(Reflection.AnnotationInfo annotation, String name) {
+        return annotation.arguments().stream()
+                .filter(argument -> argument.name().equals(name))
+                .map(argument -> ((Reflection.AnnotationString) argument.value()).value())
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/capy/src/e2e-coo/java/dev/capylang/test/ObjectOrientedReflectionTest.java
+++ b/capy/src/e2e-coo/java/dev/capylang/test/ObjectOrientedReflectionTest.java
@@ -11,7 +11,11 @@ class ObjectOrientedReflectionTest {
         var x = X.type();
 
         assertThat(x.name()).isEqualTo("X");
+        assertThat(x.annotations()).extracting(Reflection.AnnotationInfo::name).containsExactly("CooTypeMarker");
+        assertThat(annotationString(x.annotations().getFirst(), "label")).isEqualTo("contract");
         assertThat(x.methods()).extracting(Reflection.MethodInfo::name).containsExactly("print");
+        assertThat(x.methods().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("CooMethodMarker");
         assertThat(x.parents()).isEmpty();
     }
 
@@ -20,6 +24,8 @@ class ObjectOrientedReflectionTest {
         var y = Y.type();
 
         assertThat(y.name()).isEqualTo("Y");
+        assertThat(y.annotations()).extracting(Reflection.AnnotationInfo::name).containsExactly("CooTypeMarker");
+        assertThat(annotationString(y.annotations().getFirst(), "label")).isEqualTo("mixin");
         assertThat(y.methods()).extracting(Reflection.MethodInfo::name).containsExactly("bracket");
         assertThat(y.parents()).isEmpty();
     }
@@ -30,9 +36,26 @@ class ObjectOrientedReflectionTest {
 
         assertThat(z.name()).isEqualTo("Z");
         assertThat(z.open()).isFalse();
+        assertThat(z.annotations()).extracting(Reflection.AnnotationInfo::name).containsExactly("CooTypeMarker");
+        assertThat(annotationString(z.annotations().getFirst(), "label")).isEqualTo("entity");
         assertThat(z.fields()).extracting(Reflection.FieldInfo::name).containsExactly("name");
+        assertThat(z.fields().getFirst().annotations()).extracting(Reflection.AnnotationInfo::name)
+                .containsExactly("CooFieldMarker");
+        assertThat(annotationString(z.fields().getFirst().annotations().getFirst(), "value"))
+                .isEqualTo("display_name");
         assertThat(z.methods()).extracting(Reflection.MethodInfo::name).containsExactlyInAnyOrder("greet", "print");
+        assertThat(z.methods()).allSatisfy(method ->
+                assertThat(method.annotations()).extracting(Reflection.AnnotationInfo::name)
+                        .containsExactly("CooMethodMarker"));
         assertThat(z.parents()).extracting(parent -> ((Reflection.AnyInfo) parent).name())
                 .containsExactlyInAnyOrder("X", "Y");
+    }
+
+    private static String annotationString(Reflection.AnnotationInfo annotation, String name) {
+        return annotation.arguments().stream()
+                .filter(argument -> argument.name().equals(name))
+                .map(argument -> ((Reflection.AnnotationString) argument.value()).value())
+                .findFirst()
+                .orElseThrow();
     }
 }

--- a/capy/src/e2e-coo/java/dev/capylang/test/compilation_error/ObjectOrientedCompilationErrorTest.java
+++ b/capy/src/e2e-coo/java/dev/capylang/test/compilation_error/ObjectOrientedCompilationErrorTest.java
@@ -7,9 +7,14 @@ import dev.capylang.generator.JavaGenerator;
 import dev.capylang.compiler.parser.RawModule;
 import dev.capylang.compiler.parser.SourceKind;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -235,6 +240,127 @@ class ObjectOrientedCompilationErrorTest {
     }
 
     @Test
+    void shouldRejectObjectOrientedAnnotationTargetMismatch() {
+        var result = CapybaraCompiler.INSTANCE.compile(List.of(
+                new RawModule("Annotations", "/foo/meta", "annotation Entity on class {}"),
+                new RawModule(
+                        "User",
+                        "/foo/boo",
+                        """
+                                from /foo/meta/Annotations import { Entity }
+
+                                class User {
+                                    @Entity()
+                                    field name: String = "name"
+                                }
+                                """,
+                        SourceKind.OBJECT_ORIENTED
+                )
+        ), new TreeSet<>());
+
+        assertThat(result).isInstanceOf(Result.Error.class);
+        assertThat(((Result.Error<?>) result).errors())
+                .anySatisfy(error -> {
+                    assertThat(error.file()).isEqualTo("/foo/boo/User.coo");
+                    assertThat(error.message()).contains("Annotation Entity is not valid on field declarations");
+                });
+    }
+
+    @Test
+    void shouldRejectUnknownObjectOrientedAnnotation() {
+        var result = CapybaraCompiler.INSTANCE.compile(List.of(
+                new RawModule(
+                        "User",
+                        "/foo/boo",
+                        """
+                                @Missing()
+                                class User {
+                                }
+                                """,
+                        SourceKind.OBJECT_ORIENTED
+                )
+        ), new TreeSet<>());
+
+        assertThat(result).isInstanceOf(Result.Error.class);
+        assertThat(((Result.Error<?>) result).errors())
+                .anySatisfy(error -> {
+                    assertThat(error.file()).isEqualTo("/foo/boo/User.coo");
+                    assertThat(error.message()).contains("Unknown annotation Missing");
+                });
+    }
+
+    @Test
+    void shouldRejectRecursiveAnnotationOnObjectOrientedMethod() {
+        var errors = compileObjectOrientedSource(
+                "Worker",
+                """
+                        from /capy/meta_prog/Recursive import { Recursive }
+
+                        class Worker {
+                            @Recursive
+                            def run(): int = this.run()
+                        }
+                        """,
+                List.of(new RawModule("Recursive", "/capy/meta_prog", "annotation Recursive on fun {}"))
+        );
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("`@Recursive` is supported for functions, not method declarations"));
+    }
+
+    @Test
+    void shouldRejectUnimportedObjectOrientedAnnotation() {
+        var result = CapybaraCompiler.INSTANCE.compile(List.of(
+                new RawModule("Annotations", "/foo/meta", "annotation Entity on class {}"),
+                new RawModule(
+                        "User",
+                        "/foo/boo",
+                        """
+                                @Entity()
+                                class User {
+                                }
+                                """,
+                        SourceKind.OBJECT_ORIENTED
+                )
+        ), new TreeSet<>());
+
+        assertThat(result).isInstanceOf(Result.Error.class);
+        assertThat(((Result.Error<?>) result).errors())
+                .anySatisfy(error -> {
+                    assertThat(error.file()).isEqualTo("/foo/boo/User.coo");
+                    assertThat(error.message()).contains("Unknown annotation Entity");
+                });
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidObjectOrientedAnnotationSyntax")
+    void shouldRejectInvalidObjectOrientedAnnotationSyntax(String moduleName, String source) {
+        var errors = compileObjectOrientedSource(moduleName, source);
+
+        assertThat(errors).isNotEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidObjectOrientedAnnotationValidation")
+    void shouldRejectInvalidObjectOrientedAnnotationValidation(
+            String moduleName,
+            String source,
+            String expectedMessage
+    ) {
+        var errors = compileObjectOrientedSource(moduleName, source, List.of(
+                new RawModule("Annotations", "/foo/meta", """
+                        annotation Label on class {
+                            value: String
+                        }
+                        """)
+        ));
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message()).contains(expectedMessage));
+    }
+
+    @Test
     void shouldAllowMainMethodInClassThatRequiresConstructor() {
         var result = CapybaraCompiler.INSTANCE.compile(List.of(
                 new RawModule(
@@ -274,6 +400,109 @@ class ObjectOrientedCompilationErrorTest {
         assertThat(result).isInstanceOf(Result.Success.class);
         var program = ((Result.Success<CompiledProgram>) result).value();
         assertThat(new JavaGenerator().generate(program).modules()).isNotEmpty();
+    }
+
+    private static Stream<Arguments> invalidObjectOrientedAnnotationSyntax() {
+        return Stream.of(
+                Arguments.of(
+                        "EmptyAnnotationCall",
+                        """
+                                @()
+                                class Broken {
+                                }
+                                """
+                ),
+                Arguments.of(
+                        "CommaSeparatedAnnotationPrefix",
+                        """
+                                @A(), @B()
+                                class Broken {
+                                }
+                                """
+                ),
+                Arguments.of(
+                        "PositionalAnnotationArgument",
+                        """
+                                @Label("bad")
+                                class Broken {
+                                }
+                                """
+                ),
+                Arguments.of(
+                        "AnnotationAfterDeclarationStart",
+                        """
+                                class @Label() Broken {
+                                }
+                                """
+                )
+        );
+    }
+
+    private static Stream<Arguments> invalidObjectOrientedAnnotationValidation() {
+        return Stream.of(
+                Arguments.of(
+                        "MissingAnnotationArgument",
+                        """
+                                from /foo/meta/Annotations import { Label }
+
+                                @Label()
+                                class Broken {
+                                }
+                                """,
+                        "Missing required annotation argument value for Label"
+                ),
+                Arguments.of(
+                        "DuplicateAnnotationArgument",
+                        """
+                                from /foo/meta/Annotations import { Label }
+
+                                @Label(value: "one", value: "two")
+                                class Broken {
+                                }
+                                """,
+                        "Duplicate annotation argument value for Label"
+                ),
+                Arguments.of(
+                        "UnknownAnnotationArgument",
+                        """
+                                from /foo/meta/Annotations import { Label }
+
+                                @Label(value: "one", extra: "two")
+                                class Broken {
+                                }
+                                """,
+                        "Unknown annotation argument extra for Label"
+                ),
+                Arguments.of(
+                        "WrongAnnotationArgumentType",
+                        """
+                                from /foo/meta/Annotations import { Label }
+
+                                @Label(value: 1)
+                                class Broken {
+                                }
+                                """,
+                        "Annotation argument value for Label expects String, got int"
+                )
+        );
+    }
+
+    private static SortedSet<Result.Error.SingleError> compileObjectOrientedSource(String moduleName, String source) {
+        return compileObjectOrientedSource(moduleName, source, List.of());
+    }
+
+    private static SortedSet<Result.Error.SingleError> compileObjectOrientedSource(
+            String moduleName,
+            String source,
+            List<RawModule> extraModules
+    ) {
+        var rawModules = new java.util.ArrayList<>(extraModules);
+        rawModules.add(new RawModule(moduleName, "/foo/boo", source, SourceKind.OBJECT_ORIENTED));
+        var result = CapybaraCompiler.INSTANCE.compile(rawModules, new TreeSet<>());
+        if (result instanceof Result.Success<CompiledProgram> value) {
+            throw new AssertionError("Expected compilation error but got CompiledProgram: " + value);
+        }
+        return ((Result.Error<?>) result).errors();
     }
 
 }

--- a/capy/src/e2e-coo/js/dev/capylang/test/ObjectOrientedAnnotations.test.js
+++ b/capy/src/e2e-coo/js/dev/capylang/test/ObjectOrientedAnnotations.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const { assert, generatedModule } = require('./_support');
+
+test('reflects object-oriented interface and trait annotations', () => {
+    const { AnnotatedContract } = generatedModule('dev/capylang/test/AnnotatedContract.js');
+    const { AnnotatedNaming } = generatedModule('dev/capylang/test/AnnotatedNaming.js');
+    const contract = AnnotatedContract.type();
+    const naming = AnnotatedNaming.type();
+
+    assert.deepEqual(contract.annotations.map(annotation => annotation.name), ['OoAnnotationMarker', 'OoTypeLabel', 'Deprecated']);
+    assert.deepEqual(contract.annotations[0].arguments, []);
+    assert.equal(contract.annotations[0].pkg.name, 'ObjectOrientedAnnotationDefinitions');
+    assert.equal(annotationArgument(contract.annotations[1], 'label').value.value, 'contract');
+    assert.equal(annotationArgument(contract.annotations[2], 'message').value.value, 'use AnnotatedContractV2');
+    assert.equal(annotationArgument(contract.annotations[2], 'since').value.value, '');
+    assert.deepEqual(contract.methods.map(method => method.name), ['render']);
+    assert.deepEqual(contract.methods[0].annotations.map(annotation => annotation.name), ['OoMethodName']);
+
+    assert.deepEqual(naming.annotations.map(annotation => annotation.name), ['OoAnnotationMarker', 'OoTypeLabel', 'Deprecated']);
+    assert.equal(annotationArgument(naming.annotations[1], 'label').value.value, 'mixin');
+    assert.equal(annotationArgument(naming.annotations[2], 'message').value.value, 'use AnnotatedNamingV2');
+    assert.equal(annotationArgument(naming.annotations[2], 'since').value.value, '3.0');
+    assert.deepEqual(naming.methods.map(method => method.name), ['prefix']);
+});
+
+test('reflects object-oriented class field and method annotations', () => {
+    const { AnnotatedWidget } = generatedModule('dev/capylang/test/AnnotatedWidget.js');
+    const widget = AnnotatedWidget.type();
+
+    assert.deepEqual(widget.annotations.map(annotation => annotation.name), ['OoAnnotationMarker', 'OoTypeLabel', 'Deprecated']);
+    assert.equal(annotationArgument(widget.annotations[1], 'label').value.value, 'entity');
+    assert.equal(widget.annotations[2].pkg.name, 'Annotations');
+    assert.equal(widget.annotations[2].pkg.path, 'capy/meta_prog');
+    assert.equal(annotationArgument(widget.annotations[2], 'message').value.value, 'use AnnotatedView');
+    assert.equal(annotationArgument(widget.annotations[2], 'since').value.value, '3.0');
+    assert.deepEqual(widget.parents.map(parent => parent.name).sort(), ['AnnotatedContract', 'AnnotatedNaming']);
+    assert.deepEqual(widget.fields.map(field => field.name), ['name']);
+    assert.deepEqual(widget.fields[0].annotations.map(annotation => annotation.name), ['OoAnnotationMarker', 'OoFieldName', 'Deprecated']);
+    assert.deepEqual(widget.fields[0].annotations[0].arguments, []);
+    assert.equal(annotationArgument(widget.fields[0].annotations[1], 'value').value.value, 'display_name');
+    assert.equal(annotationArgument(widget.fields[0].annotations[2], 'message').value.value, 'use label');
+    assert.equal(annotationArgument(widget.fields[0].annotations[2], 'since').value.value, '');
+    assert.deepEqual(widget.methods.map(method => method.name), ['render']);
+    assert.deepEqual(widget.methods[0].annotations.map(annotation => annotation.name), ['OoMethodName', 'Deprecated']);
+    assert.equal(annotationArgument(widget.methods[0].annotations[0], 'value').value.value, 'render');
+    assert.equal(annotationArgument(widget.methods[0].annotations[1], 'message').value.value, 'use render_label');
+    assert.equal(annotationArgument(widget.methods[0].annotations[1], 'since').value.value, '3.1');
+});
+
+function annotationArgument(annotation, name) {
+    return annotation.arguments.find(argument => argument.name === name);
+}

--- a/capy/src/e2e-coo/js/dev/capylang/test/ObjectOrientedReflection.test.js
+++ b/capy/src/e2e-coo/js/dev/capylang/test/ObjectOrientedReflection.test.js
@@ -6,7 +6,10 @@ test('reflects object-oriented interface', () => {
     const x = X.type();
 
     assert.equal(x.name, 'X');
+    assert.deepEqual(x.annotations.map(annotation => annotation.name), ['CooTypeMarker']);
+    assert.equal(annotationArgument(x.annotations[0], 'label').value.value, 'contract');
     assert.deepEqual(x.methods.map(method => method.name), ['print']);
+    assert.deepEqual(x.methods[0].annotations.map(annotation => annotation.name), ['CooMethodMarker']);
     assert.deepEqual(x.parents, []);
 });
 
@@ -15,7 +18,10 @@ test('reflects object-oriented trait', () => {
     const y = Y.type();
 
     assert.equal(y.name, 'Y');
+    assert.deepEqual(y.annotations.map(annotation => annotation.name), ['CooTypeMarker']);
+    assert.equal(annotationArgument(y.annotations[0], 'label').value.value, 'mixin');
     assert.deepEqual(y.methods.map(method => method.name), ['bracket']);
+    assert.deepEqual(y.methods[0].annotations.map(annotation => annotation.name), ['CooMethodMarker']);
     assert.deepEqual(y.parents, []);
 });
 
@@ -25,7 +31,16 @@ test('reflects object-oriented class with parents', () => {
 
     assert.equal(z.name, 'Z');
     assert.equal(z.open, false);
+    assert.deepEqual(z.annotations.map(annotation => annotation.name), ['CooTypeMarker']);
+    assert.equal(annotationArgument(z.annotations[0], 'label').value.value, 'entity');
     assert.deepEqual(z.fields.map(field => field.name), ['name']);
+    assert.deepEqual(z.fields[0].annotations.map(annotation => annotation.name), ['CooFieldMarker']);
+    assert.equal(annotationArgument(z.fields[0].annotations[0], 'value').value.value, 'display_name');
     assert.deepEqual(z.methods.map(method => method.name).sort(), ['greet', 'print']);
+    assert.deepEqual(z.methods.map(method => method.annotations[0].name).sort(), ['CooMethodMarker', 'CooMethodMarker']);
     assert.deepEqual(z.parents.map(parent => parent.name).sort(), ['X', 'Y']);
 });
+
+function annotationArgument(annotation, name) {
+    return annotation.arguments.find(argument => argument.name === name);
+}

--- a/capy/src/e2e-coo/py/dev/capylang/test/object_oriented_annotations_test.py
+++ b/capy/src/e2e-coo/py/dev/capylang/test/object_oriented_annotations_test.py
@@ -1,0 +1,62 @@
+import os
+import pathlib
+import sys
+import unittest
+
+
+generated_dir = pathlib.Path(os.environ["CAPY_E2E_COO_PY_GENERATED_DIR"])
+sys.path.insert(0, str(generated_dir))
+
+from dev.capylang.test.AnnotatedContract import AnnotatedContract
+from dev.capylang.test.AnnotatedNaming import AnnotatedNaming
+from dev.capylang.test.AnnotatedWidget import AnnotatedWidget
+
+
+def annotation_argument(annotation, name):
+    return next(argument for argument in annotation.arguments if argument.name == name)
+
+
+class ObjectOrientedAnnotationsPythonE2ETest(unittest.TestCase):
+    def test_reflects_object_oriented_interface_and_trait_annotations(self):
+        contract = AnnotatedContract.type()
+        naming = AnnotatedNaming.type()
+
+        self.assertEqual([annotation.name for annotation in contract.annotations], ["OoAnnotationMarker", "OoTypeLabel", "Deprecated"])
+        self.assertEqual(contract.annotations[0].arguments, [])
+        self.assertEqual(contract.annotations[0].pkg.name, "ObjectOrientedAnnotationDefinitions")
+        self.assertEqual(annotation_argument(contract.annotations[1], "label").value.value, "contract")
+        self.assertEqual(annotation_argument(contract.annotations[2], "message").value.value, "use AnnotatedContractV2")
+        self.assertEqual(annotation_argument(contract.annotations[2], "since").value.value, "")
+        self.assertEqual([method.name for method in contract.methods], ["render"])
+        self.assertEqual([annotation.name for annotation in contract.methods[0].annotations], ["OoMethodName"])
+
+        self.assertEqual([annotation.name for annotation in naming.annotations], ["OoAnnotationMarker", "OoTypeLabel", "Deprecated"])
+        self.assertEqual(annotation_argument(naming.annotations[1], "label").value.value, "mixin")
+        self.assertEqual(annotation_argument(naming.annotations[2], "message").value.value, "use AnnotatedNamingV2")
+        self.assertEqual(annotation_argument(naming.annotations[2], "since").value.value, "3.0")
+        self.assertEqual([method.name for method in naming.methods], ["prefix"])
+
+    def test_reflects_object_oriented_class_field_and_method_annotations(self):
+        widget = AnnotatedWidget.type()
+
+        self.assertEqual([annotation.name for annotation in widget.annotations], ["OoAnnotationMarker", "OoTypeLabel", "Deprecated"])
+        self.assertEqual(annotation_argument(widget.annotations[1], "label").value.value, "entity")
+        self.assertEqual(widget.annotations[2].pkg.name, "Annotations")
+        self.assertEqual(widget.annotations[2].pkg.path, "capy/meta_prog")
+        self.assertEqual(annotation_argument(widget.annotations[2], "message").value.value, "use AnnotatedView")
+        self.assertEqual(annotation_argument(widget.annotations[2], "since").value.value, "3.0")
+        self.assertEqual(sorted(parent.name for parent in widget.parents), ["AnnotatedContract", "AnnotatedNaming"])
+        self.assertEqual([field.name for field in widget.fields], ["name"])
+        self.assertEqual(
+            [annotation.name for annotation in widget.fields[0].annotations],
+            ["OoAnnotationMarker", "OoFieldName", "Deprecated"],
+        )
+        self.assertEqual(widget.fields[0].annotations[0].arguments, [])
+        self.assertEqual(annotation_argument(widget.fields[0].annotations[1], "value").value.value, "display_name")
+        self.assertEqual(annotation_argument(widget.fields[0].annotations[2], "message").value.value, "use label")
+        self.assertEqual(annotation_argument(widget.fields[0].annotations[2], "since").value.value, "")
+        self.assertEqual([method.name for method in widget.methods], ["render"])
+        self.assertEqual([annotation.name for annotation in widget.methods[0].annotations], ["OoMethodName", "Deprecated"])
+        self.assertEqual(annotation_argument(widget.methods[0].annotations[0], "value").value.value, "render")
+        self.assertEqual(annotation_argument(widget.methods[0].annotations[1], "message").value.value, "use render_label")
+        self.assertEqual(annotation_argument(widget.methods[0].annotations[1], "since").value.value, "3.1")

--- a/capy/src/e2e-coo/py/dev/capylang/test/object_oriented_reflection_test.py
+++ b/capy/src/e2e-coo/py/dev/capylang/test/object_oriented_reflection_test.py
@@ -1,0 +1,55 @@
+import os
+import pathlib
+import sys
+import unittest
+
+
+generated_dir = pathlib.Path(os.environ["CAPY_E2E_COO_PY_GENERATED_DIR"])
+sys.path.insert(0, str(generated_dir))
+
+from dev.capylang.test.X import X
+from dev.capylang.test.Y import Y
+from dev.capylang.test.Z import Z
+
+
+def annotation_argument(annotation, name):
+    return next(argument for argument in annotation.arguments if argument.name == name)
+
+
+class ObjectOrientedReflectionPythonE2ETest(unittest.TestCase):
+    def test_reflects_object_oriented_interface_annotations(self):
+        info = X.type()
+
+        self.assertEqual(info.name, "X")
+        self.assertEqual([annotation.name for annotation in info.annotations], ["CooTypeMarker"])
+        self.assertEqual(annotation_argument(info.annotations[0], "label").value.value, "contract")
+        self.assertEqual([method.name for method in info.methods], ["print"])
+        self.assertEqual([annotation.name for annotation in info.methods[0].annotations], ["CooMethodMarker"])
+        self.assertEqual(info.parents, [])
+
+    def test_reflects_object_oriented_trait_annotations(self):
+        info = Y.type()
+
+        self.assertEqual(info.name, "Y")
+        self.assertEqual([annotation.name for annotation in info.annotations], ["CooTypeMarker"])
+        self.assertEqual(annotation_argument(info.annotations[0], "label").value.value, "mixin")
+        self.assertEqual([method.name for method in info.methods], ["bracket"])
+        self.assertEqual([annotation.name for annotation in info.methods[0].annotations], ["CooMethodMarker"])
+        self.assertEqual(info.parents, [])
+
+    def test_reflects_object_oriented_class_field_and_method_annotations(self):
+        info = Z.type()
+
+        self.assertEqual(info.name, "Z")
+        self.assertFalse(info.open)
+        self.assertEqual([annotation.name for annotation in info.annotations], ["CooTypeMarker"])
+        self.assertEqual(annotation_argument(info.annotations[0], "label").value.value, "entity")
+        self.assertEqual([field.name for field in info.fields], ["name"])
+        self.assertEqual([annotation.name for annotation in info.fields[0].annotations], ["CooFieldMarker"])
+        self.assertEqual(annotation_argument(info.fields[0].annotations[0], "value").value.value, "display_name")
+        self.assertEqual(sorted(method.name for method in info.methods), ["greet", "print"])
+        self.assertEqual(
+            sorted(method.annotations[0].name for method in info.methods),
+            ["CooMethodMarker", "CooMethodMarker"],
+        )
+        self.assertEqual(sorted(parent.name for parent in info.parents), ["X", "Y"])

--- a/capy/src/test/java/dev/capylang/CapyTest.java
+++ b/capy/src/test/java/dev/capylang/CapyTest.java
@@ -118,6 +118,45 @@ class CapyTest {
     }
 
     @Test
+    void shouldWriteAnnotationMetadataToLinkedJsonDeterministically() throws IOException {
+        var sourceDir = Files.createDirectories(tempDir.resolve("annotation-linked-source"));
+        Files.createDirectories(sourceDir.resolve("foo"));
+        Files.writeString(sourceDir.resolve("foo").resolve("Main.cfun"), """
+                annotation Label on fun, data {
+                    value: String
+                    order: int = 1
+                }
+
+                @Label(value: "user")
+                data User { name: String }
+
+                @Label(order: 2, value: "main")
+                fun main(): int = 1
+                """);
+        var linkedDir = Files.createDirectories(tempDir.resolve("annotation-linked-output"));
+
+        assertEquals(0, Capy.execute(
+                new String[]{"compile", "-i", sourceDir.toString(), "-o", linkedDir.toString()},
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream())
+        ));
+
+        var moduleJson = linkedDir.resolve("foo").resolve("Main.json");
+        var first = Files.readString(moduleJson);
+        assertTrue(first.contains("\"annotations\""));
+        assertTrue(first.contains("\"name\" : \"Label\""));
+        assertTrue(first.contains("\"packageName\" : \"Main\""));
+        assertTrue(first.contains("\"packagePath\" : \"foo\""));
+
+        assertEquals(0, Capy.execute(
+                new String[]{"compile", "-i", sourceDir.toString(), "-o", linkedDir.toString()},
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(new ByteArrayOutputStream())
+        ));
+        assertEquals(first, Files.readString(moduleJson));
+    }
+
+    @Test
     void shouldCompileGenerateObjectOrientedFilesToJava() throws IOException {
         var sourceDir = Files.createDirectories(tempDir.resolve("oo-source-input"));
         Files.createDirectories(sourceDir.resolve("foo"));

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -23,24 +23,22 @@ program : definition+ EOF;
 definition:
     functionDeclaration
     | deriverDeclaration
+    | annotationDeclaration
     | primitiveBackedTypeDeclaration
     | typeDeclaration
     | enumDeclaration
     | dataDeclaration
     | constDeclaration;
 
-functionDeclaration: docComment* VISIBILITY? 'fun' recFunctionMarker functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody
-                   | docComment* VISIBILITY? 'fun' functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody;
-recFunctionMarker: REC;
+functionDeclaration: docComment* annotationBlock* VISIBILITY? 'fun' functionNameDeclaration '(' parameters? ')' functionType? '=' functionBody;
 functionBody: expression
             | localDefinition+ '---' expression;
 localDefinition: localFunctionDeclaration
                | localTypeDeclaration
                | localDataDeclaration
                | localConstDeclaration;
-localFunctionDeclaration: docComment* 'fun' recFunctionMarker localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression
-                        | docComment* 'fun' localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression;
-localFunctionNameDeclaration: NAME | REC;
+localFunctionDeclaration: docComment* annotationBlock* 'fun' localFunctionNameDeclaration '(' parameters? ')' functionType? '=' expression;
+localFunctionNameDeclaration: NAME;
 localTypeDeclaration: 'union' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*
                     | 'union' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)*;
 localDataDeclaration: 'data' genericTypeDeclaration '{' dataBody? '}' constructorClause?
@@ -53,23 +51,100 @@ methodIdentifier: identifier | 'with' | infixMethodLiteral | infixOperator;
 infixMethodLiteral: BACKTICKED_INFIX_METHOD_LITERAL | INFIX_METHOD_LITERAL;
 docComment: DOC_COMMENT;
 
-primitiveBackedTypeDeclaration: docComment* VISIBILITY? 'type' primitiveBackedTypeName MATCH_ARROW primitiveBackingType constructorClause?;
+annotationBlock
+    : annotationOpen annotationName (LPAREN annotationArgumentList? RPAREN)?
+    ;
+annotationOpen
+    : AT
+    ;
+annotationName
+    : qualifiedType
+    | lowerQualifiedType
+    ;
+annotationArgumentList
+    : annotationArgument (COMMA annotationArgument)* COMMA?
+    ;
+annotationArgument
+    : identifier COLON annotationValue
+    ;
+annotationValue
+    : STRING_LITERAL
+    | INT_LITERAL
+    | LONG_LITERAL
+    | FLOAT_LITERAL
+    | DOUBLE_LITERAL
+    | BOOL_LITERAL
+    | NOTHING_LITERAL
+    | annotationTypeReference
+    ;
+annotationTypeReference
+    : 'byte'
+    | 'int'
+    | 'long'
+    | 'double'
+    | 'bool'
+    | 'float'
+    | 'any'
+    | 'data'
+    | 'enum'
+    | 'nothing'
+    | qualifiedType (typeLbrack annotationTypeReference (COMMA annotationTypeReference)* RBRACK)?
+    | lowerQualifiedType
+    ;
+annotationDeclaration
+    : docComment* annotationBlock* VISIBILITY? annotationKeyword TYPE annotationTargetClause annotationBody
+    ;
+annotationKeyword
+    : { "annotation".equals(_input.LT(1).getText()) }? NAME
+    ;
+annotationTargetClause
+    : onKeyword annotationTarget (COMMA annotationTarget)* COMMA?
+    ;
+onKeyword
+    : { "on".equals(_input.LT(1).getText()) }? NAME
+    ;
+annotationTarget
+    : 'fun'
+    | { "method".equals(_input.LT(1).getText()) }? NAME
+    | 'const'
+    | 'data'
+    | 'union'
+    | 'enum'
+    | 'type'
+    | 'deriver'
+    | { "class".equals(_input.LT(1).getText()) }? NAME
+    | { "interface".equals(_input.LT(1).getText()) }? NAME
+    | { "trait".equals(_input.LT(1).getText()) }? NAME
+    | { "field".equals(_input.LT(1).getText()) }? NAME
+    | { "init".equals(_input.LT(1).getText()) }? NAME
+    ;
+annotationBody
+    : LBRACE annotationFieldDeclaration* RBRACE
+    ;
+annotationFieldDeclaration
+    : identifier COLON annotationFieldType (ASSIGN annotationValue)?
+    ;
+annotationFieldType
+    : annotationTypeReference
+    ;
+
+primitiveBackedTypeDeclaration: docComment* annotationBlock* VISIBILITY? 'type' primitiveBackedTypeName MATCH_ARROW primitiveBackingType constructorClause?;
 primitiveBackedTypeName: NAME | TYPE;
 primitiveBackingType: 'byte' | 'int' | 'long' | 'float' | 'double' | stringBackingType;
 stringBackingType: { "String".equals(_input.LT(1).getText()) }? TYPE;
-typeDeclaration: docComment* VISIBILITY? 'union' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?
-               | docComment* VISIBILITY? 'union' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?;
-enumDeclaration: docComment* 'enum' TYPE '{' TYPE (COMMA TYPE)* COMMA? '}';
-dataDeclaration: docComment* VISIBILITY? 'data' genericTypeDeclaration '{' dataBody? '}' constructorClause? deriveClause?
-               | docComment* VISIBILITY? 'data' genericTypeDeclaration '=' '{' dataBody? '}' constructorClause? deriveClause?;
+typeDeclaration: docComment* annotationBlock* VISIBILITY? 'union' genericTypeDeclaration constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?
+               | docComment* annotationBlock* VISIBILITY? 'union' genericTypeDeclaration '{' fieldDeclarationList? '}' constructorClause? '=' genericTypeDeclaration (PIPE genericTypeDeclaration)* deriveClause?;
+enumDeclaration: docComment* annotationBlock* 'enum' TYPE '{' TYPE (COMMA TYPE)* COMMA? '}';
+dataDeclaration: docComment* annotationBlock* VISIBILITY? 'data' genericTypeDeclaration '{' dataBody? '}' constructorClause? deriveClause?
+               | docComment* annotationBlock* VISIBILITY? 'data' genericTypeDeclaration '=' '{' dataBody? '}' constructorClause? deriveClause?;
 constructorClause: 'with' 'constructor' '{' expression '}';
 deriveClause: 'derive' TYPE (COMMA TYPE)* COMMA?;
-deriverDeclaration: docComment* VISIBILITY? 'deriver' TYPE '{' deriverMethodDeclaration+ '}';
-deriverMethodDeclaration: docComment* 'fun' identifier '(' parameters? ')' functionType '=' expression;
-constDeclaration: docComment* VISIBILITY? 'const' TYPE (':' type)? '=' expressionNoLet;
+deriverDeclaration: docComment* annotationBlock* VISIBILITY? 'deriver' TYPE '{' deriverMethodDeclaration+ '}';
+deriverMethodDeclaration: docComment* annotationBlock* 'fun' identifier '(' parameters? ')' functionType '=' expression;
+constDeclaration: docComment* annotationBlock* VISIBILITY? 'const' TYPE (':' type)? '=' expressionNoLet;
 fieldDeclarationList: fieldDeclaration (',' fieldDeclaration)* ','?;
-fieldDeclaration: identifier ':' type
-                | STRING_LITERAL ':' type
+fieldDeclaration: annotationBlock* identifier ':' type
+                | annotationBlock* STRING_LITERAL ':' type
                 | SPREAD TYPE;
 dataBody: NATIVE_LITERAL | fieldDeclarationList;
 methodOwnerDeclaration: genericTypeDeclaration | lowerQualifiedType;
@@ -78,9 +153,8 @@ typeLbrack: LBRACK | LINE_START_LBRACK;
 
 VISIBILITY: 'local' | 'private';
 BOOL_LITERAL: 'true' | 'false';
-REC: 'rec';
 NAME : [_]* [a-z] [a-zA-Z0-9_]*;
-identifier: NAME | REC | 'derive' | 'deriver' | 'fun' | 'type' | 'union' | 'enum' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'float' | 'nothing' | 'any';
+identifier: NAME | 'derive' | 'deriver' | 'fun' | 'type' | 'union' | 'enum' | 'byte' | 'int' | 'long' | 'double' | 'bool' | 'float' | 'nothing' | 'any';
 parameters: parameter (',' parameter)*;
 parameter: identifier ':' type;
 functionType: ':' type;
@@ -172,7 +246,6 @@ ifExpression: 'if' expression 'then' expression 'else' expression;
 functionReference: COLON identifier;
 placeholder: UNDERSCORE;
 functionCall: NAME '(' argumentList? ')'
-            | REC '(' argumentList? ')'
             | 'derive' '(' argumentList? ')'
             | 'deriver' '(' argumentList? ')'
             | 'fun' '(' argumentList? ')'
@@ -368,6 +441,7 @@ MOD_ASSIGN : '%=';
 LSHIFT_ASSIGN : '<<=';
 RSHIFT_ASSIGN : '>>=';
 URSHIFT_ASSIGN : '>>>=';
+AT : '@';
 
 DOC_COMMENT : '///' ~[\r\n]*;
 LINE_COMMENT : '//' ~[\r\n]* -> skip;

--- a/compiler/src/main/antlr/ObjectOriented.g4
+++ b/compiler/src/main/antlr/ObjectOriented.g4
@@ -11,9 +11,9 @@ definition:
     | traitDeclaration
     | interfaceDeclaration;
 
-classDeclaration: docComment* classModifier* 'class' TYPE constructorParameters? inheritanceClause? typeBody;
-traitDeclaration: docComment* 'trait' TYPE inheritanceClause? typeBody;
-interfaceDeclaration: docComment* 'interface' TYPE inheritanceClause? interfaceBody;
+classDeclaration: docComment* annotationBlock* classModifier* 'class' TYPE constructorParameters? inheritanceClause? typeBody;
+traitDeclaration: docComment* annotationBlock* 'trait' TYPE inheritanceClause? typeBody;
+interfaceDeclaration: docComment* annotationBlock* 'interface' TYPE inheritanceClause? interfaceBody;
 
 classModifier
     : 'open'
@@ -27,12 +27,12 @@ memberDeclaration: fieldDeclaration
                  | methodDeclaration
                  | initBlock;
 interfaceMemberDeclaration: interfaceMethodDeclaration;
-fieldDeclaration: docComment* visibility? 'field' identifier ':' type ('=' expression)?;
-methodDeclaration: docComment* visibility? methodModifier* 'def' identifier '(' parameters? ')' functionType methodBody?;
+fieldDeclaration: docComment* annotationBlock* visibility? 'field' identifier ':' type ('=' expression)?;
+methodDeclaration: docComment* annotationBlock* visibility? methodModifier* 'def' identifier '(' parameters? ')' functionType methodBody?;
 methodBody: '=' expression
           | statementBlock;
-interfaceMethodDeclaration: docComment* visibility? methodModifier* 'def' identifier '(' parameters? ')' functionType;
-initBlock: docComment* 'init' statementBlock;
+interfaceMethodDeclaration: docComment* annotationBlock* visibility? methodModifier* 'def' identifier '(' parameters? ')' functionType;
+initBlock: docComment* annotationBlock* 'init' statementBlock;
 statementBlock: '{' statement* '}';
 statement: letStatement
          | defStatement
@@ -353,8 +353,48 @@ infixOperatorNoPipe
     | AND
     ;
 
-methodIdentifier: identifier | 'with' | INFIX_METHOD_LITERAL;
+methodIdentifier: identifier | 'with' | INFIX_METHOD_LITERAL | AT;
 docComment: DOC_COMMENT;
+
+annotationBlock
+    : annotationOpen annotationName (LPAREN annotationArgumentList? RPAREN)?
+    ;
+annotationOpen
+    : AT
+    ;
+annotationName
+    : qualifiedType
+    | lowerQualifiedType
+    ;
+annotationArgumentList
+    : annotationArgument (COMMA annotationArgument)* COMMA?
+    ;
+annotationArgument
+    : identifier COLON annotationValue
+    ;
+annotationValue
+    : STRING_LITERAL
+    | INT_LITERAL
+    | LONG_LITERAL
+    | FLOAT_LITERAL
+    | DOUBLE_LITERAL
+    | BOOL_LITERAL
+    | NOTHING_LITERAL
+    | annotationTypeReference
+    ;
+annotationTypeReference
+    : 'byte'
+    | 'int'
+    | 'long'
+    | 'double'
+    | 'bool'
+    | 'float'
+    | 'any'
+    | 'data'
+    | 'void'
+    | qualifiedType ('[' annotationTypeReference (COMMA annotationTypeReference)* ']')?
+    | lowerQualifiedType
+    ;
 
 UNDERSCORE: '_';
 LPAREN : '(';
@@ -395,6 +435,7 @@ POWER: '^';
 MOD : '%';
 FAT_ARROW : '=>';
 MATCH_ARROW : '->';
+AT : '@';
 DOC_COMMENT : '///' ~[\r\n]*;
 LINE_COMMENT : '//' ~[\r\n]* -> skip;
 BLOCK_COMMENT : '/*' .*? '*/' -> skip;

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -31,8 +31,12 @@ public class CapybaraCompiler {
     private static final String TYPE_CONSTRUCTOR_FUNCTION_PREFIX = "__constructor__type__";
     private static final String PRIMITIVE_BACKED_TYPE_CONSTRUCTOR_FUNCTION_PREFIX = "__constructor__primitive__";
     private static final String CONSTRUCTOR_STATE_TYPE_PREFIX = "__constructor_state__";
+    private static final String RECURSIVE_ANNOTATION_NAME = "Recursive";
+    private static final String RECURSIVE_ANNOTATION_MODULE_NAME = "Recursive";
+    private static final String RECURSIVE_ANNOTATION_MODULE_PATH = "capy/meta_prog";
     private static final java.util.regex.Pattern IDENTIFIER_PATTERN = java.util.regex.Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
     private static final java.util.regex.Pattern PRIMITIVE_BACKED_TYPE_NAME_PATTERN = java.util.regex.Pattern.compile("[a-z][a-z_]*");
+    private static final java.util.regex.Pattern CONST_NAME_PATTERN = java.util.regex.Pattern.compile("^_?[A-Z_][A-Z0-9_]*$");
     private static final ObjectMapper OBJECT_MAPPER = objectMapper();
     private static final Logger log = Logger.getLogger(CapybaraCompiler.class.getName());
     private static final Object BUNDLED_LIBRARIES_LOCK = new Object();
@@ -60,20 +64,22 @@ public class CapybaraCompiler {
             var functionalModules = rawModules.stream()
                     .filter(rawModule -> rawModule.sourceKind() == SourceKind.FUNCTIONAL)
                     .toList();
-            if (functionalModules.isEmpty()) {
-                return Result.success(new CompiledProgram(new TreeSet<>(), parsedObjectOrientedModules));
+            var parsedProgram = new Program(List.of());
+            if (!functionalModules.isEmpty()) {
+                var program = CapybaraParser.INSTANCE.parseModule(functionalModules);
+                if (program instanceof Result.Error<Program> error) {
+                    return new Result.Error<>(error.errors());
+                }
+                parsedProgram = ((Result.Success<Program>) program).value();
             }
-            var program = CapybaraParser.INSTANCE.parseModule(functionalModules);
-            if (program instanceof Result.Error<Program> error) {
-                return new Result.Error<>(error.errors());
-            }
-            var mergedLibraries = mergeLibraries(functionalModules, libraries);
-            var compiledProgram = compile(((Result.Success<Program>) program).value(), mergedLibraries, parsedObjectOrientedModules);
+            var modulesForBundledLibraryCheck = functionalModules.isEmpty() ? rawModules : functionalModules;
+            var mergedLibraries = mergeLibraries(modulesForBundledLibraryCheck, libraries);
+            var compiledProgram = compile(parsedProgram, mergedLibraries, parsedObjectOrientedModules);
             if (compiledProgram instanceof Result.Error<CompiledProgram> error) {
                 return error;
             }
             var functionalProgram = ((Result.Success<CompiledProgram>) compiledProgram).value();
-            return Result.success(new CompiledProgram(functionalProgram.modules(), parsedObjectOrientedModules));
+            return Result.success(functionalProgram);
         } catch (RuntimeException e) {
             // Public boundary: source/compiler errors should not escape as exceptions.
             return new Result.Error<>(new Result.Error.SingleError(boundaryErrorMessage(e)));
@@ -263,7 +269,6 @@ public class CapybaraCompiler {
         }
 
         var moduleLinkIndex = buildModuleLinkIndex(allModuleRefs, linkedTypesByModule, moduleHelperClassRequiredByModule);
-        var moduleClassNameByModuleName = moduleLinkIndex.moduleJavaClassNameByModuleName();
         var staticImportsByModule = new HashMap<String, SortedSet<CompiledModule.StaticImport>>();
         for (var library : libraries) {
             putImportedModuleEntry(
@@ -292,6 +297,44 @@ public class CapybaraCompiler {
                     ((Result.Success<Map<String, DeriverDeclaration>>) derivers).value()
             );
         }
+        var annotationsByModule = new HashMap<String, Map<String, AnnotationDeclaration>>();
+        for (var library : libraries) {
+            putImportedModuleEntry(
+                    annotationsByModule,
+                    new ModuleRef(library.name(), library.path()),
+                    library.annotations()
+            );
+        }
+        for (var module : program.modules()) {
+            var sourceFile = moduleSourceFile(module);
+            var annotations = withFile(annotationDefinitions(module.functional().definitions(), sourceFile), sourceFile);
+            if (annotations instanceof Result.Error<Map<String, AnnotationDeclaration>> error) {
+                return new Result.Error<>(error.errors());
+            }
+            putOwnedModuleEntry(
+                    annotationsByModule,
+                    new ModuleRef(module.name(), module.path()),
+                    ((Result.Success<Map<String, AnnotationDeclaration>>) annotations).value()
+            );
+        }
+        for (var module : objectOrientedModules) {
+            putOwnedModuleEntry(
+                    annotationsByModule,
+                    new ModuleRef(module.name(), module.path()),
+                    Map.of()
+            );
+        }
+        var annotationValidation = validateAnnotationUsages(program, objectOrientedModules, annotationsByModule, moduleLinkIndex);
+        if (annotationValidation instanceof Result.Error<Void> error) {
+            return new Result.Error<>(error.errors());
+        }
+        linkFunctionalAnnotationMetadata(program, linkedTypesByModule, annotationsByModule, moduleLinkIndex);
+        objectOrientedModules = linkObjectOrientedAnnotationMetadata(objectOrientedModules, annotationsByModule, moduleLinkIndex);
+        objectTypeCatalog = objectTypeCatalog(objectOrientedModules);
+        objectTypeCatalog.linkedTypesByModule().forEach((moduleName, objectTypes) ->
+                mergeModuleTypes(linkedTypesByModule, moduleName, objectTypes));
+        moduleLinkIndex = buildModuleLinkIndex(allModuleRefs, linkedTypesByModule, moduleHelperClassRequiredByModule);
+        var moduleClassNameByModuleName = moduleLinkIndex.moduleJavaClassNameByModuleName();
         var constructorCatalog = constructorCatalog(program.modules(), libraries);
         var visibleConstructorsByModule = new HashMap<String, CapybaraExpressionCompiler.ConstructorRegistry>();
         for (var module : program.modules()) {
@@ -365,7 +408,7 @@ public class CapybaraCompiler {
                 continue;
             }
             var sourceFile = moduleSourceFile(module);
-            var availableConstructorSignatures = availableSignatures(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, staticImportsByModule, compileCache);
+            var availableConstructorSignatures = availableSignatures(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, annotationsByModule, staticImportsByModule, compileCache);
             if (availableConstructorSignatures instanceof Result.Error<List<CapybaraExpressionCompiler.FunctionSignature>> error) {
                 return new Result.Error<>(error.errors());
             }
@@ -378,6 +421,7 @@ public class CapybaraCompiler {
                     moduleClassNameByModuleName,
                     qualifiedImportAliases(module, moduleLinkIndex),
                     getModuleEntry(visibleConstructorsByModule, moduleRef),
+                    availableAnnotations(module.name(), module.path(), module.imports(), annotationsByModule, moduleLinkIndex),
                     sourceFile,
                     compileCache
             ), sourceFile);
@@ -415,6 +459,7 @@ public class CapybaraCompiler {
                     visibleTypesByModule,
                     signaturesByModule,
                     deriversByModule,
+                    annotationsByModule,
                     staticImportsByModule,
                     moduleClassNameByModuleName,
                     getModuleEntry(visibleConstructorsByModule, moduleRef),
@@ -433,16 +478,19 @@ public class CapybaraCompiler {
         log.info("Completed first-pass linking for " + program.modules().size() + " modules in " + Duration.ofNanos(System.nanoTime() - firstPassStartedAt));
 
         var finalLinkStartedAt = System.nanoTime();
+        var linkedObjectOrientedModules = objectOrientedModules;
+        var finalModuleLinkIndex = moduleLinkIndex;
         var result = program.modules().stream()
                 .map(module -> {
                     var moduleRef = new ModuleRef(module.name(), module.path());
                     return linkModule(
                             module,
-                            moduleLinkIndex,
+                            finalModuleLinkIndex,
                             linkedTypesByModule,
                             visibleTypesByModule,
                             refinedSignaturesByModule,
                             deriversByModule,
+                            annotationsByModule,
                             staticImportsByModule,
                             moduleClassNameByModuleName,
                             getModuleEntry(visibleConstructorsByModule, moduleRef),
@@ -450,7 +498,7 @@ public class CapybaraCompiler {
                     );
                 })
                 .collect(new ResultCollectionCollector<>())
-                .map(CompiledProgram::new);
+                .map(modules -> new CompiledProgram(modules, linkedObjectOrientedModules));
         if (result instanceof Result.Success<CompiledProgram> success) {
             var postValidation = validateResultReturningTypeConstructors(program, success.value());
             if (postValidation instanceof Result.Error<Void> error) {
@@ -483,6 +531,37 @@ public class CapybaraCompiler {
         DATA,
         TYPE,
         PRIMITIVE_BACKED
+    }
+
+    private enum AnnotationSemanticTarget {
+        FUNCTION("fun", "function"),
+        METHOD("method", "method"),
+        CONST("const", "const"),
+        DATA("data", "data"),
+        UNION("union", "union"),
+        ENUM("enum", "enum"),
+        PRIMITIVE_TYPE("type", "type"),
+        DERIVER("deriver", "deriver"),
+        CLASS("class", "class"),
+        INTERFACE("interface", "interface"),
+        TRAIT("trait", "trait"),
+        FIELD("field", "field"),
+        INIT("init", "init"),
+        ANNOTATION(null, "annotation");
+
+        private final String sourceName;
+        private final String displayName;
+
+        AnnotationSemanticTarget(String sourceName, String displayName) {
+            this.sourceName = sourceName;
+            this.displayName = displayName;
+        }
+
+        static Optional<AnnotationSemanticTarget> fromSourceName(String sourceName) {
+            return Arrays.stream(values())
+                    .filter(target -> target.sourceName != null && target.sourceName.equals(sourceName))
+                    .findFirst();
+        }
     }
 
     private record ConstructorDescriptor(ConstructorKind kind, String targetTypeName) {
@@ -715,6 +794,7 @@ public class CapybaraCompiler {
             Map<String, Map<String, GenericDataType>> visibleTypesByModule,
             Map<String, List<CapybaraExpressionCompiler.FunctionSignature>> signaturesByModule,
             Map<String, Map<String, DeriverDeclaration>> deriversByModule,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
             Map<String, SortedSet<CompiledModule.StaticImport>> staticImportsByModule,
             Map<String, String> moduleClassNameByModuleName,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
@@ -729,12 +809,13 @@ public class CapybaraCompiler {
             return new Result.Error<>(error.errors());
         }
         var moduleSourceFile = moduleSourceFile(module);
-        var availableSignatures = availableSignatures(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, staticImportsByModule, compileCache);
+        var availableSignatures = availableSignatures(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, annotationsByModule, staticImportsByModule, compileCache);
         if (availableSignatures instanceof Result.Error<List<CapybaraExpressionCompiler.FunctionSignature>> error) {
             return withFile(new Result.Error<>(error.errors()), moduleSourceFile);
         }
         var initialSignatures = ((Result.Success<List<CapybaraExpressionCompiler.FunctionSignature>>) availableSignatures).value();
-        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), dataTypes, localTypeNames, initialSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, moduleSourceFile, compileCache), moduleSourceFile);
+        var availableAnnotations = availableAnnotations(module.name(), module.path(), module.imports(), annotationsByModule, moduleLinkIndex);
+        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), dataTypes, localTypeNames, initialSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, availableAnnotations, moduleSourceFile, compileCache), moduleSourceFile);
     }
 
     private Result<CompiledModule> linkModule(
@@ -744,6 +825,7 @@ public class CapybaraCompiler {
             Map<String, Map<String, GenericDataType>> visibleTypesByModule,
             Map<String, List<CapybaraExpressionCompiler.FunctionSignature>> signaturesByModule,
             Map<String, Map<String, DeriverDeclaration>> deriversByModule,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
             Map<String, SortedSet<CompiledModule.StaticImport>> staticImportsByModule,
             Map<String, String> moduleClassNameByModuleName,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
@@ -757,12 +839,13 @@ public class CapybaraCompiler {
             return new Result.Error<>(error.errors());
         }
         var moduleSourceFile = moduleSourceFile(module);
-        var availableSignatures = availableSignatures(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, staticImportsByModule, compileCache);
+        var availableSignatures = availableSignatures(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, annotationsByModule, staticImportsByModule, compileCache);
         if (availableSignatures instanceof Result.Error<List<CapybaraExpressionCompiler.FunctionSignature>> error) {
             return withFile(new Result.Error<>(error.errors()), moduleSourceFile);
         }
         var initialSignatures = ((Result.Success<List<CapybaraExpressionCompiler.FunctionSignature>>) availableSignatures).value();
-        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), initialSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, moduleSourceFile, compileCache)
+        var availableAnnotations = availableAnnotations(module.name(), module.path(), module.imports(), annotationsByModule, moduleLinkIndex);
+        return withFile(linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), initialSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, availableAnnotations, moduleSourceFile, compileCache)
                 .flatMap(firstPassFunctions -> {
                     var moduleSignatures = getModuleEntry(signaturesByModule, moduleRef);
                     var refinedSignatures = mergeSignatures(
@@ -777,11 +860,12 @@ public class CapybaraCompiler {
                                 deduplicateFunctions(firstPassFunctions),
                                 getModuleEntry(deriversByModule, new ModuleRef(module.name(), module.path())),
                                 visiblePrimitiveBackedTypes(visibleTypes),
+                                getModuleEntry(annotationsByModule, new ModuleRef(module.name(), module.path())),
                                 staticImports(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, staticImportsByModule, compileCache)
                         ));
                     }
                     var refinedAvailableSignatures = mergeSignatures(initialSignatures, refinedSignatures);
-                    return linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), refinedAvailableSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, moduleSourceFile, compileCache)
+                    return linkFunctions(((Result.Success<List<Function>>) functions).value(), visibleTypes, localTypes.keySet(), refinedAvailableSignatures, signaturesByModule, moduleClassNameByModuleName, qualifiedImportAliases(module, moduleLinkIndex), protectedConstructorsByType, availableAnnotations, moduleSourceFile, compileCache)
                             .map(linkedFunctions -> new CompiledModule(
                                     module.name(),
                                     module.path(),
@@ -789,6 +873,7 @@ public class CapybaraCompiler {
                                     deduplicateFunctions(linkedFunctions),
                                     getModuleEntry(deriversByModule, new ModuleRef(module.name(), module.path())),
                                     visiblePrimitiveBackedTypes(visibleTypes),
+                                    getModuleEntry(annotationsByModule, new ModuleRef(module.name(), module.path())),
                                     staticImports(module, moduleLinkIndex, linkedTypesByModule, signaturesByModule, deriversByModule, staticImportsByModule, compileCache)
                             ));
                 }), moduleSourceFile);
@@ -811,6 +896,7 @@ public class CapybaraCompiler {
             Map<String, SortedMap<String, GenericDataType>> linkedTypesByModule,
             Map<String, List<CapybaraExpressionCompiler.FunctionSignature>> signaturesByModule,
             Map<String, Map<String, DeriverDeclaration>> deriversByModule,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
             Map<String, SortedSet<CompiledModule.StaticImport>> staticImportsByModule,
             CompileCache compileCache
     ) {
@@ -847,9 +933,15 @@ public class CapybaraCompiler {
                     importedModule,
                     getModuleEntry(deriversByModule, importedModule)
             ).keySet();
+            var availableAnnotationMembers = visibleAnnotations(
+                    module.path(),
+                    importedModule,
+                    getModuleEntry(annotationsByModule, importedModule)
+            ).keySet();
             var availableMembers = new HashSet<String>(availableFunctionMembers);
             availableMembers.addAll(availableTypeMembers);
             availableMembers.addAll(availableDeriverMembers);
+            availableMembers.addAll(availableAnnotationMembers);
             for (var excludedSymbol : importDeclaration.excludedSymbols()) {
                 if (!availableMembers.contains(excludedSymbol)) {
                     return Result.error(
@@ -1026,7 +1118,11 @@ public class CapybaraCompiler {
             case CompiledDataType linkedDataType -> new CompiledDataType(
                     linkedDataType.name(),
                     linkedDataType.fields().stream()
-                            .map(field -> new CompiledDataType.CompiledField(field.name(), resolveLinkedType(field.type(), all, nextResolvingTypeNames)))
+                            .map(field -> new CompiledDataType.CompiledField(
+                                    field.name(),
+                                    resolveLinkedType(field.type(), all, nextResolvingTypeNames),
+                                    field.annotations()
+                            ))
                             .toList(),
                     linkedDataType.typeParameters(),
                     linkedDataType.extendedTypes(),
@@ -1034,12 +1130,17 @@ public class CapybaraCompiler {
                     linkedDataType.visibility(),
                     linkedDataType.singleton(),
                     linkedDataType.nativeType(),
-                    linkedDataType.enumValue()
+                    linkedDataType.enumValue(),
+                    linkedDataType.annotations()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
                     linkedDataParentType.fields().stream()
-                            .map(field -> new CompiledDataType.CompiledField(field.name(), resolveLinkedType(field.type(), all, nextResolvingTypeNames)))
+                            .map(field -> new CompiledDataType.CompiledField(
+                                    field.name(),
+                                    resolveLinkedType(field.type(), all, nextResolvingTypeNames),
+                                    field.annotations()
+                            ))
                             .toList(),
                     linkedDataParentType.subTypes().stream()
                             .map(subType -> (CompiledDataType) resolveGenericDataType(subType, all, nextResolvingTypeNames))
@@ -1047,7 +1148,8 @@ public class CapybaraCompiler {
                     linkedDataParentType.typeParameters(),
                     linkedDataParentType.comments(),
                     linkedDataParentType.visibility(),
-                    linkedDataParentType.enumType()
+                    linkedDataParentType.enumType(),
+                    linkedDataParentType.annotations()
             );
             case CompiledObjectType objectType -> objectType;
             case CompiledPrimitiveBackedType primitiveBackedType -> primitiveBackedType;
@@ -1323,7 +1425,8 @@ public class CapybaraCompiler {
                     linkedDataType.visibility(),
                     linkedDataType.singleton(),
                     linkedDataType.nativeType(),
-                    linkedDataType.enumValue()
+                    linkedDataType.enumValue(),
+                    linkedDataType.annotations()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     requestedName,
@@ -1332,20 +1435,23 @@ public class CapybaraCompiler {
                     linkedDataParentType.typeParameters(),
                     linkedDataParentType.comments(),
                     linkedDataParentType.visibility(),
-                    linkedDataParentType.enumType()
+                    linkedDataParentType.enumType(),
+                    linkedDataParentType.annotations()
             );
             case CompiledPrimitiveBackedType primitiveBackedType -> new CompiledPrimitiveBackedType(
                     requestedName,
                     primitiveBackedType.backingType(),
                     primitiveBackedType.cfunType(),
                     primitiveBackedType.comments(),
-                    primitiveBackedType.visibility()
+                    primitiveBackedType.visibility(),
+                    primitiveBackedType.annotations()
             );
             case CompiledObjectType objectType -> new CompiledObjectType(
                     requestedName,
                     objectType.backendClassName(),
                     objectType.parents(),
-                    objectType.visibility()
+                    objectType.visibility(),
+                    objectType.annotations()
             );
         };
     }
@@ -1824,6 +1930,9 @@ public class CapybaraCompiler {
     private record AvailableDeriver(ModuleRef ownerModule, DeriverDeclaration deriver) {
     }
 
+    private record AvailableAnnotation(ModuleRef ownerModule, AnnotationDeclaration annotation) {
+    }
+
     private Map<String, DeriverDeclaration> visibleDerivers(
             String currentModulePath,
             ModuleRef ownerModule,
@@ -1839,6 +1948,894 @@ public class CapybaraCompiler {
             }
         }
         return Map.copyOf(visible);
+    }
+
+    private Result<Map<String, AnnotationDeclaration>> annotationDefinitions(Set<Definition> definitions, String moduleSourceFile) {
+        var normalizedFile = normalizeFile(moduleSourceFile);
+        var annotations = new LinkedHashMap<String, AnnotationDeclaration>();
+        var errors = new TreeSet<Result.Error.SingleError>();
+        for (var definition : definitions) {
+            if (!(definition instanceof AnnotationDeclaration annotation)) {
+                continue;
+            }
+            var existing = annotations.putIfAbsent(annotation.name(), annotation);
+            if (existing != null) {
+                errors.add(errorAt(
+                        "Duplicate annotation `" + annotation.name() + "`",
+                        annotation.position(),
+                        normalizedFile
+                ));
+            }
+            validateAnnotationDefinition(annotation, normalizedFile, errors);
+        }
+        return errors.isEmpty() ? Result.success(Map.copyOf(annotations)) : new Result.Error<>(errors);
+    }
+
+    private void validateAnnotationDefinition(
+            AnnotationDeclaration annotation,
+            String normalizedFile,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        for (var target : annotation.targets()) {
+            if (AnnotationSemanticTarget.fromSourceName(target.name()).isEmpty()) {
+                errors.add(errorAt(
+                        "Unknown annotation target " + target.name() + " for " + annotation.name(),
+                        target.position(),
+                        normalizedFile
+                ));
+            }
+        }
+        var fieldNames = new HashSet<String>();
+        for (var field : annotation.fields()) {
+            if (!fieldNames.add(field.name())) {
+                errors.add(errorAt(
+                        "Duplicate annotation field " + field.name() + " for " + annotation.name(),
+                        field.position(),
+                        normalizedFile
+                ));
+                continue;
+            }
+            field.defaultValue().ifPresent(value -> validateAnnotationValueType(
+                    annotation.name(),
+                    field.name(),
+                    field.type(),
+                    value,
+                    value.position().or(field::position),
+                    normalizedFile,
+                    errors
+            ));
+        }
+    }
+
+    private Result<Void> validateAnnotationUsages(
+            Program program,
+            List<ObjectOrientedModule> objectOrientedModules,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
+            ModuleLinkIndex moduleLinkIndex
+    ) {
+        var errors = new TreeSet<Result.Error.SingleError>();
+        for (var module : program.modules()) {
+            var availableAnnotations = availableAnnotations(
+                    module.name(),
+                    module.path(),
+                    module.imports(),
+                    annotationsByModule,
+                    moduleLinkIndex
+            );
+            validateFunctionalAnnotationUsages(module, availableAnnotations, errors);
+        }
+        for (var module : objectOrientedModules) {
+            var availableAnnotations = availableAnnotations(
+                    module.name(),
+                    module.path(),
+                    module.imports(),
+                    annotationsByModule,
+                    moduleLinkIndex
+            );
+            validateObjectOrientedAnnotationUsages(module, availableAnnotations, errors);
+        }
+        return errors.isEmpty() ? Result.success(null) : new Result.Error<>(errors);
+    }
+
+    private void validateFunctionalAnnotationUsages(
+            Module module,
+            Map<String, AvailableAnnotation> availableAnnotations,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        var normalizedFile = normalizeFile(moduleSourceFile(module));
+        for (var definition : module.functional().definitions()) {
+            switch (definition) {
+                case AnnotationDeclaration annotationDeclaration -> validateAnnotationUsageList(
+                        annotationDeclaration.annotations(),
+                        Optional.of(AnnotationSemanticTarget.ANNOTATION),
+                        AnnotationSemanticTarget.ANNOTATION.displayName,
+                        availableAnnotations,
+                        normalizedFile,
+                        errors
+                );
+                case DataDeclaration dataDeclaration -> {
+                    validateAnnotationUsageList(
+                            dataDeclaration.annotations(),
+                            Optional.of(AnnotationSemanticTarget.DATA),
+                            AnnotationSemanticTarget.DATA.displayName,
+                            availableAnnotations,
+                            normalizedFile,
+                            errors
+                    );
+                    for (var field : dataDeclaration.fields()) {
+                        validateAnnotationUsageList(
+                                field.annotations(),
+                                Optional.of(AnnotationSemanticTarget.FIELD),
+                                AnnotationSemanticTarget.FIELD.displayName,
+                                availableAnnotations,
+                                normalizedFile,
+                                errors
+                        );
+                    }
+                }
+                case DeriverDeclaration deriverDeclaration -> {
+                    validateAnnotationUsageList(
+                            deriverDeclaration.annotations(),
+                            Optional.of(AnnotationSemanticTarget.DERIVER),
+                            AnnotationSemanticTarget.DERIVER.displayName,
+                            availableAnnotations,
+                            normalizedFile,
+                            errors
+                    );
+                    for (var method : deriverDeclaration.methods()) {
+                        validateAnnotationUsageList(
+                                method.annotations(),
+                                Optional.of(AnnotationSemanticTarget.METHOD),
+                                AnnotationSemanticTarget.METHOD.displayName,
+                                availableAnnotations,
+                                normalizedFile,
+                                errors
+                        );
+                    }
+                }
+                case EnumDeclaration enumDeclaration -> validateAnnotationUsageList(
+                        enumDeclaration.annotations(),
+                        Optional.of(AnnotationSemanticTarget.ENUM),
+                        AnnotationSemanticTarget.ENUM.displayName,
+                        availableAnnotations,
+                        normalizedFile,
+                        errors
+                );
+                case Function function -> {
+                    if (isLocalFunction(function)) {
+                        validateLocalFunctionAnnotationUsages(
+                                function.annotations(),
+                                availableAnnotations,
+                                normalizedFile,
+                                errors
+                        );
+                    } else {
+                        validateAnnotationUsageList(
+                                function.annotations(),
+                                Optional.of(annotationTargetForFunction(function)),
+                                annotationTargetForFunction(function).displayName,
+                                availableAnnotations,
+                                normalizedFile,
+                                errors
+                        );
+                    }
+                }
+                case PrimitiveBackedTypeDeclaration primitiveBackedTypeDeclaration -> validateAnnotationUsageList(
+                        primitiveBackedTypeDeclaration.annotations(),
+                        Optional.of(AnnotationSemanticTarget.PRIMITIVE_TYPE),
+                        AnnotationSemanticTarget.PRIMITIVE_TYPE.displayName,
+                        availableAnnotations,
+                        normalizedFile,
+                        errors
+                );
+                case TypeDeclaration typeDeclaration -> {
+                    validateAnnotationUsageList(
+                            typeDeclaration.annotations(),
+                            Optional.of(AnnotationSemanticTarget.UNION),
+                            AnnotationSemanticTarget.UNION.displayName,
+                            availableAnnotations,
+                            normalizedFile,
+                            errors
+                    );
+                    for (var field : typeDeclaration.fields()) {
+                        validateAnnotationUsageList(
+                                field.annotations(),
+                                Optional.of(AnnotationSemanticTarget.FIELD),
+                                AnnotationSemanticTarget.FIELD.displayName,
+                                availableAnnotations,
+                                normalizedFile,
+                                errors
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    private AnnotationSemanticTarget annotationTargetForFunction(Function function) {
+        if (function.name().startsWith(METHOD_DECL_PREFIX)) {
+            return AnnotationSemanticTarget.METHOD;
+        }
+        if (CONST_NAME_PATTERN.matcher(function.name()).matches()) {
+            return AnnotationSemanticTarget.CONST;
+        }
+        return AnnotationSemanticTarget.FUNCTION;
+    }
+
+    private boolean isLocalFunction(Function function) {
+        return function.name().contains("__local_fun_");
+    }
+
+    private void validateLocalFunctionAnnotationUsages(
+            List<AnnotationUsage> usages,
+            Map<String, AvailableAnnotation> availableAnnotations,
+            String normalizedFile,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        for (var usage : usages) {
+            var availableAnnotation = availableAnnotations.get(usage.name());
+            if (availableAnnotation == null) {
+                errors.add(errorAt(unknownAnnotationMessage(usage.name()), usage.position(), normalizedFile));
+                continue;
+            }
+            if (!isRecursiveAnnotation(availableAnnotation)) {
+                errors.add(errorAt(
+                        "Only `@Recursive` is supported on local function declarations; import it from /capy/meta_prog/Recursive",
+                        usage.position(),
+                        normalizedFile
+                ));
+                continue;
+            }
+            validateAnnotationUsageList(
+                    List.of(usage),
+                    Optional.of(AnnotationSemanticTarget.FUNCTION),
+                    AnnotationSemanticTarget.FUNCTION.displayName,
+                    availableAnnotations,
+                    normalizedFile,
+                    errors
+            );
+        }
+    }
+
+    private void validateObjectOrientedAnnotationUsages(
+            ObjectOrientedModule module,
+            Map<String, AvailableAnnotation> availableAnnotations,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        var normalizedFile = normalizeFile(moduleSourceFile(module));
+        for (var definition : module.objectOriented().definitions()) {
+            switch (definition) {
+                case ObjectOriented.ClassDeclaration classDeclaration -> validateAnnotationUsageList(
+                        classDeclaration.annotations(),
+                        Optional.of(AnnotationSemanticTarget.CLASS),
+                        AnnotationSemanticTarget.CLASS.displayName,
+                        availableAnnotations,
+                        normalizedFile,
+                        errors
+                );
+                case ObjectOriented.InterfaceDeclaration interfaceDeclaration -> validateAnnotationUsageList(
+                        interfaceDeclaration.annotations(),
+                        Optional.of(AnnotationSemanticTarget.INTERFACE),
+                        AnnotationSemanticTarget.INTERFACE.displayName,
+                        availableAnnotations,
+                        normalizedFile,
+                        errors
+                );
+                case ObjectOriented.TraitDeclaration traitDeclaration -> validateAnnotationUsageList(
+                        traitDeclaration.annotations(),
+                        Optional.of(AnnotationSemanticTarget.TRAIT),
+                        AnnotationSemanticTarget.TRAIT.displayName,
+                        availableAnnotations,
+                        normalizedFile,
+                        errors
+                );
+            }
+            for (var member : definition.members()) {
+                switch (member) {
+                    case ObjectOriented.FieldDeclaration fieldDeclaration -> validateAnnotationUsageList(
+                            fieldDeclaration.annotations(),
+                            Optional.of(AnnotationSemanticTarget.FIELD),
+                            AnnotationSemanticTarget.FIELD.displayName,
+                            availableAnnotations,
+                            normalizedFile,
+                            errors
+                    );
+                    case ObjectOriented.MethodDeclaration methodDeclaration -> validateAnnotationUsageList(
+                            methodDeclaration.annotations(),
+                            Optional.of(AnnotationSemanticTarget.METHOD),
+                            AnnotationSemanticTarget.METHOD.displayName,
+                            availableAnnotations,
+                            normalizedFile,
+                            errors
+                    );
+                    case ObjectOriented.InitBlock initBlock -> validateAnnotationUsageList(
+                            initBlock.annotations(),
+                            Optional.of(AnnotationSemanticTarget.INIT),
+                            AnnotationSemanticTarget.INIT.displayName,
+                            availableAnnotations,
+                            normalizedFile,
+                            errors
+                    );
+                }
+            }
+        }
+    }
+
+    private void validateAnnotationUsageList(
+            List<AnnotationUsage> usages,
+            Optional<AnnotationSemanticTarget> target,
+            String targetDisplayName,
+            Map<String, AvailableAnnotation> availableAnnotations,
+            String normalizedFile,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        for (var usage : usages) {
+            var availableAnnotation = availableAnnotations.get(usage.name());
+            if (availableAnnotation == null) {
+                errors.add(errorAt(unknownAnnotationMessage(usage.name()), usage.position(), normalizedFile));
+                continue;
+            }
+            if (isRecursiveAnnotation(availableAnnotation)
+                && target.filter(AnnotationSemanticTarget.FUNCTION::equals).isEmpty()) {
+                errors.add(errorAt(
+                        "`@Recursive` is supported for functions, not " + targetDisplayName + " declarations",
+                        usage.position(),
+                        normalizedFile
+                ));
+                continue;
+            }
+            var annotation = availableAnnotation.annotation();
+            var allowedTargets = annotation.targets().stream()
+                    .map(AnnotationTarget::name)
+                    .map(AnnotationSemanticTarget::fromSourceName)
+                    .flatMap(Optional::stream)
+                    .collect(java.util.stream.Collectors.toSet());
+            if (target.isEmpty() || !allowedTargets.contains(target.orElseThrow())) {
+                errors.add(errorAt(
+                        "Annotation " + usage.name() + " is not valid on " + targetDisplayName + " declarations",
+                        usage.position(),
+                        normalizedFile
+                ));
+                continue;
+            }
+            validateAnnotationArguments(usage, annotation, normalizedFile, errors);
+        }
+    }
+
+    private String unknownAnnotationMessage(String name) {
+        if (RECURSIVE_ANNOTATION_NAME.equals(name)) {
+            return "Unknown annotation Recursive. Import it from /capy/meta_prog/Recursive to use the tail-recursion contract";
+        }
+        return "Unknown annotation " + name;
+    }
+
+    private void validateAnnotationArguments(
+            AnnotationUsage usage,
+            AnnotationDeclaration annotation,
+            String normalizedFile,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        var fieldsByName = annotation.fields().stream()
+                .collect(toMap(
+                        AnnotationFieldDeclaration::name,
+                        identity(),
+                        (first, second) -> first,
+                        LinkedHashMap::new
+                ));
+        var provided = new HashSet<String>();
+        for (var argument : usage.arguments()) {
+            if (!provided.add(argument.name())) {
+                errors.add(errorAt(
+                        "Duplicate annotation argument " + argument.name() + " for " + usage.name(),
+                        argument.position(),
+                        normalizedFile
+                ));
+                continue;
+            }
+            var field = fieldsByName.get(argument.name());
+            if (field == null) {
+                errors.add(errorAt(
+                        "Unknown annotation argument " + argument.name() + " for " + usage.name(),
+                        argument.position(),
+                        normalizedFile
+                ));
+                continue;
+            }
+            validateAnnotationValueType(
+                    usage.name(),
+                    argument.name(),
+                    field.type(),
+                    argument.value(),
+                    argument.value().position().or(argument::position),
+                    normalizedFile,
+                    errors
+            );
+        }
+        for (var field : annotation.fields()) {
+            if (field.defaultValue().isEmpty() && !provided.contains(field.name())) {
+                errors.add(errorAt(
+                        "Missing required annotation argument " + field.name() + " for " + usage.name(),
+                        usage.position(),
+                        normalizedFile
+                ));
+            }
+        }
+    }
+
+    private void validateAnnotationValueType(
+            String annotationName,
+            String argumentName,
+            String expectedType,
+            AnnotationValue value,
+            Optional<SourcePosition> position,
+            String normalizedFile,
+            TreeSet<Result.Error.SingleError> errors
+    ) {
+        if (annotationValueMatchesFieldType(expectedType, value)) {
+            return;
+        }
+        errors.add(errorAt(
+                "Annotation argument " + argumentName + " for " + annotationName
+                + " expects " + expectedType + ", got " + annotationValueTypeName(value),
+                position,
+                normalizedFile
+        ));
+    }
+
+    private boolean annotationValueMatchesFieldType(String expectedType, AnnotationValue value) {
+        var normalizedExpectedType = expectedType.replace(" ", "");
+        return switch (normalizedExpectedType) {
+            case "String" -> value instanceof AnnotationValue.StringValue;
+            case "byte", "int" -> value instanceof AnnotationValue.IntValue;
+            case "long" -> value instanceof AnnotationValue.IntValue
+                           || value instanceof AnnotationValue.LongValue;
+            case "float" -> value instanceof AnnotationValue.IntValue
+                            || value instanceof AnnotationValue.LongValue
+                            || value instanceof AnnotationValue.FloatValue;
+            case "double" -> value instanceof AnnotationValue.IntValue
+                             || value instanceof AnnotationValue.LongValue
+                             || value instanceof AnnotationValue.FloatValue
+                             || value instanceof AnnotationValue.DoubleValue;
+            case "bool" -> value instanceof AnnotationValue.BoolValue;
+            case "nothing" -> value instanceof AnnotationValue.NothingValue;
+            default -> value instanceof AnnotationValue.TypeNameValue;
+        };
+    }
+
+    private String annotationValueTypeName(AnnotationValue value) {
+        return switch (value) {
+            case AnnotationValue.StringValue ignored -> "String";
+            case AnnotationValue.IntValue ignored -> "int";
+            case AnnotationValue.LongValue ignored -> "long";
+            case AnnotationValue.FloatValue ignored -> "float";
+            case AnnotationValue.DoubleValue ignored -> "double";
+            case AnnotationValue.BoolValue ignored -> "bool";
+            case AnnotationValue.NothingValue ignored -> "nothing";
+            case AnnotationValue.TypeNameValue ignored -> "type";
+        };
+    }
+
+    private Map<String, AvailableAnnotation> availableAnnotations(
+            String moduleName,
+            String modulePath,
+            List<ImportDeclaration> imports,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
+            ModuleLinkIndex moduleLinkIndex
+    ) {
+        var currentModule = new ModuleRef(moduleName, modulePath);
+        var localAnnotations = Optional.ofNullable(getModuleEntry(annotationsByModule, currentModule)).orElse(Map.of());
+        var all = new LinkedHashMap<String, AvailableAnnotation>();
+        localAnnotations.forEach((name, annotation) -> all.put(name, new AvailableAnnotation(currentModule, annotation)));
+        addQualifiedAnnotationAliases(all, currentModule, localAnnotations);
+        for (var importDeclaration : imports) {
+            var importedModule = resolveImportedModule(importDeclaration.moduleName(), moduleLinkIndex);
+            if (importedModule == null) {
+                continue;
+            }
+            var importedAnnotations = visibleAnnotations(
+                    modulePath,
+                    importedModule,
+                    getModuleEntry(annotationsByModule, importedModule)
+            );
+            addQualifiedAnnotationAliases(all, importedModule, importedAnnotations);
+            if (importDeclaration.qualifiedOnly()) {
+                continue;
+            }
+            for (var symbol : importDeclaration.selectedSymbols(importedAnnotations.keySet())) {
+                var annotation = importedAnnotations.get(symbol);
+                if (annotation != null) {
+                    all.put(symbol, new AvailableAnnotation(importedModule, annotation));
+                }
+            }
+        }
+        return Map.copyOf(all);
+    }
+
+    private boolean isRecursiveAnnotation(AvailableAnnotation annotation) {
+        return annotation != null
+               && RECURSIVE_ANNOTATION_NAME.equals(annotation.annotation().name())
+               && RECURSIVE_ANNOTATION_MODULE_NAME.equals(annotation.ownerModule().name())
+               && RECURSIVE_ANNOTATION_MODULE_PATH.equals(normalizedAnnotationModulePath(annotation.ownerModule().path()));
+    }
+
+    private String normalizedAnnotationModulePath(String path) {
+        var normalized = path == null ? "" : path.replace('\\', '/');
+        return normalized.startsWith("/") ? normalized.substring(1) : normalized;
+    }
+
+    private Map<String, AnnotationDeclaration> visibleAnnotations(
+            String currentModulePath,
+            ModuleRef ownerModule,
+            Map<String, AnnotationDeclaration> annotations
+    ) {
+        if (annotations == null || annotations.isEmpty()) {
+            return Map.of();
+        }
+        var visible = new LinkedHashMap<String, AnnotationDeclaration>();
+        for (var entry : annotations.entrySet()) {
+            if (isVisibleFromModule(currentModulePath, ownerModule.path(), entry.getValue().visibility())) {
+                visible.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return Map.copyOf(visible);
+    }
+
+    private void addQualifiedAnnotationAliases(
+            Map<String, AvailableAnnotation> all,
+            ModuleRef module,
+            Map<String, AnnotationDeclaration> annotations
+    ) {
+        annotations.forEach((name, annotation) -> all.put(module.name() + "." + name, new AvailableAnnotation(module, annotation)));
+        var modulePath = module.path().replace('\\', '/') + "/" + module.name();
+        annotations.forEach((name, annotation) -> {
+            all.put(modulePath + "." + name, new AvailableAnnotation(module, annotation));
+            all.put("/" + modulePath + "." + name, new AvailableAnnotation(module, annotation));
+            if (module.name().equals(name)) {
+                all.put(modulePath, new AvailableAnnotation(module, annotation));
+                all.put("/" + modulePath, new AvailableAnnotation(module, annotation));
+            }
+        });
+    }
+
+    private void linkFunctionalAnnotationMetadata(
+            Program program,
+            Map<String, SortedMap<String, GenericDataType>> linkedTypesByModule,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
+            ModuleLinkIndex moduleLinkIndex
+    ) {
+        for (var module : program.modules()) {
+            var moduleRef = new ModuleRef(module.name(), module.path());
+            var availableAnnotations = availableAnnotations(
+                    module.name(),
+                    module.path(),
+                    module.imports(),
+                    annotationsByModule,
+                    moduleLinkIndex
+            );
+            var annotationsByTypeName = new LinkedHashMap<String, List<CompiledAnnotation>>();
+            var definitionsByTypeName = new LinkedHashMap<String, Definition>();
+            for (var definition : module.functional().definitions()) {
+                if (definition instanceof DataDeclaration dataDeclaration) {
+                    definitionsByTypeName.put(dataDeclaration.name(), dataDeclaration);
+                    annotationsByTypeName.put(dataDeclaration.name(), linkAnnotations(dataDeclaration.annotations(), availableAnnotations));
+                } else if (definition instanceof TypeDeclaration typeDeclaration) {
+                    definitionsByTypeName.put(typeDeclaration.name(), typeDeclaration);
+                    annotationsByTypeName.put(typeDeclaration.name(), linkAnnotations(typeDeclaration.annotations(), availableAnnotations));
+                } else if (definition instanceof PrimitiveBackedTypeDeclaration primitiveBackedTypeDeclaration) {
+                    annotationsByTypeName.put(primitiveBackedTypeDeclaration.name(), linkAnnotations(primitiveBackedTypeDeclaration.annotations(), availableAnnotations));
+                } else if (definition instanceof EnumDeclaration enumDeclaration) {
+                    annotationsByTypeName.put(enumDeclaration.name(), linkAnnotations(enumDeclaration.annotations(), availableAnnotations));
+                }
+            }
+
+            var linkedTypes = getModuleEntry(linkedTypesByModule, moduleRef);
+            var annotatedTypes = new TreeMap<String, GenericDataType>();
+            linkedTypes.forEach((name, type) -> annotatedTypes.put(
+                    name,
+                    withCompiledTypeAnnotations(type, annotationsByTypeName, definitionsByTypeName, availableAnnotations)
+            ));
+            putOwnedModuleEntry(linkedTypesByModule, moduleRef, unmodifiableSortedMap(annotatedTypes));
+        }
+    }
+
+    private GenericDataType withCompiledTypeAnnotations(
+            GenericDataType type,
+            Map<String, List<CompiledAnnotation>> annotationsByTypeName,
+            Map<String, Definition> definitionsByTypeName,
+            Map<String, AvailableAnnotation> availableAnnotations
+    ) {
+        return switch (type) {
+            case CompiledDataType dataType -> withCompiledDataTypeAnnotations(
+                    dataType,
+                    annotationsByTypeName,
+                    definitionsByTypeName,
+                    availableAnnotations
+            );
+            case CompiledDataParentType parentType -> new CompiledDataParentType(
+                    parentType.name(),
+                    withCompiledFieldAnnotations(
+                            parentType.name(),
+                            parentType.fields(),
+                            definitionsByTypeName,
+                            availableAnnotations
+                    ),
+                    parentType.subTypes().stream()
+                            .map(subType -> withCompiledDataTypeAnnotations(
+                                    subType,
+                                    annotationsByTypeName,
+                                    definitionsByTypeName,
+                                    availableAnnotations
+                            ))
+                            .toList(),
+                    parentType.typeParameters(),
+                    parentType.comments(),
+                    parentType.visibility(),
+                    parentType.enumType(),
+                    annotationsByTypeName.getOrDefault(parentType.name(), parentType.annotations())
+            );
+            case CompiledPrimitiveBackedType primitiveBackedType -> new CompiledPrimitiveBackedType(
+                    primitiveBackedType.name(),
+                    primitiveBackedType.backingType(),
+                    primitiveBackedType.cfunType(),
+                    primitiveBackedType.comments(),
+                    primitiveBackedType.visibility(),
+                    annotationsByTypeName.getOrDefault(primitiveBackedType.name(), primitiveBackedType.annotations())
+            );
+            case CompiledObjectType objectType -> new CompiledObjectType(
+                    objectType.name(),
+                    objectType.backendClassName(),
+                    objectType.parents(),
+                    objectType.visibility(),
+                    annotationsByTypeName.getOrDefault(objectType.name(), objectType.annotations())
+            );
+        };
+    }
+
+    private CompiledDataType withCompiledDataTypeAnnotations(
+            CompiledDataType dataType,
+            Map<String, List<CompiledAnnotation>> annotationsByTypeName,
+            Map<String, Definition> definitionsByTypeName,
+            Map<String, AvailableAnnotation> availableAnnotations
+    ) {
+        return new CompiledDataType(
+                dataType.name(),
+                withCompiledFieldAnnotations(
+                        dataType.name(),
+                        dataType.fields(),
+                        definitionsByTypeName,
+                        availableAnnotations
+                ),
+                dataType.typeParameters(),
+                dataType.extendedTypes(),
+                dataType.comments(),
+                dataType.visibility(),
+                dataType.singleton(),
+                dataType.nativeType(),
+                dataType.enumValue(),
+                annotationsByTypeName.getOrDefault(dataType.name(), dataType.annotations())
+        );
+    }
+
+    private List<CompiledDataType.CompiledField> withCompiledFieldAnnotations(
+            String typeName,
+            List<CompiledDataType.CompiledField> fields,
+            Map<String, Definition> definitionsByTypeName,
+            Map<String, AvailableAnnotation> availableAnnotations
+    ) {
+        return fields.stream()
+                .map(field -> new CompiledDataType.CompiledField(
+                        field.name(),
+                        field.type(),
+                        findFunctionalFieldAnnotationUsages(typeName, field.name(), definitionsByTypeName, new HashSet<>())
+                                .map(usages -> linkAnnotations(usages, availableAnnotations))
+                                .orElse(field.annotations())
+                ))
+                .toList();
+    }
+
+    private Optional<List<AnnotationUsage>> findFunctionalFieldAnnotationUsages(
+            String typeName,
+            String fieldName,
+            Map<String, Definition> definitionsByTypeName,
+            Set<String> visiting
+    ) {
+        if (!visiting.add(typeName)) {
+            return Optional.empty();
+        }
+        var definition = definitionsByTypeName.get(typeName);
+        if (definition instanceof DataDeclaration dataDeclaration) {
+            var ownField = dataDeclaration.fields().stream()
+                    .filter(field -> field.name().equals(fieldName))
+                    .findFirst();
+            if (ownField.isPresent()) {
+                return Optional.of(ownField.orElseThrow().annotations());
+            }
+            for (var parentName : dataDeclaration.extendsTypes()) {
+                var parent = findFunctionalFieldAnnotationUsages(parentName, fieldName, definitionsByTypeName, visiting);
+                if (parent.isPresent()) {
+                    return parent;
+                }
+            }
+        } else if (definition instanceof TypeDeclaration typeDeclaration) {
+            var ownField = typeDeclaration.fields().stream()
+                    .filter(field -> field.name().equals(fieldName))
+                    .findFirst();
+            if (ownField.isPresent()) {
+                return Optional.of(ownField.orElseThrow().annotations());
+            }
+        }
+        for (var enclosingDefinition : definitionsByTypeName.values()) {
+            if (enclosingDefinition instanceof TypeDeclaration typeDeclaration
+                && typeDeclaration.subTypes().contains(typeName)) {
+                var parentField = typeDeclaration.fields().stream()
+                        .filter(field -> field.name().equals(fieldName))
+                        .findFirst();
+                if (parentField.isPresent()) {
+                    return Optional.of(parentField.orElseThrow().annotations());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private List<ObjectOrientedModule> linkObjectOrientedAnnotationMetadata(
+            List<ObjectOrientedModule> modules,
+            Map<String, Map<String, AnnotationDeclaration>> annotationsByModule,
+            ModuleLinkIndex moduleLinkIndex
+    ) {
+        return modules.stream()
+                .map(module -> {
+                    var availableAnnotations = availableAnnotations(
+                            module.name(),
+                            module.path(),
+                            module.imports(),
+                            annotationsByModule,
+                            moduleLinkIndex
+                    );
+                    var definitions = module.objectOriented().definitions().stream()
+                            .map(definition -> linkObjectOrientedAnnotationMetadata(definition, availableAnnotations))
+                            .toList();
+                    return new ObjectOrientedModule(
+                            module.name(),
+                            module.path(),
+                            new ObjectOriented(definitions),
+                            module.imports(),
+                            module.sourceKind()
+                    );
+                })
+                .toList();
+    }
+
+    private ObjectOriented.TypeDeclaration linkObjectOrientedAnnotationMetadata(
+            ObjectOriented.TypeDeclaration definition,
+            Map<String, AvailableAnnotation> availableAnnotations
+    ) {
+        var linkedMembers = definition.members().stream()
+                .map(member -> linkObjectOrientedAnnotationMetadata(member, availableAnnotations))
+                .toList();
+        return switch (definition) {
+            case ObjectOriented.ClassDeclaration classDeclaration -> new ObjectOriented.ClassDeclaration(
+                    classDeclaration.name(),
+                    classDeclaration.constructorParameters(),
+                    classDeclaration.parents(),
+                    linkedMembers,
+                    classDeclaration.modifiers(),
+                    classDeclaration.comments(),
+                    classDeclaration.annotations(),
+                    linkAnnotations(classDeclaration.annotations(), availableAnnotations)
+            );
+            case ObjectOriented.InterfaceDeclaration interfaceDeclaration -> new ObjectOriented.InterfaceDeclaration(
+                    interfaceDeclaration.name(),
+                    interfaceDeclaration.parents(),
+                    linkedMembers,
+                    interfaceDeclaration.comments(),
+                    interfaceDeclaration.annotations(),
+                    linkAnnotations(interfaceDeclaration.annotations(), availableAnnotations)
+            );
+            case ObjectOriented.TraitDeclaration traitDeclaration -> new ObjectOriented.TraitDeclaration(
+                    traitDeclaration.name(),
+                    traitDeclaration.parents(),
+                    linkedMembers,
+                    traitDeclaration.comments(),
+                    traitDeclaration.annotations(),
+                    linkAnnotations(traitDeclaration.annotations(), availableAnnotations)
+            );
+        };
+    }
+
+    private ObjectOriented.MemberDeclaration linkObjectOrientedAnnotationMetadata(
+            ObjectOriented.MemberDeclaration member,
+            Map<String, AvailableAnnotation> availableAnnotations
+    ) {
+        return switch (member) {
+            case ObjectOriented.FieldDeclaration fieldDeclaration -> new ObjectOriented.FieldDeclaration(
+                    fieldDeclaration.name(),
+                    fieldDeclaration.type(),
+                    fieldDeclaration.visibility(),
+                    fieldDeclaration.initializer(),
+                    fieldDeclaration.comments(),
+                    fieldDeclaration.annotations(),
+                    linkAnnotations(fieldDeclaration.annotations(), availableAnnotations)
+            );
+            case ObjectOriented.MethodDeclaration methodDeclaration -> new ObjectOriented.MethodDeclaration(
+                    methodDeclaration.name(),
+                    methodDeclaration.parameters(),
+                    methodDeclaration.returnType(),
+                    methodDeclaration.visibility(),
+                    methodDeclaration.modifiers(),
+                    methodDeclaration.body(),
+                    methodDeclaration.comments(),
+                    methodDeclaration.annotations(),
+                    linkAnnotations(methodDeclaration.annotations(), availableAnnotations)
+            );
+            case ObjectOriented.InitBlock initBlock -> new ObjectOriented.InitBlock(
+                    initBlock.body(),
+                    initBlock.comments(),
+                    initBlock.annotations(),
+                    linkAnnotations(initBlock.annotations(), availableAnnotations)
+            );
+        };
+    }
+
+    private List<CompiledAnnotation> linkAnnotations(
+            List<AnnotationUsage> usages,
+            Map<String, AvailableAnnotation> availableAnnotations
+    ) {
+        return usages.stream()
+                .map(usage -> linkAnnotation(usage, availableAnnotations.get(usage.name())))
+                .toList();
+    }
+
+    private CompiledAnnotation linkAnnotation(AnnotationUsage usage, AvailableAnnotation availableAnnotation) {
+        if (availableAnnotation == null) {
+            return new CompiledAnnotation(usage.name(), "", "", List.of());
+        }
+        var annotation = availableAnnotation.annotation();
+        var providedArguments = usage.arguments().stream()
+                .collect(toMap(
+                        AnnotationArgument::name,
+                        identity(),
+                        (first, second) -> first,
+                        LinkedHashMap::new
+                ));
+        var arguments = annotation.fields().stream()
+                .map(field -> {
+                    var provided = providedArguments.get(field.name());
+                    var value = provided == null
+                            ? field.defaultValue().orElseThrow()
+                            : provided.value();
+                    return new CompiledAnnotationArgument(field.name(), compiledAnnotationValue(value));
+                })
+                .toList();
+        return new CompiledAnnotation(
+                annotation.name(),
+                availableAnnotation.ownerModule().name(),
+                availableAnnotation.ownerModule().path(),
+                arguments
+        );
+    }
+
+    private CompiledAnnotationValue compiledAnnotationValue(AnnotationValue value) {
+        return switch (value) {
+            case AnnotationValue.StringValue stringValue -> new CompiledAnnotationValue.StringValue(stringValue.value());
+            case AnnotationValue.IntValue intValue -> new CompiledAnnotationValue.IntValue(intValue.value());
+            case AnnotationValue.LongValue longValue -> new CompiledAnnotationValue.LongValue(longValue.value());
+            case AnnotationValue.FloatValue floatValue -> new CompiledAnnotationValue.FloatValue(floatValue.value());
+            case AnnotationValue.DoubleValue doubleValue -> new CompiledAnnotationValue.DoubleValue(doubleValue.value());
+            case AnnotationValue.BoolValue boolValue -> new CompiledAnnotationValue.BoolValue(boolValue.value());
+            case AnnotationValue.NothingValue ignored -> new CompiledAnnotationValue.NothingValue();
+            case AnnotationValue.TypeNameValue typeNameValue -> new CompiledAnnotationValue.TypeNameValue(typeNameValue.name());
+        };
+    }
+
+    private Result.Error.SingleError errorAt(String message, Optional<SourcePosition> position, String file) {
+        var sourcePosition = position.orElse(SourcePosition.EMPTY);
+        return new Result.Error.SingleError(
+                sourcePosition.line(),
+                sourcePosition.column(),
+                file,
+                message
+        );
     }
 
     private List<ModuleRef> usedImportedDeriverOwnerModules(
@@ -2376,7 +3373,8 @@ public class CapybaraCompiler {
                     definition.name(),
                     objectBackendClassName(module, definition.name()),
                     objectParentNames(definition, definitionsByName, new LinkedHashSet<>()),
-                    null
+                    null,
+                    definition.linkedAnnotations()
             );
             types.put(definition.name(), type);
         }
@@ -3278,6 +4276,7 @@ public class CapybaraCompiler {
             Map<String, String> moduleClassNameByModuleName,
             Map<String, String> qualifiedModuleAliases,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
+            Map<String, AvailableAnnotation> availableAnnotations,
             String moduleSourceFile,
             CompileCache compileCache
     ) {
@@ -3286,7 +4285,7 @@ public class CapybaraCompiler {
                 CapybaraExpressionCompiler.LinkCache::new
         );
         return functions.stream()
-                .map(f -> linkFunction(f, dataTypes, localTypeNames, signatures, signaturesByModule, moduleClassNameByModuleName, qualifiedModuleAliases, protectedConstructorsByType, moduleSourceFile, linkCache, compileCache))
+                .map(f -> linkFunction(f, dataTypes, localTypeNames, signatures, signaturesByModule, moduleClassNameByModuleName, qualifiedModuleAliases, protectedConstructorsByType, availableAnnotations, moduleSourceFile, linkCache, compileCache))
                 .collect(new ResultCollectionCollector<>());
     }
 
@@ -3299,6 +4298,7 @@ public class CapybaraCompiler {
             Map<String, String> moduleClassNameByModuleName,
             Map<String, String> qualifiedModuleAliases,
             CapybaraExpressionCompiler.ConstructorRegistry protectedConstructorsByType,
+            Map<String, AvailableAnnotation> availableAnnotations,
             String moduleSourceFile,
             CapybaraExpressionCompiler.LinkCache linkCache,
             CompileCache compileCache
@@ -3312,6 +4312,10 @@ public class CapybaraCompiler {
             return localMethodValidationError.get();
         }
         var functionGenericTypeNames = functionGenericTypeNames(function, dataTypes, compileCache);
+        var linkedAnnotations = linkAnnotations(function.annotations(), availableAnnotations);
+        var tailRecursiveContract = function.annotations().stream()
+                .map(usage -> availableAnnotations.get(usage.name()))
+                .anyMatch(this::isRecursiveAnnotation);
         var linked = linkParameters(function.parameters(), dataTypes, functionGenericTypeNames, compileCache)
                 .flatMap(parameters -> linkExpressionWithRecursiveInference(
                         function,
@@ -3334,6 +4338,7 @@ public class CapybaraCompiler {
                                                 parameters,
                                                 finalExpression,
                                                 tailRecursiveSelfCallNames(function.name(), moduleSourceFile, moduleClassNameByModuleName),
+                                                tailRecursiveContract,
                                                 moduleSourceFile
                                         ).map(recursion -> new CompiledFunction(
                                                 function.name(),
@@ -3344,7 +4349,8 @@ public class CapybaraCompiler {
                                                 function.visibility(),
                                                 isProgramMain(function.name(), rtype, parameters),
                                                 recursion.recursive(),
-                                                recursion.tailRecursive()
+                                                recursion.tailRecursive(),
+                                                linkedAnnotations
                                         )))))));
         linked = normalizeInfixOperatorErrors(linked, function, moduleSourceFile);
         linked = normalizeMatchExhaustivenessErrors(linked, function, moduleSourceFile);
@@ -3361,23 +4367,24 @@ public class CapybaraCompiler {
             List<CompiledFunctionParameter> parameters,
             CompiledExpression expression,
             Set<String> selfCallNames,
+            boolean tailRecursiveContract,
             String moduleSourceFile
     ) {
         var analysis = analyzeTailRecursion(selfCallNames, parameters, expression, true);
         if (methodOwnerType(function.name()).isPresent()) {
-            if (function.tailRecursive()) {
+            if (tailRecursiveContract) {
                 return tailRecursiveFunctionError(
                         function,
                         function.position(),
                         moduleSourceFile,
-                        "`fun rec` is supported for functions, not type methods"
+                        "`@Recursive` is supported for functions, not type methods"
                 );
             }
             return Result.success(new RecursionClassification(analysis.hasSelfCall(), false));
         }
 
         if (analysis.firstNonTailCall().isPresent()) {
-            if (function.tailRecursive()) {
+            if (tailRecursiveContract) {
                 return tailRecursiveFunctionError(
                         function,
                         function.position(),
@@ -3388,12 +4395,12 @@ public class CapybaraCompiler {
             return Result.success(new RecursionClassification(true, false));
         }
         if (!analysis.hasSelfCall()) {
-            if (function.tailRecursive()) {
+            if (tailRecursiveContract) {
                 return tailRecursiveFunctionError(
                         function,
                         function.position(),
                         moduleSourceFile,
-                        "`fun rec` function `" + displayFunctionName(function.name()) + "` must call itself in tail position"
+                        "`@Recursive` function `" + displayFunctionName(function.name()) + "` must call itself in tail position"
                 );
             }
             return Result.success(new RecursionClassification(false, false));
@@ -4105,7 +5112,7 @@ public class CapybaraCompiler {
     }
 
     private String functionKeyword(Function function) {
-        return function.tailRecursive() ? "fun rec" : "fun";
+        return "fun";
     }
 
     private int methodDeclarationErrorLine(Function function) {
@@ -5099,6 +6106,10 @@ public class CapybaraCompiler {
         return module.sourceKind().moduleFile(module.path(), module.name());
     }
 
+    private String moduleSourceFile(ObjectOrientedModule module) {
+        return module.sourceKind().moduleFile(module.path(), module.name());
+    }
+
     private dev.capylang.compiler.expression.CompiledExpression enrichNothing(
             dev.capylang.compiler.expression.CompiledExpression expression,
             String functionName,
@@ -5274,6 +6285,7 @@ public class CapybaraCompiler {
                             value.packageName(),
                             value.packagePath(),
                             value.fields(),
+                            value.annotations(),
                             value.type()
                     );
             case dev.capylang.compiler.expression.CompiledSliceExpression value ->
@@ -6110,14 +7122,18 @@ public class CapybaraCompiler {
                         parentType.fields().stream()
                                 .map(field -> new CompiledDataType.CompiledField(
                                         field.name(),
-                                        substituteTypeParameters(field.type(), substitutions)
+                                        substituteTypeParameters(field.type(), substitutions),
+                                        field.annotations()
                                 ))
                                 .toList(),
                         parentType.subTypes().stream()
                                 .map(subType -> (CompiledDataType) substituteTypeParameters(subType, substitutions))
                                 .toList(),
                         mappedTypeArguments,
-                        parentType.enumType()
+                        parentType.comments(),
+                        parentType.visibility(),
+                        parentType.enumType(),
+                        parentType.annotations()
                 );
             }
             case CompiledDataType dataType -> {
@@ -6131,7 +7147,8 @@ public class CapybaraCompiler {
                             dataType.visibility(),
                             dataType.singleton(),
                             dataType.nativeType(),
-                            dataType.enumValue()
+                            dataType.enumValue(),
+                            dataType.annotations()
                     );
                 }
                 var substitutions = new LinkedHashMap<String, CompiledType>();
@@ -6140,7 +7157,11 @@ public class CapybaraCompiler {
                     substitutions.put(dataType.typeParameters().get(i), typeArguments.get(i));
                 }
                 var substitutedFields = dataType.fields().stream()
-                        .map(field -> new CompiledDataType.CompiledField(field.name(), substituteTypeParameters(field.type(), substitutions)))
+                        .map(field -> new CompiledDataType.CompiledField(
+                                field.name(),
+                                substituteTypeParameters(field.type(), substitutions),
+                                field.annotations()
+                        ))
                         .toList();
                 yield new CompiledDataType(
                         dataType.name(),
@@ -6151,7 +7172,8 @@ public class CapybaraCompiler {
                         dataType.visibility(),
                         dataType.singleton(),
                         dataType.nativeType(),
-                        dataType.enumValue()
+                        dataType.enumValue(),
+                        dataType.annotations()
                 );
             }
             default -> linkedType;
@@ -6450,7 +7472,8 @@ public class CapybaraCompiler {
                 List.of(dataType.name(), PrimitiveLinkedType.STRING.name()),
                 resultParent.comments(),
                 resultParent.visibility(),
-                resultParent.enumType()
+                resultParent.enumType(),
+                resultParent.annotations()
         );
     }
 
@@ -6905,7 +7928,8 @@ public class CapybaraCompiler {
                     parentType.typeParameters(),
                     parentType.comments(),
                     parentType.visibility(),
-                    parentType.enumType()
+                    parentType.enumType(),
+                    parentType.annotations()
             );
             case CompiledDataType dataType -> new CompiledDataType(
                     alias,
@@ -6916,7 +7940,8 @@ public class CapybaraCompiler {
                     dataType.visibility(),
                     dataType.singleton(),
                     dataType.nativeType(),
-                    dataType.enumValue()
+                    dataType.enumValue(),
+                    dataType.annotations()
             );
             default -> placeholder;
         };
@@ -7134,7 +8159,8 @@ public class CapybaraCompiler {
                 childType.visibility(),
                 childType.singleton(),
                 childType.nativeType(),
-                childType.enumValue()
+                childType.enumValue(),
+                childType.annotations()
         ));
     }
 

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraTypeCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraTypeCompiler.java
@@ -228,7 +228,8 @@ public class CapybaraTypeCompiler {
                         parentType.fields().stream()
                                 .map(field -> new CompiledDataType.CompiledField(
                                         field.name(),
-                                        substituteTypeParameters(field.type(), substitutions)
+                                        substituteTypeParameters(field.type(), substitutions),
+                                        field.annotations()
                                 ))
                                 .toList(),
                         parentType.subTypes().stream()
@@ -237,7 +238,8 @@ public class CapybaraTypeCompiler {
                         mappedTypeArguments,
                         parentType.comments(),
                         parentType.visibility(),
-                        parentType.enumType()
+                        parentType.enumType(),
+                        parentType.annotations()
                 );
             }
             case CompiledDataType dataType -> {
@@ -251,12 +253,17 @@ public class CapybaraTypeCompiler {
                             dataType.visibility(),
                             dataType.singleton(),
                             dataType.nativeType(),
-                            dataType.enumValue()
+                            dataType.enumValue(),
+                            dataType.annotations()
                     );
                 }
                 var substitutions = substitutionsFor(dataType.typeParameters(), typeArguments);
                 var substitutedFields = dataType.fields().stream()
-                        .map(field -> new CompiledDataType.CompiledField(field.name(), substituteTypeParameters(field.type(), substitutions)))
+                        .map(field -> new CompiledDataType.CompiledField(
+                                field.name(),
+                                substituteTypeParameters(field.type(), substitutions),
+                                field.annotations()
+                        ))
                         .toList();
                 yield new CompiledDataType(
                         dataType.name(),
@@ -271,7 +278,8 @@ public class CapybaraTypeCompiler {
                         dataType.visibility(),
                         dataType.singleton(),
                         dataType.nativeType(),
-                        dataType.enumValue()
+                        dataType.enumValue(),
+                        dataType.annotations()
                 );
             }
             case CompiledObjectType objectType -> objectType;
@@ -337,7 +345,8 @@ public class CapybaraTypeCompiler {
                     linkedDataType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    substituteTypeParameters(field.type(), substitutions)
+                                    substituteTypeParameters(field.type(), substitutions),
+                                    field.annotations()
                             ))
                             .toList(),
                     linkedDataType.typeParameters().stream()
@@ -350,14 +359,16 @@ public class CapybaraTypeCompiler {
                     linkedDataType.visibility(),
                     linkedDataType.singleton(),
                     linkedDataType.nativeType(),
-                    linkedDataType.enumValue()
+                    linkedDataType.enumValue(),
+                    linkedDataType.annotations()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
                     linkedDataParentType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    substituteTypeParameters(field.type(), substitutions)
+                                    substituteTypeParameters(field.type(), substitutions),
+                                    field.annotations()
                             ))
                             .toList(),
                     linkedDataParentType.subTypes().stream()
@@ -368,7 +379,8 @@ public class CapybaraTypeCompiler {
                             .toList(),
                     linkedDataParentType.comments(),
                     linkedDataParentType.visibility(),
-                    linkedDataParentType.enumType()
+                    linkedDataParentType.enumType(),
+                    linkedDataParentType.annotations()
             );
             default -> type;
         };
@@ -546,7 +558,8 @@ public class CapybaraTypeCompiler {
                     linkedDataType.visibility(),
                     linkedDataType.singleton(),
                     linkedDataType.nativeType(),
-                    linkedDataType.enumValue()
+                    linkedDataType.enumValue(),
+                    linkedDataType.annotations()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     requestedName,
@@ -555,14 +568,16 @@ public class CapybaraTypeCompiler {
                     linkedDataParentType.typeParameters(),
                     linkedDataParentType.comments(),
                     linkedDataParentType.visibility(),
-                    linkedDataParentType.enumType()
+                    linkedDataParentType.enumType(),
+                    linkedDataParentType.annotations()
             );
             case CompiledPrimitiveBackedType primitiveBackedType -> new CompiledPrimitiveBackedType(
                     requestedName,
                     primitiveBackedType.backingType(),
                     primitiveBackedType.cfunType(),
                     primitiveBackedType.comments(),
-                    primitiveBackedType.visibility()
+                    primitiveBackedType.visibility(),
+                    primitiveBackedType.annotations()
             );
             case CompiledObjectType objectType -> objectType;
         };

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledAnnotation.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledAnnotation.java
@@ -1,0 +1,14 @@
+package dev.capylang.compiler;
+
+import java.util.List;
+
+public record CompiledAnnotation(
+        String name,
+        String packageName,
+        String packagePath,
+        List<CompiledAnnotationArgument> arguments
+) {
+    public CompiledAnnotation {
+        arguments = arguments == null ? List.of() : List.copyOf(arguments);
+    }
+}

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledAnnotationArgument.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledAnnotationArgument.java
@@ -1,0 +1,4 @@
+package dev.capylang.compiler;
+
+public record CompiledAnnotationArgument(String name, CompiledAnnotationValue value) {
+}

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledAnnotationValue.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledAnnotationValue.java
@@ -1,0 +1,34 @@
+package dev.capylang.compiler;
+
+public sealed interface CompiledAnnotationValue permits CompiledAnnotationValue.StringValue,
+        CompiledAnnotationValue.IntValue,
+        CompiledAnnotationValue.LongValue,
+        CompiledAnnotationValue.FloatValue,
+        CompiledAnnotationValue.DoubleValue,
+        CompiledAnnotationValue.BoolValue,
+        CompiledAnnotationValue.NothingValue,
+        CompiledAnnotationValue.TypeNameValue {
+    record StringValue(String value) implements CompiledAnnotationValue {
+    }
+
+    record IntValue(String value) implements CompiledAnnotationValue {
+    }
+
+    record LongValue(String value) implements CompiledAnnotationValue {
+    }
+
+    record FloatValue(String value) implements CompiledAnnotationValue {
+    }
+
+    record DoubleValue(String value) implements CompiledAnnotationValue {
+    }
+
+    record BoolValue(boolean value) implements CompiledAnnotationValue {
+    }
+
+    record NothingValue() implements CompiledAnnotationValue {
+    }
+
+    record TypeNameValue(String name) implements CompiledAnnotationValue {
+    }
+}

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledDataParentType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledDataParentType.java
@@ -9,7 +9,21 @@ public record CompiledDataParentType(String name, List<CompiledField> fields,
                                    List<String> typeParameters,
                                    List<String> comments,
                                    Visibility visibility,
-                                   boolean enumType) implements GenericDataType, Comparable<CompiledDataParentType> {
+                                   boolean enumType,
+                                   List<CompiledAnnotation> annotations) implements GenericDataType, Comparable<CompiledDataParentType> {
+
+    public CompiledDataParentType {
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
+    }
+
+    public CompiledDataParentType(String name, List<CompiledField> fields,
+                                  List<CompiledDataType> subTypes,
+                                  List<String> typeParameters,
+                                  List<String> comments,
+                                  Visibility visibility,
+                                  boolean enumType) {
+        this(name, fields, subTypes, typeParameters, comments, visibility, enumType, List.of());
+    }
 
     public CompiledDataParentType(String name, List<CompiledField> fields, List<CompiledDataType> subTypes, List<String> typeParameters) {
         this(name, fields, subTypes, typeParameters, List.of(), null, false);

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledDataType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledDataType.java
@@ -10,7 +10,24 @@ public record CompiledDataType(String name,
                              Visibility visibility,
                              boolean singleton,
                              boolean nativeType,
-                             boolean enumValue) implements GenericDataType, Comparable<CompiledDataType> {
+                             boolean enumValue,
+                             List<CompiledAnnotation> annotations) implements GenericDataType, Comparable<CompiledDataType> {
+    public CompiledDataType {
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
+    }
+
+    public CompiledDataType(String name,
+                            List<CompiledField> fields,
+                            List<String> typeParameters,
+                            List<String> extendedTypes,
+                            List<String> comments,
+                            Visibility visibility,
+                            boolean singleton,
+                            boolean nativeType,
+                            boolean enumValue) {
+        this(name, fields, typeParameters, extendedTypes, comments, visibility, singleton, nativeType, enumValue, List.of());
+    }
+
     public CompiledDataType(String name,
                             List<CompiledField> fields,
                             List<String> typeParameters,
@@ -66,6 +83,13 @@ public record CompiledDataType(String name,
         return name.compareTo(o.name);
     }
 
-    public record CompiledField(String name, CompiledType type) {
+    public record CompiledField(String name, CompiledType type, List<CompiledAnnotation> annotations) {
+        public CompiledField {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+        }
+
+        public CompiledField(String name, CompiledType type) {
+            this(name, type, List.of());
+        }
     }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledFunction.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledFunction.java
@@ -13,7 +13,24 @@ public record CompiledFunction(String name,
                              Visibility visibility,
                              boolean programMain,
                              boolean recursive,
-                             boolean tailRecursive) implements Comparable<CompiledFunction> {
+                             boolean tailRecursive,
+                             List<CompiledAnnotation> annotations) implements Comparable<CompiledFunction> {
+    public CompiledFunction {
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
+    }
+
+    public CompiledFunction(String name,
+                            CompiledType returnType,
+                            List<CompiledFunctionParameter> parameters,
+                            CompiledExpression expression,
+                            List<String> comments,
+                            Visibility visibility,
+                            boolean programMain,
+                            boolean recursive,
+                            boolean tailRecursive) {
+        this(name, returnType, parameters, expression, comments, visibility, programMain, recursive, tailRecursive, List.of());
+    }
+
     public CompiledFunction(String name,
                           CompiledType returnType,
                           List<CompiledFunctionParameter> parameters,

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledModule.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledModule.java
@@ -1,5 +1,6 @@
 package dev.capylang.compiler;
 
+import dev.capylang.compiler.parser.AnnotationDeclaration;
 import dev.capylang.compiler.parser.DeriverDeclaration;
 
 import java.util.Collection;
@@ -18,6 +19,7 @@ public record CompiledModule(
         SortedMap<String, CompiledPrimitiveBackedType> visiblePrimitiveBackedTypes,
         SortedSet<CompiledFunction> functions,
         SortedMap<String, DeriverDeclaration> derivers,
+        SortedMap<String, AnnotationDeclaration> annotations,
         SortedSet<StaticImport> staticImports) implements Comparable<CompiledModule> {
 
     public static final String EXTENSION = ".json";
@@ -29,7 +31,7 @@ public record CompiledModule(
             Collection<CompiledFunction> functions,
             Collection<StaticImport> staticImports
     ) {
-        this(name, path, types, functions, Map.of(), Map.of(), staticImports);
+        this(name, path, types, functions, Map.of(), Map.of(), Map.of(), staticImports);
     }
 
     public CompiledModule(
@@ -40,7 +42,7 @@ public record CompiledModule(
             Map<String, DeriverDeclaration> derivers,
             Collection<StaticImport> staticImports
     ) {
-        this(name, path, types, functions, derivers, Map.of(), staticImports);
+        this(name, path, types, functions, derivers, Map.of(), Map.of(), staticImports);
     }
 
     public CompiledModule(
@@ -52,6 +54,19 @@ public record CompiledModule(
             Map<String, CompiledPrimitiveBackedType> visiblePrimitiveBackedTypes,
             Collection<StaticImport> staticImports
     ) {
+        this(name, path, types, functions, derivers, visiblePrimitiveBackedTypes, Map.of(), staticImports);
+    }
+
+    public CompiledModule(
+            String name,
+            String path,
+            Map<String, GenericDataType> types,
+            Collection<CompiledFunction> functions,
+            Map<String, DeriverDeclaration> derivers,
+            Map<String, CompiledPrimitiveBackedType> visiblePrimitiveBackedTypes,
+            Map<String, AnnotationDeclaration> annotations,
+            Collection<StaticImport> staticImports
+    ) {
         this(
                 name,
                 path,
@@ -59,6 +74,7 @@ public record CompiledModule(
                 new TreeMap<>(visiblePrimitiveBackedTypes),
                 new TreeSet<>(functions),
                 new TreeMap<>(derivers),
+                new TreeMap<>(annotations),
                 new TreeSet<>(staticImports)
         );
     }
@@ -68,6 +84,7 @@ public record CompiledModule(
         visiblePrimitiveBackedTypes = visiblePrimitiveBackedTypes == null ? new TreeMap<>() : new TreeMap<>(visiblePrimitiveBackedTypes);
         functions = new TreeSet<>(functions);
         derivers = derivers == null ? new TreeMap<>() : new TreeMap<>(derivers);
+        annotations = annotations == null ? new TreeMap<>() : new TreeMap<>(annotations);
         staticImports = new TreeSet<>(staticImports);
     }
 

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledObjectType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledObjectType.java
@@ -6,10 +6,21 @@ public record CompiledObjectType(
         String name,
         String backendClassName,
         List<String> parents,
-        Visibility visibility
+        Visibility visibility,
+        List<CompiledAnnotation> annotations
 ) implements GenericDataType {
     public CompiledObjectType {
         parents = List.copyOf(parents);
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
+    }
+
+    public CompiledObjectType(
+            String name,
+            String backendClassName,
+            List<String> parents,
+            Visibility visibility
+    ) {
+        this(name, backendClassName, parents, visibility, List.of());
     }
 
     @Override

--- a/compiler/src/main/java/dev/capylang/compiler/CompiledPrimitiveBackedType.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CompiledPrimitiveBackedType.java
@@ -7,8 +7,23 @@ public record CompiledPrimitiveBackedType(
         PrimitiveLinkedType backingType,
         String cfunType,
         List<String> comments,
-        Visibility visibility
+        Visibility visibility,
+        List<CompiledAnnotation> annotations
 ) implements GenericDataType, Comparable<CompiledPrimitiveBackedType> {
+    public CompiledPrimitiveBackedType {
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
+    }
+
+    public CompiledPrimitiveBackedType(
+            String name,
+            PrimitiveLinkedType backingType,
+            String cfunType,
+            List<String> comments,
+            Visibility visibility
+    ) {
+        this(name, backingType, cfunType, comments, visibility, List.of());
+    }
+
     public CompiledPrimitiveBackedType(
             String name,
             PrimitiveLinkedType backingType,

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -1325,6 +1325,7 @@ public class CapybaraExpressionCompiler {
                     "",
                     "",
                     List.of(),
+                    List.of(),
                     dataValueInfo
             ));
         }
@@ -1334,7 +1335,7 @@ public class CapybaraExpressionCompiler {
                     functionCall.arguments().getFirst().position()
             );
         }
-        var packagePath = reflectionPackagePath(dataType.name());
+        var packagePath = reflectionValuePackagePath(dataType);
         var packageName = packagePath.isBlank() ? "" : simpleTypeNameStatic(packagePath);
         return Result.success(new CompiledReflectionValue(
                 target,
@@ -1342,10 +1343,40 @@ public class CapybaraExpressionCompiler {
                 packageName,
                 packagePath,
                 dataType.fields().stream()
-                        .map(field -> new CompiledReflectionValue.Field(field.name(), field.type()))
+                        .map(field -> new CompiledReflectionValue.Field(
+                                field.name(),
+                                field.type(),
+                                field.annotations()
+                        ))
                         .toList(),
+                reflectionValueAnnotations(dataType),
                 dataValueInfo
         ));
+    }
+
+    private String reflectionValuePackagePath(GenericDataType dataType) {
+        if (dataType instanceof CompiledDataType compiledDataType && compiledDataType.enumValue()) {
+            return enumParentForValue(compiledDataType)
+                    .map(parentType -> reflectionPackagePath(parentType.name()))
+                    .orElseGet(() -> reflectionPackagePath(compiledDataType.name()));
+        }
+        return reflectionPackagePath(dataType.name());
+    }
+
+    private List<CompiledAnnotation> reflectionValueAnnotations(GenericDataType dataType) {
+        if (dataType instanceof CompiledDataType compiledDataType && compiledDataType.enumValue()) {
+            return enumParentForValue(compiledDataType)
+                    .map(CompiledDataParentType::annotations)
+                    .orElseGet(compiledDataType::annotations);
+        }
+        return reflectionAnnotations(dataType);
+    }
+
+    private Optional<CompiledDataParentType> enumParentForValue(CompiledDataType dataType) {
+        return parentTypesForSubtype(dataType.name()).stream()
+                .filter(CompiledDataParentType::enumType)
+                .filter(parentType -> hasMatchingSubtype(parentType, dataType))
+                .findFirst();
     }
 
     private CompiledExpression reflectionTypeInfo(CompiledType type, CompiledDataParentType anyInfo) {
@@ -1372,7 +1403,8 @@ public class CapybaraExpressionCompiler {
         var dataInfo = reflectionDataType(anyInfo, "DataInfo");
         return newData(dataInfo,
                 "name", stringLiteral(simpleTypeNameStatic(parentType.name())),
-                "pkg", packageInfo(parentType.name(), anyInfo)
+                "pkg", packageInfo(parentType.name(), anyInfo),
+                "annotations", reflectionAnnotations(anyInfo, parentType.annotations())
         );
     }
 
@@ -1383,14 +1415,25 @@ public class CapybaraExpressionCompiler {
         var dataInfo = reflectionDataType(anyInfo, "DataInfo");
         return newData(dataInfo,
                 "name", stringLiteral(simpleTypeNameStatic(dataType.name())),
-                "pkg", packageInfo(dataType.name(), anyInfo)
+                "pkg", packageInfo(dataType.name(), anyInfo),
+                "annotations", reflectionAnnotations(anyInfo, reflectionAnnotations(dataType))
         );
+    }
+
+    private List<CompiledAnnotation> reflectionAnnotations(GenericDataType dataType) {
+        return switch (dataType) {
+            case CompiledDataType compiledDataType -> compiledDataType.annotations();
+            case CompiledDataParentType parentType -> parentType.annotations();
+            case CompiledObjectType objectType -> objectType.annotations();
+            case CompiledPrimitiveBackedType primitiveBackedType -> primitiveBackedType.annotations();
+        };
     }
 
     private CompiledExpression reflectionPrimitiveInfo(PrimitiveLinkedType primitive, CompiledDataParentType anyInfo) {
         return newData(reflectionDataType(anyInfo, "DataInfo"),
                 "name", stringLiteral(primitiveTypeName(primitive)),
-                "pkg", emptyPackageInfo(anyInfo)
+                "pkg", emptyPackageInfo(anyInfo),
+                "annotations", reflectionAnnotations(anyInfo, List.of())
         );
     }
 
@@ -1442,16 +1485,99 @@ public class CapybaraExpressionCompiler {
     ) {
         return newData(reflectionDataType(anyInfo, "DataInfo"),
                 "name", stringLiteral(genericTypeParameter.name()),
-                "pkg", emptyPackageInfo(anyInfo)
+                "pkg", emptyPackageInfo(anyInfo),
+                "annotations", reflectionAnnotations(anyInfo, List.of())
         );
+    }
+
+    private CompiledExpression reflectionAnnotations(
+            CompiledDataParentType anyInfo,
+            List<CompiledAnnotation> annotations
+    ) {
+        var annotationInfo = reflectionDataType(anyInfo, "AnnotationInfo");
+        return new CompiledNewList(
+                annotations.stream()
+                        .map(annotation -> reflectionAnnotationInfo(anyInfo, annotation))
+                        .toList(),
+                new CompiledList(annotationInfo)
+        );
+    }
+
+    private CompiledExpression reflectionAnnotationInfo(
+            CompiledDataParentType anyInfo,
+            CompiledAnnotation annotation
+    ) {
+        return newData(reflectionDataType(anyInfo, "AnnotationInfo"),
+                "name", stringLiteral(annotation.name()),
+                "pkg", packageInfo(annotation.packageName(), annotation.packagePath(), anyInfo),
+                "arguments", new CompiledNewList(
+                        annotation.arguments().stream()
+                                .map(argument -> reflectionAnnotationArgumentInfo(anyInfo, argument))
+                                .toList(),
+                        new CompiledList(reflectionDataType(anyInfo, "AnnotationArgumentInfo"))
+                )
+        );
+    }
+
+    private CompiledExpression reflectionAnnotationArgumentInfo(
+            CompiledDataParentType anyInfo,
+            CompiledAnnotationArgument argument
+    ) {
+        return newData(reflectionDataType(anyInfo, "AnnotationArgumentInfo"),
+                "name", stringLiteral(argument.name()),
+                "value", reflectionAnnotationValue(anyInfo, argument.value())
+        );
+    }
+
+    private CompiledExpression reflectionAnnotationValue(
+            CompiledDataParentType anyInfo,
+            CompiledAnnotationValue value
+    ) {
+        return switch (value) {
+            case CompiledAnnotationValue.StringValue stringValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationString"),
+                    "value", new CompiledStringValue(normalizeAnnotationStringLiteral(stringValue.value()))
+            );
+            case CompiledAnnotationValue.IntValue intValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationInt"),
+                    "value", new CompiledIntValue(intValue.value())
+            );
+            case CompiledAnnotationValue.LongValue longValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationLong"),
+                    "value", new CompiledLongValue(longValue.value())
+            );
+            case CompiledAnnotationValue.DoubleValue doubleValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationDouble"),
+                    "value", new CompiledDoubleValue(doubleValue.value())
+            );
+            case CompiledAnnotationValue.FloatValue floatValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationFloat"),
+                    "value", new CompiledFloatValue(floatValue.value())
+            );
+            case CompiledAnnotationValue.BoolValue boolValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationBool"),
+                    "value", boolValue.value() ? CompiledBooleanValue.TRUE : CompiledBooleanValue.FALSE
+            );
+            case CompiledAnnotationValue.TypeNameValue typeNameValue -> newData(
+                    reflectionDataType(anyInfo, "AnnotationTypeName"),
+                    "value", stringLiteral(typeNameValue.name())
+            );
+            case CompiledAnnotationValue.NothingValue ignored -> newData(
+                    reflectionDataType(anyInfo, "AnnotationNothing")
+            );
+        };
     }
 
     private CompiledExpression packageInfo(String symbolName, CompiledDataParentType anyInfo) {
         var path = reflectionPackagePath(symbolName);
         var name = path.isBlank() ? "" : simpleTypeNameStatic(path);
+        return packageInfo(name, path, anyInfo);
+    }
+
+    private CompiledExpression packageInfo(String name, String path, CompiledDataParentType anyInfo) {
         return newData(reflectionDataType(anyInfo, "PackageInfo"),
-                "name", stringLiteral(name),
-                "path", stringLiteral(path)
+                "name", stringLiteral(name == null ? "" : name),
+                "path", stringLiteral(path == null ? "" : path.replaceFirst("^/", ""))
         );
     }
 
@@ -1498,7 +1624,8 @@ public class CapybaraExpressionCompiler {
                 dataType.visibility(),
                 dataType.singleton(),
                 dataType.nativeType(),
-                dataType.enumValue()
+                dataType.enumValue(),
+                dataType.annotations()
         );
     }
 
@@ -1511,7 +1638,8 @@ public class CapybaraExpressionCompiler {
                 parentType.typeParameters(),
                 parentType.comments(),
                 parentType.visibility(),
-                parentType.enumType()
+                parentType.enumType(),
+                parentType.annotations()
         );
     }
 
@@ -1672,6 +1800,45 @@ public class CapybaraExpressionCompiler {
                 .replace("\r", "\\r")
                 .replace("\t", "\\t")
                 + "\"");
+    }
+
+    private static String normalizeAnnotationStringLiteral(String raw) {
+        if (raw.length() < 2) {
+            return "\"" + raw + "\"";
+        }
+        if (raw.charAt(0) == '"' && raw.charAt(raw.length() - 1) == '"') {
+            var content = normalizeAnnotationDoubleQuotedContent(raw.substring(1, raw.length() - 1));
+            return "\"" + content
+                    .replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    + "\"";
+        }
+        if (raw.charAt(0) == '\'' && raw.charAt(raw.length() - 1) == '\'') {
+            var content = raw.substring(1, raw.length() - 1)
+                    .replace("\"", "\\\"");
+            return "\"" + content + "\"";
+        }
+        return "\"" + raw
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                + "\"";
+    }
+
+    private static String normalizeAnnotationDoubleQuotedContent(String content) {
+        var normalized = new StringBuilder(content.length());
+        for (var i = 0; i < content.length(); i++) {
+            var ch = content.charAt(i);
+            if (ch == '\\' && i + 1 < content.length()) {
+                var next = content.charAt(i + 1);
+                if (next == '"' || next == '\\') {
+                    normalized.append(next);
+                    i++;
+                    continue;
+                }
+            }
+            normalized.append(ch);
+        }
+        return normalized.toString();
     }
 
     private record SingletonDataType(CompiledDataType type, Optional<CompiledDataParentType> enumParent) {
@@ -3367,7 +3534,8 @@ public class CapybaraExpressionCompiler {
                 dataType.visibility(),
                 dataType.singleton(),
                 dataType.nativeType(),
-                dataType.enumValue()
+                dataType.enumValue(),
+                dataType.annotations()
         )));
     }
 
@@ -4120,7 +4288,8 @@ public class CapybaraExpressionCompiler {
                 expectedSubtype.visibility(),
                 expectedSubtype.singleton(),
                 expectedSubtype.nativeType(),
-                expectedSubtype.enumValue()
+                expectedSubtype.enumValue(),
+                expectedSubtype.annotations()
         );
     }
 
@@ -5769,7 +5938,10 @@ public class CapybaraExpressionCompiler {
                 parent.fields(),
                 parent.subTypes(),
                 parent.typeParameters(),
-                canonical.enumType()
+                canonical.comments(),
+                canonical.visibility(),
+                canonical.enumType(),
+                canonical.annotations()
         );
     }
 
@@ -5874,7 +6046,8 @@ public class CapybaraExpressionCompiler {
                     dataType.visibility(),
                     dataType.singleton(),
                     dataType.nativeType(),
-                    dataType.enumValue()
+                    dataType.enumValue(),
+                    dataType.annotations()
             );
         }
         var substitutions = typeParameterSubstitutions(rawDataType.typeParameters(), typeParameters);
@@ -5891,7 +6064,8 @@ public class CapybaraExpressionCompiler {
                 dataType.visibility(),
                 substituted.singleton(),
                 substituted.nativeType(),
-                substituted.enumValue()
+                substituted.enumValue(),
+                substituted.annotations()
         );
     }
 
@@ -5906,7 +6080,10 @@ public class CapybaraExpressionCompiler {
                     parentType.fields(),
                     parentType.subTypes(),
                     typeParameters,
-                    parentType.enumType()
+                    parentType.comments(),
+                    parentType.visibility(),
+                    parentType.enumType(),
+                    parentType.annotations()
             );
         }
         var substitutions = typeParameterSubstitutions(rawParentType.typeParameters(), typeParameters);
@@ -5919,7 +6096,10 @@ public class CapybaraExpressionCompiler {
                 substituted.fields(),
                 substituted.subTypes(),
                 typeParameters,
-                substituted.enumType()
+                substituted.comments(),
+                substituted.visibility(),
+                substituted.enumType(),
+                substituted.annotations()
         );
     }
 
@@ -6588,7 +6768,16 @@ public class CapybaraExpressionCompiler {
         var typeParameters = optionType.typeParameters().isEmpty()
                 ? List.<String>of()
                 : List.of(linkedTypeDescriptor(elementType));
-        return new CompiledDataParentType(optionType.name(), optionType.fields(), optionType.subTypes(), typeParameters);
+        return new CompiledDataParentType(
+                optionType.name(),
+                optionType.fields(),
+                optionType.subTypes(),
+                typeParameters,
+                optionType.comments(),
+                optionType.visibility(),
+                optionType.enumType(),
+                optionType.annotations()
+        );
     }
 
     private CompiledDataParentType findResultType() {
@@ -6603,7 +6792,16 @@ public class CapybaraExpressionCompiler {
         var typeParameters = resultType.typeParameters().isEmpty()
                 ? List.<String>of()
                 : List.of(linkedTypeDescriptor(elementType));
-        return new CompiledDataParentType(resultType.name(), resultType.fields(), resultType.subTypes(), typeParameters);
+        return new CompiledDataParentType(
+                resultType.name(),
+                resultType.fields(),
+                resultType.subTypes(),
+                typeParameters,
+                resultType.comments(),
+                resultType.visibility(),
+                resultType.enumType(),
+                resultType.annotations()
+        );
     }
 
     private boolean isResultOf(CompiledType type, CompiledType elementType) {
@@ -6630,7 +6828,16 @@ public class CapybaraExpressionCompiler {
         var typeParameters = effectType.typeParameters().isEmpty()
                 ? List.<String>of()
                 : List.of(linkedTypeDescriptor(elementType));
-        return new CompiledDataParentType(effectType.name(), effectType.fields(), effectType.subTypes(), typeParameters);
+        return new CompiledDataParentType(
+                effectType.name(),
+                effectType.fields(),
+                effectType.subTypes(),
+                typeParameters,
+                effectType.comments(),
+                effectType.visibility(),
+                effectType.enumType(),
+                effectType.annotations()
+        );
     }
 
     private boolean isResultType(CompiledType type) {
@@ -7050,7 +7257,10 @@ public class CapybaraExpressionCompiler {
                 parent.fields(),
                 parent.subTypes(),
                 specializedDescriptors,
-                parent.enumType()
+                parent.comments(),
+                parent.visibility(),
+                parent.enumType(),
+                parent.annotations()
         );
     }
 
@@ -7690,7 +7900,11 @@ public class CapybaraExpressionCompiler {
             return rawConstructorType.fields();
         }
         return rawConstructorType.fields().stream()
-                .map(field -> new CompiledDataType.CompiledField(field.name(), substituteTypeParameters(field.type(), substitutions)))
+                .map(field -> new CompiledDataType.CompiledField(
+                        field.name(),
+                        substituteTypeParameters(field.type(), substitutions),
+                        field.annotations()
+                ))
                 .toList();
     }
 
@@ -7818,7 +8032,8 @@ public class CapybaraExpressionCompiler {
                     linkedDataType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    substituteTypeParameters(field.type(), substitutions)
+                                    substituteTypeParameters(field.type(), substitutions),
+                                    field.annotations()
                             ))
                             .toList(),
                     linkedDataType.typeParameters().stream()
@@ -7831,14 +8046,16 @@ public class CapybaraExpressionCompiler {
                     linkedDataType.visibility(),
                     linkedDataType.singleton(),
                     linkedDataType.nativeType(),
-                    linkedDataType.enumValue()
+                    linkedDataType.enumValue(),
+                    linkedDataType.annotations()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
                     linkedDataParentType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    substituteTypeParameters(field.type(), substitutions)
+                                    substituteTypeParameters(field.type(), substitutions),
+                                    field.annotations()
                             ))
                             .toList(),
                     linkedDataParentType.subTypes().stream()
@@ -7847,7 +8064,10 @@ public class CapybaraExpressionCompiler {
                     linkedDataParentType.typeParameters().stream()
                             .map(typeDescriptor -> substituteTypeDescriptor(typeDescriptor, substitutions))
                             .toList(),
-                    linkedDataParentType.enumType()
+                    linkedDataParentType.comments(),
+                    linkedDataParentType.visibility(),
+                    linkedDataParentType.enumType(),
+                    linkedDataParentType.annotations()
             );
             default -> type;
         };
@@ -8012,7 +8232,10 @@ public class CapybaraExpressionCompiler {
                                 parentType.fields(),
                                 parentType.subTypes(),
                                 typeArgumentDescriptors,
-                                parentType.enumType()
+                                parentType.comments(),
+                                parentType.visibility(),
+                                parentType.enumType(),
+                                parentType.annotations()
                         );
                     }
                     var substitutions = new java.util.LinkedHashMap<String, CompiledType>();
@@ -8026,7 +8249,10 @@ public class CapybaraExpressionCompiler {
                             substituted.fields(),
                             substituted.subTypes(),
                             typeArgumentDescriptors,
-                            substituted.enumType()
+                            substituted.comments(),
+                            substituted.visibility(),
+                            substituted.enumType(),
+                            substituted.annotations()
                     );
                 }
                 case CompiledDataType dataType -> {
@@ -8040,7 +8266,8 @@ public class CapybaraExpressionCompiler {
                                 dataType.visibility(),
                                 dataType.singleton(),
                                 dataType.nativeType(),
-                                dataType.enumValue()
+                                dataType.enumValue(),
+                                dataType.annotations()
                         );
                     }
                     var substitutions = new java.util.LinkedHashMap<String, CompiledType>();
@@ -8051,7 +8278,8 @@ public class CapybaraExpressionCompiler {
                     var substitutedFields = dataType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    substituteTypeParameters(field.type(), substitutions)
+                                    substituteTypeParameters(field.type(), substitutions),
+                                    field.annotations()
                             ))
                             .toList();
                     yield new CompiledDataType(
@@ -8063,7 +8291,8 @@ public class CapybaraExpressionCompiler {
                             dataType.visibility(),
                             dataType.singleton(),
                             dataType.nativeType(),
-                            dataType.enumValue()
+                            dataType.enumValue(),
+                            dataType.annotations()
                     );
                 }
                 case CompiledPrimitiveBackedType ignored -> throw new IllegalStateException(
@@ -10625,7 +10854,8 @@ public class CapybaraExpressionCompiler {
                     linkedDataType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    replaceScopeGenericPlaceholders(field.type(), genericTypeNames)
+                                    replaceScopeGenericPlaceholders(field.type(), genericTypeNames),
+                                    field.annotations()
                             ))
                             .toList(),
                     linkedDataType.typeParameters(),
@@ -10634,21 +10864,26 @@ public class CapybaraExpressionCompiler {
                     linkedDataType.visibility(),
                     linkedDataType.singleton(),
                     linkedDataType.nativeType(),
-                    linkedDataType.enumValue()
+                    linkedDataType.enumValue(),
+                    linkedDataType.annotations()
             );
             case CompiledDataParentType linkedDataParentType -> new CompiledDataParentType(
                     linkedDataParentType.name(),
                     linkedDataParentType.fields().stream()
                             .map(field -> new CompiledDataType.CompiledField(
                                     field.name(),
-                                    replaceScopeGenericPlaceholders(field.type(), genericTypeNames)
+                                    replaceScopeGenericPlaceholders(field.type(), genericTypeNames),
+                                    field.annotations()
                             ))
                             .toList(),
                     linkedDataParentType.subTypes().stream()
                             .map(subType -> (CompiledDataType) replaceScopeGenericPlaceholders(subType, genericTypeNames))
                             .toList(),
                     linkedDataParentType.typeParameters(),
-                    linkedDataParentType.enumType()
+                    linkedDataParentType.comments(),
+                    linkedDataParentType.visibility(),
+                    linkedDataParentType.enumType(),
+                    linkedDataParentType.annotations()
             );
             default -> type;
         };

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CompiledReflectionValue.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CompiledReflectionValue.java
@@ -1,6 +1,7 @@
 package dev.capylang.compiler.expression;
 
 import dev.capylang.compiler.CompiledType;
+import dev.capylang.compiler.CompiledAnnotation;
 
 import java.util.List;
 
@@ -10,8 +11,21 @@ public record CompiledReflectionValue(
         String packageName,
         String packagePath,
         List<Field> fields,
+        List<CompiledAnnotation> annotations,
         CompiledType type
 ) implements CompiledExpression {
-    public record Field(String name, CompiledType type) {
+    public CompiledReflectionValue {
+        fields = fields == null ? List.of() : List.copyOf(fields);
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
+    }
+
+    public record Field(String name, CompiledType type, List<CompiledAnnotation> annotations) {
+        public Field {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+        }
+
+        public Field(String name, CompiledType type) {
+            this(name, type, List.of());
+        }
     }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationArgument.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationArgument.java
@@ -1,0 +1,10 @@
+package dev.capylang.compiler.parser;
+
+import java.util.Optional;
+
+public record AnnotationArgument(
+        String name,
+        AnnotationValue value,
+        Optional<SourcePosition> position
+) {
+}

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationDeclaration.java
@@ -1,0 +1,27 @@
+package dev.capylang.compiler.parser;
+
+import dev.capylang.compiler.Visibility;
+
+import java.util.List;
+import java.util.Optional;
+
+public record AnnotationDeclaration(
+        String name,
+        List<AnnotationTarget> targets,
+        List<AnnotationFieldDeclaration> fields,
+        List<String> comments,
+        Visibility visibility,
+        Optional<SourcePosition> position,
+        List<AnnotationUsage> annotations
+) implements Definition {
+    public AnnotationDeclaration(
+            String name,
+            List<AnnotationTarget> targets,
+            List<AnnotationFieldDeclaration> fields,
+            List<String> comments,
+            Visibility visibility,
+            Optional<SourcePosition> position
+    ) {
+        this(name, targets, fields, comments, visibility, position, List.of());
+    }
+}

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationFieldDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationFieldDeclaration.java
@@ -1,0 +1,11 @@
+package dev.capylang.compiler.parser;
+
+import java.util.Optional;
+
+public record AnnotationFieldDeclaration(
+        String name,
+        String type,
+        Optional<AnnotationValue> defaultValue,
+        Optional<SourcePosition> position
+) {
+}

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationTarget.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationTarget.java
@@ -1,0 +1,9 @@
+package dev.capylang.compiler.parser;
+
+import java.util.Optional;
+
+public record AnnotationTarget(
+        String name,
+        Optional<SourcePosition> position
+) {
+}

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationUsage.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationUsage.java
@@ -1,0 +1,11 @@
+package dev.capylang.compiler.parser;
+
+import java.util.List;
+import java.util.Optional;
+
+public record AnnotationUsage(
+        String name,
+        List<AnnotationArgument> arguments,
+        Optional<SourcePosition> position
+) {
+}

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationValue.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationValue.java
@@ -1,0 +1,38 @@
+package dev.capylang.compiler.parser;
+
+import java.util.Optional;
+
+public sealed interface AnnotationValue permits AnnotationValue.StringValue,
+        AnnotationValue.IntValue,
+        AnnotationValue.LongValue,
+        AnnotationValue.FloatValue,
+        AnnotationValue.DoubleValue,
+        AnnotationValue.BoolValue,
+        AnnotationValue.NothingValue,
+        AnnotationValue.TypeNameValue {
+    Optional<SourcePosition> position();
+
+    record StringValue(String value, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record IntValue(String value, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record LongValue(String value, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record FloatValue(String value, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record DoubleValue(String value, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record BoolValue(boolean value, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record NothingValue(Optional<SourcePosition> position) implements AnnotationValue {
+    }
+
+    record TypeNameValue(String name, Optional<SourcePosition> position) implements AnnotationValue {
+    }
+}

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -391,7 +391,7 @@ public class CapybaraParser {
 
     private List<SourcePosition> findLocalFunctionLocations(String source, String localName) {
         var locations = new ArrayList<SourcePosition>();
-        var pattern = Pattern.compile("(^|\\R)([ \\t]*)fun\\s+(?:rec\\s+)?" + Pattern.quote(localName) + "\\s*\\(");
+        var pattern = Pattern.compile("(^|\\R)([ \\t]*)fun\\s+" + Pattern.quote(localName) + "\\s*\\(");
         var matcher = pattern.matcher(source);
         while (matcher.find()) {
             var prefix = source.substring(0, matcher.start(2));
@@ -428,6 +428,11 @@ public class CapybaraParser {
             return List.of(deriverDeclaration(deriverDeclaration));
         }
 
+        var annotationDeclaration = context.annotationDeclaration();
+        if (annotationDeclaration != null) {
+            return List.of(annotationDeclaration(annotationDeclaration));
+        }
+
         var primitiveBackedTypeDeclaration = context.primitiveBackedTypeDeclaration();
         if (primitiveBackedTypeDeclaration != null) {
             return List.of(primitiveBackedTypeDeclaration(primitiveBackedTypeDeclaration));
@@ -461,7 +466,8 @@ public class CapybaraParser {
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
                 visibility(context.VISIBILITY()),
-                position(context)
+                position(context),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -485,7 +491,8 @@ public class CapybaraParser {
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
                 visibility(context.VISIBILITY()),
-                position(context)
+                position(context),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -506,7 +513,8 @@ public class CapybaraParser {
                         .toList(),
                 visibility(context.VISIBILITY()),
                 nativeType,
-                position(context)
+                position(context),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -520,7 +528,8 @@ public class CapybaraParser {
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
                 visibility(context.VISIBILITY()),
-                position(context)
+                position(context),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -535,8 +544,100 @@ public class CapybaraParser {
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
+                position(context),
+                annotations(context.annotationBlock())
+        );
+    }
+
+    private AnnotationDeclaration annotationDeclaration(FunctionalParser.AnnotationDeclarationContext context) {
+        return new AnnotationDeclaration(
+                context.TYPE().getText(),
+                context.annotationTargetClause().annotationTarget().stream()
+                        .map(this::annotationTarget)
+                        .toList(),
+                context.annotationBody().annotationFieldDeclaration().stream()
+                        .map(this::annotationFieldDeclaration)
+                        .toList(),
+                context.docComment().stream()
+                        .map(comment -> stripDocComment(comment.getText()))
+                        .toList(),
+                visibility(context.VISIBILITY()),
+                position(context),
+                annotations(context.annotationBlock())
+        );
+    }
+
+    private AnnotationTarget annotationTarget(FunctionalParser.AnnotationTargetContext context) {
+        return new AnnotationTarget(context.getText(), position(context));
+    }
+
+    private AnnotationFieldDeclaration annotationFieldDeclaration(FunctionalParser.AnnotationFieldDeclarationContext context) {
+        return new AnnotationFieldDeclaration(
+                identifier(context.identifier()),
+                context.annotationFieldType().getText(),
+                Optional.ofNullable(context.annotationValue()).map(this::annotationValue),
                 position(context)
         );
+    }
+
+    private List<AnnotationUsage> annotations(List<FunctionalParser.AnnotationBlockContext> contexts) {
+        return contexts.stream()
+                .map(this::annotationBlock)
+                .toList();
+    }
+
+    private AnnotationUsage annotationBlock(FunctionalParser.AnnotationBlockContext context) {
+        return new AnnotationUsage(
+                annotationName(context.annotationName()),
+                annotationArguments(context.annotationArgumentList()),
+                position(context)
+        );
+    }
+
+    private String annotationName(FunctionalParser.AnnotationNameContext context) {
+        return context.getText();
+    }
+
+    private List<AnnotationArgument> annotationArguments(FunctionalParser.AnnotationArgumentListContext context) {
+        if (context == null) {
+            return List.of();
+        }
+        return context.annotationArgument().stream()
+                .map(this::annotationArgument)
+                .toList();
+    }
+
+    private AnnotationArgument annotationArgument(FunctionalParser.AnnotationArgumentContext context) {
+        return new AnnotationArgument(
+                identifier(context.identifier()),
+                annotationValue(context.annotationValue()),
+                position(context)
+        );
+    }
+
+    private AnnotationValue annotationValue(FunctionalParser.AnnotationValueContext context) {
+        if (context.STRING_LITERAL() != null) {
+            return new AnnotationValue.StringValue(context.STRING_LITERAL().getText(), position(context.STRING_LITERAL()));
+        }
+        if (context.INT_LITERAL() != null) {
+            return new AnnotationValue.IntValue(context.INT_LITERAL().getText(), position(context.INT_LITERAL()));
+        }
+        if (context.LONG_LITERAL() != null) {
+            return new AnnotationValue.LongValue(context.LONG_LITERAL().getText(), position(context.LONG_LITERAL()));
+        }
+        if (context.FLOAT_LITERAL() != null) {
+            return new AnnotationValue.FloatValue(context.FLOAT_LITERAL().getText(), position(context.FLOAT_LITERAL()));
+        }
+        if (context.DOUBLE_LITERAL() != null) {
+            return new AnnotationValue.DoubleValue(context.DOUBLE_LITERAL().getText(), position(context.DOUBLE_LITERAL()));
+        }
+        if (context.BOOL_LITERAL() != null) {
+            return new AnnotationValue.BoolValue(Boolean.parseBoolean(context.BOOL_LITERAL().getText()), position(context.BOOL_LITERAL()));
+        }
+        if (context.NOTHING_LITERAL() != null) {
+            return new AnnotationValue.NothingValue(position(context.NOTHING_LITERAL()));
+        }
+        return new AnnotationValue.TypeNameValue(context.annotationTypeReference().getText(), position(context.annotationTypeReference()));
     }
 
     private List<DeriveDirective> deriveClause(FunctionalParser.DeriveClauseContext context) {
@@ -564,7 +665,8 @@ public class CapybaraParser {
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
-                position(context)
+                position(context),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -582,7 +684,9 @@ public class CapybaraParser {
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),
                 visibility,
-                position(context)
+                position(context),
+                false,
+                annotations(context.annotationBlock())
         );
     }
 
@@ -597,7 +701,11 @@ public class CapybaraParser {
         if (context.SPREAD() != null) {
             throw new IllegalStateException("Spread field declaration is not allowed in this context: " + context.getText());
         }
-        return new DataDeclaration.DataField(fieldName(context.identifier(), context.STRING_LITERAL()), type(context.type()));
+        return new DataDeclaration.DataField(
+                fieldName(context.identifier(), context.STRING_LITERAL()),
+                type(context.type()),
+                annotations(context.annotationBlock())
+        );
     }
 
     private List<Definition> functionDeclaration(dev.capylang.parser.antlr.FunctionalParser.FunctionDeclarationContext functionDeclarationContext) {
@@ -768,7 +876,8 @@ public class CapybaraParser {
                         .toList(),
                 visibility,
                 position(functionDeclarationContext),
-                functionDeclarationContext.recFunctionMarker() != null
+                false,
+                annotations(functionDeclarationContext.annotationBlock())
         );
         var allDefinitions = new java.util.ArrayList<Definition>(1 + extractedLocalDefinitions.size());
         allDefinitions.add(topLevelFunction);
@@ -809,7 +918,8 @@ public class CapybaraParser {
                         .toList(),
                 null,
                 position(context),
-                context.recFunctionMarker() != null
+                false,
+                annotations(context.annotationBlock())
         );
     }
 
@@ -859,7 +969,8 @@ public class CapybaraParser {
                 .flatMap(Collection::stream)
                 .map(field -> new DataDeclaration.DataField(
                         field.name(),
-                        rewriteLocalTypeNames(field.type(), localTypeNameMap)))
+                        rewriteLocalTypeNames(field.type(), localTypeNameMap),
+                        field.annotations()))
                 .toList();
         var subTypes = context.genericTypeDeclaration().stream()
                 .skip(1)
@@ -899,7 +1010,8 @@ public class CapybaraParser {
                 dataFields.fields().stream()
                         .map(field -> new DataDeclaration.DataField(
                                 field.name(),
-                                rewriteLocalTypeNames(field.type(), localTypeNameMap)
+                                rewriteLocalTypeNames(field.type(), localTypeNameMap),
+                                field.annotations()
                         ))
                         .toList(),
                 dataFields.extendsTypes().stream()
@@ -2467,9 +2579,7 @@ public class CapybaraParser {
                 ? identifier(context.identifier())
                 : context.NAME() != null
                         ? context.NAME().getText()
-                        : context.REC() != null
-                                ? context.REC().getText()
-                                : context.getChild(0).getText();
+                        : context.getChild(0).getText();
         return new FunctionCall(moduleName, functionName, arguments, position(context));
     }
 

--- a/compiler/src/main/java/dev/capylang/compiler/parser/DataDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/DataDeclaration.java
@@ -13,7 +13,20 @@ public record DataDeclaration(String name, List<DataField> fields,
                               List<String> comments,
                               Visibility visibility,
                               boolean nativeType,
-                              Optional<SourcePosition> position) implements Definition {
+                              Optional<SourcePosition> position,
+                              List<AnnotationUsage> annotations) implements Definition {
+    public DataDeclaration(String name, List<DataField> fields,
+                           List<String> extendsTypes,
+                           List<String> typeParameters,
+                           Optional<Expression> constructor,
+                           List<DeriveDirective> derives,
+                           List<String> comments,
+                           Visibility visibility,
+                           boolean nativeType,
+                           Optional<SourcePosition> position) {
+        this(name, fields, extendsTypes, typeParameters, constructor, derives, comments, visibility, nativeType, position, List.of());
+    }
+
     public DataDeclaration(String name, List<DataField> fields,
                            List<String> extendsTypes,
                            List<String> typeParameters,
@@ -41,6 +54,13 @@ public record DataDeclaration(String name, List<DataField> fields,
         this(name, fields, extendsTypes, typeParameters, Optional.empty(), comments, null, position);
     }
 
-    public record DataField(String name, Type type) {
+    public record DataField(String name, Type type, List<AnnotationUsage> annotations) {
+        public DataField {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+        }
+
+        public DataField(String name, Type type) {
+            this(name, type, List.of());
+        }
     }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/Definition.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/Definition.java
@@ -4,7 +4,7 @@ import dev.capylang.compiler.Visibility;
 
 import java.util.Optional;
 
-public sealed interface Definition permits DataDeclaration, DeriverDeclaration, EnumDeclaration, Function, PrimitiveBackedTypeDeclaration, TypeDeclaration {
+public sealed interface Definition permits AnnotationDeclaration, DataDeclaration, DeriverDeclaration, EnumDeclaration, Function, PrimitiveBackedTypeDeclaration, TypeDeclaration {
     Optional<SourcePosition> position();
 
     default Visibility visibility() {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/DeriverDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/DeriverDeclaration.java
@@ -10,15 +10,37 @@ public record DeriverDeclaration(
         List<DeriverMethod> methods,
         List<String> comments,
         Visibility visibility,
-        Optional<SourcePosition> position
+        Optional<SourcePosition> position,
+        List<AnnotationUsage> annotations
 ) implements Definition {
+    public DeriverDeclaration(
+            String name,
+            List<DeriverMethod> methods,
+            List<String> comments,
+            Visibility visibility,
+            Optional<SourcePosition> position
+    ) {
+        this(name, methods, comments, visibility, position, List.of());
+    }
+
     public record DeriverMethod(
             String name,
             List<Parameter> parameters,
             Type returnType,
             Expression expression,
             List<String> comments,
-            Optional<SourcePosition> position
+            Optional<SourcePosition> position,
+            List<AnnotationUsage> annotations
     ) {
+        public DeriverMethod(
+                String name,
+                List<Parameter> parameters,
+                Type returnType,
+                Expression expression,
+                List<String> comments,
+                Optional<SourcePosition> position
+        ) {
+            this(name, parameters, returnType, expression, comments, position, List.of());
+        }
     }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/EnumDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/EnumDeclaration.java
@@ -3,5 +3,14 @@ package dev.capylang.compiler.parser;
 import java.util.List;
 import java.util.Optional;
 
-public record EnumDeclaration(String name, List<String> values, List<String> comments, Optional<SourcePosition> position) implements Definition {
+public record EnumDeclaration(
+        String name,
+        List<String> values,
+        List<String> comments,
+        Optional<SourcePosition> position,
+        List<AnnotationUsage> annotations
+) implements Definition {
+    public EnumDeclaration(String name, List<String> values, List<String> comments, Optional<SourcePosition> position) {
+        this(name, values, comments, position, List.of());
+    }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/Function.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/Function.java
@@ -10,7 +10,17 @@ public record Function(String name, List<Parameter> parameters, Optional<Type> r
                        List<String> comments,
                        Visibility visibility,
                        Optional<SourcePosition> position,
-                       boolean tailRecursive) implements Definition {
+                       boolean tailRecursive,
+                       List<AnnotationUsage> annotations) implements Definition {
+    public Function(String name, List<Parameter> parameters, Optional<Type> returnType,
+                    Expression expression,
+                    List<String> comments,
+                    Visibility visibility,
+                    Optional<SourcePosition> position,
+                    boolean tailRecursive) {
+        this(name, parameters, returnType, expression, comments, visibility, position, tailRecursive, List.of());
+    }
+
     public Function(String name, List<Parameter> parameters, Optional<Type> returnType,
                     Expression expression,
                     List<String> comments,

--- a/compiler/src/main/java/dev/capylang/compiler/parser/ObjectOriented.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/ObjectOriented.java
@@ -1,5 +1,7 @@
 package dev.capylang.compiler.parser;
 
+import dev.capylang.compiler.CompiledAnnotation;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -10,9 +12,12 @@ public record ObjectOriented(List<TypeDeclaration> definitions) {
         List<TypeReference> parents();
 
         List<MemberDeclaration> members();
+
+        List<CompiledAnnotation> linkedAnnotations();
     }
 
     public sealed interface MemberDeclaration permits FieldDeclaration, MethodDeclaration, InitBlock {
+        List<CompiledAnnotation> linkedAnnotations();
     }
 
     public sealed interface MethodBody permits ExpressionBody, StatementBlock {
@@ -27,24 +32,103 @@ public record ObjectOriented(List<TypeDeclaration> definitions) {
             List<TypeReference> parents,
             List<MemberDeclaration> members,
             List<String> modifiers,
-            List<String> comments
+            List<String> comments,
+            List<AnnotationUsage> annotations,
+            List<CompiledAnnotation> linkedAnnotations
     ) implements TypeDeclaration {
+        public ClassDeclaration {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+            linkedAnnotations = linkedAnnotations == null ? List.of() : List.copyOf(linkedAnnotations);
+        }
+
+        public ClassDeclaration(
+                String name,
+                List<Parameter> constructorParameters,
+                List<TypeReference> parents,
+                List<MemberDeclaration> members,
+                List<String> modifiers,
+                List<String> comments,
+                List<AnnotationUsage> annotations
+        ) {
+            this(name, constructorParameters, parents, members, modifiers, comments, annotations, List.of());
+        }
+
+        public ClassDeclaration(
+                String name,
+                List<Parameter> constructorParameters,
+                List<TypeReference> parents,
+                List<MemberDeclaration> members,
+                List<String> modifiers,
+                List<String> comments
+        ) {
+            this(name, constructorParameters, parents, members, modifiers, comments, List.of(), List.of());
+        }
     }
 
     public record TraitDeclaration(
             String name,
             List<TypeReference> parents,
             List<MemberDeclaration> members,
-            List<String> comments
+            List<String> comments,
+            List<AnnotationUsage> annotations,
+            List<CompiledAnnotation> linkedAnnotations
     ) implements TypeDeclaration {
+        public TraitDeclaration {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+            linkedAnnotations = linkedAnnotations == null ? List.of() : List.copyOf(linkedAnnotations);
+        }
+
+        public TraitDeclaration(
+                String name,
+                List<TypeReference> parents,
+                List<MemberDeclaration> members,
+                List<String> comments,
+                List<AnnotationUsage> annotations
+        ) {
+            this(name, parents, members, comments, annotations, List.of());
+        }
+
+        public TraitDeclaration(
+                String name,
+                List<TypeReference> parents,
+                List<MemberDeclaration> members,
+                List<String> comments
+        ) {
+            this(name, parents, members, comments, List.of(), List.of());
+        }
     }
 
     public record InterfaceDeclaration(
             String name,
             List<TypeReference> parents,
             List<MemberDeclaration> members,
-            List<String> comments
+            List<String> comments,
+            List<AnnotationUsage> annotations,
+            List<CompiledAnnotation> linkedAnnotations
     ) implements TypeDeclaration {
+        public InterfaceDeclaration {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+            linkedAnnotations = linkedAnnotations == null ? List.of() : List.copyOf(linkedAnnotations);
+        }
+
+        public InterfaceDeclaration(
+                String name,
+                List<TypeReference> parents,
+                List<MemberDeclaration> members,
+                List<String> comments,
+                List<AnnotationUsage> annotations
+        ) {
+            this(name, parents, members, comments, annotations, List.of());
+        }
+
+        public InterfaceDeclaration(
+                String name,
+                List<TypeReference> parents,
+                List<MemberDeclaration> members,
+                List<String> comments
+        ) {
+            this(name, parents, members, comments, List.of(), List.of());
+        }
     }
 
     public record FieldDeclaration(
@@ -52,8 +136,35 @@ public record ObjectOriented(List<TypeDeclaration> definitions) {
             String type,
             String visibility,
             Optional<String> initializer,
-            List<String> comments
+            List<String> comments,
+            List<AnnotationUsage> annotations,
+            List<CompiledAnnotation> linkedAnnotations
     ) implements MemberDeclaration {
+        public FieldDeclaration {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+            linkedAnnotations = linkedAnnotations == null ? List.of() : List.copyOf(linkedAnnotations);
+        }
+
+        public FieldDeclaration(
+                String name,
+                String type,
+                String visibility,
+                Optional<String> initializer,
+                List<String> comments,
+                List<AnnotationUsage> annotations
+        ) {
+            this(name, type, visibility, initializer, comments, annotations, List.of());
+        }
+
+        public FieldDeclaration(
+                String name,
+                String type,
+                String visibility,
+                Optional<String> initializer,
+                List<String> comments
+        ) {
+            this(name, type, visibility, initializer, comments, List.of(), List.of());
+        }
     }
 
     public record MethodDeclaration(
@@ -63,11 +174,59 @@ public record ObjectOriented(List<TypeDeclaration> definitions) {
             String visibility,
             List<String> modifiers,
             Optional<MethodBody> body,
-            List<String> comments
+            List<String> comments,
+            List<AnnotationUsage> annotations,
+            List<CompiledAnnotation> linkedAnnotations
     ) implements MemberDeclaration {
+        public MethodDeclaration {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+            linkedAnnotations = linkedAnnotations == null ? List.of() : List.copyOf(linkedAnnotations);
+        }
+
+        public MethodDeclaration(
+                String name,
+                List<Parameter> parameters,
+                String returnType,
+                String visibility,
+                List<String> modifiers,
+                Optional<MethodBody> body,
+                List<String> comments,
+                List<AnnotationUsage> annotations
+        ) {
+            this(name, parameters, returnType, visibility, modifiers, body, comments, annotations, List.of());
+        }
+
+        public MethodDeclaration(
+                String name,
+                List<Parameter> parameters,
+                String returnType,
+                String visibility,
+                List<String> modifiers,
+                Optional<MethodBody> body,
+                List<String> comments
+        ) {
+            this(name, parameters, returnType, visibility, modifiers, body, comments, List.of(), List.of());
+        }
     }
 
-    public record InitBlock(StatementBlock body, List<String> comments) implements MemberDeclaration {
+    public record InitBlock(
+            StatementBlock body,
+            List<String> comments,
+            List<AnnotationUsage> annotations,
+            List<CompiledAnnotation> linkedAnnotations
+    ) implements MemberDeclaration {
+        public InitBlock {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+            linkedAnnotations = linkedAnnotations == null ? List.of() : List.copyOf(linkedAnnotations);
+        }
+
+        public InitBlock(StatementBlock body, List<String> comments, List<AnnotationUsage> annotations) {
+            this(body, comments, annotations, List.of());
+        }
+
+        public InitBlock(StatementBlock body, List<String> comments) {
+            this(body, comments, List.of(), List.of());
+        }
     }
 
     public record ExpressionBody(String expression) implements MethodBody {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/ObjectOrientedParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/ObjectOrientedParser.java
@@ -5,12 +5,15 @@ import dev.capylang.compiler.Result;
 import dev.capylang.parser.antlr.ObjectOrientedLexer;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -135,7 +138,8 @@ public final class ObjectOrientedParser {
                 typeReferences(context.inheritanceClause() == null ? null : context.inheritanceClause().qualifiedType()),
                 members(context.typeBody().memberDeclaration()),
                 context.classModifier().stream().map(org.antlr.v4.runtime.RuleContext::getText).toList(),
-                comments(context.docComment())
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -144,7 +148,8 @@ public final class ObjectOrientedParser {
                 context.TYPE().getText(),
                 typeReferences(context.inheritanceClause() == null ? null : context.inheritanceClause().qualifiedType()),
                 members(context.typeBody().memberDeclaration()),
-                comments(context.docComment())
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -156,7 +161,8 @@ public final class ObjectOrientedParser {
                 context.TYPE().getText(),
                 typeReferences(context.inheritanceClause() == null ? null : context.inheritanceClause().qualifiedType()),
                 members,
-                comments(context.docComment())
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -180,7 +186,8 @@ public final class ObjectOrientedParser {
                 context.type().getText(),
                 context.visibility() == null ? "public" : context.visibility().getText(),
                 context.expression() == null ? java.util.Optional.empty() : java.util.Optional.of(context.expression().getText()),
-                comments(context.docComment())
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -192,7 +199,8 @@ public final class ObjectOrientedParser {
                 context.visibility() == null ? "public" : context.visibility().getText(),
                 context.methodModifier().stream().map(org.antlr.v4.runtime.RuleContext::getText).toList(),
                 context.methodBody() == null ? java.util.Optional.empty() : java.util.Optional.of(methodBody(context.methodBody())),
-                comments(context.docComment())
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
         );
     }
 
@@ -204,12 +212,77 @@ public final class ObjectOrientedParser {
                 context.visibility() == null ? "public" : context.visibility().getText(),
                 context.methodModifier().stream().map(org.antlr.v4.runtime.RuleContext::getText).toList(),
                 java.util.Optional.empty(),
-                comments(context.docComment())
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
         );
     }
 
     private ObjectOriented.InitBlock initBlock(dev.capylang.parser.antlr.ObjectOrientedParser.InitBlockContext context) {
-        return new ObjectOriented.InitBlock(statementBlock(context.statementBlock()), comments(context.docComment()));
+        return new ObjectOriented.InitBlock(
+                statementBlock(context.statementBlock()),
+                comments(context.docComment()),
+                annotations(context.annotationBlock())
+        );
+    }
+
+    private List<AnnotationUsage> annotations(List<dev.capylang.parser.antlr.ObjectOrientedParser.AnnotationBlockContext> contexts) {
+        return contexts.stream()
+                .map(this::annotationBlock)
+                .toList();
+    }
+
+    private AnnotationUsage annotationBlock(dev.capylang.parser.antlr.ObjectOrientedParser.AnnotationBlockContext context) {
+        return new AnnotationUsage(
+                annotationName(context.annotationName()),
+                annotationArguments(context.annotationArgumentList()),
+                position(context)
+        );
+    }
+
+    private String annotationName(dev.capylang.parser.antlr.ObjectOrientedParser.AnnotationNameContext context) {
+        return context.getText();
+    }
+
+    private List<AnnotationArgument> annotationArguments(dev.capylang.parser.antlr.ObjectOrientedParser.AnnotationArgumentListContext context) {
+        if (context == null) {
+            return List.of();
+        }
+        return context.annotationArgument().stream()
+                .map(this::annotationArgument)
+                .toList();
+    }
+
+    private AnnotationArgument annotationArgument(dev.capylang.parser.antlr.ObjectOrientedParser.AnnotationArgumentContext context) {
+        return new AnnotationArgument(
+                context.identifier().getText(),
+                annotationValue(context.annotationValue()),
+                position(context)
+        );
+    }
+
+    private AnnotationValue annotationValue(dev.capylang.parser.antlr.ObjectOrientedParser.AnnotationValueContext context) {
+        if (context.STRING_LITERAL() != null) {
+            return new AnnotationValue.StringValue(context.STRING_LITERAL().getText(), position(context.STRING_LITERAL()));
+        }
+        if (context.INT_LITERAL() != null) {
+            return new AnnotationValue.IntValue(context.INT_LITERAL().getText(), position(context.INT_LITERAL()));
+        }
+        if (context.LONG_LITERAL() != null) {
+            return new AnnotationValue.LongValue(context.LONG_LITERAL().getText(), position(context.LONG_LITERAL()));
+        }
+        if (context.FLOAT_LITERAL() != null) {
+            return new AnnotationValue.FloatValue(context.FLOAT_LITERAL().getText(), position(context.FLOAT_LITERAL()));
+        }
+        if (context.DOUBLE_LITERAL() != null) {
+            return new AnnotationValue.DoubleValue(context.DOUBLE_LITERAL().getText(), position(context.DOUBLE_LITERAL()));
+        }
+        if (context.BOOL_LITERAL() != null) {
+            return new AnnotationValue.BoolValue(Boolean.parseBoolean(context.BOOL_LITERAL().getText()), position(context.BOOL_LITERAL()));
+        }
+        if (context.NOTHING_LITERAL() != null) {
+            return new AnnotationValue.NothingValue(position(context.NOTHING_LITERAL()));
+        }
+        return new AnnotationValue.TypeNameValue(context.annotationTypeReference().getText(), position(context.annotationTypeReference()));
     }
 
     private ObjectOriented.MethodBody methodBody(dev.capylang.parser.antlr.ObjectOrientedParser.MethodBodyContext context) {
@@ -392,6 +465,14 @@ public final class ObjectOrientedParser {
         return contexts.stream()
                 .map(context -> new ObjectOriented.TypeReference(context.getText()))
                 .toList();
+    }
+
+    private static Optional<SourcePosition> position(ParserRuleContext context) {
+        return SourcePosition.of(context);
+    }
+
+    private static Optional<SourcePosition> position(TerminalNode node) {
+        return Optional.of(SourcePosition.of(node));
     }
 
     private record ParsedSource(String source, List<ImportDeclaration> imports) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/PrimitiveBackedTypeDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/PrimitiveBackedTypeDeclaration.java
@@ -11,6 +11,17 @@ public record PrimitiveBackedTypeDeclaration(
         Optional<Expression> constructor,
         List<String> comments,
         Visibility visibility,
-        Optional<SourcePosition> position
+        Optional<SourcePosition> position,
+        List<AnnotationUsage> annotations
 ) implements Definition {
+    public PrimitiveBackedTypeDeclaration(
+            String name,
+            PrimitiveType backingType,
+            Optional<Expression> constructor,
+            List<String> comments,
+            Visibility visibility,
+            Optional<SourcePosition> position
+    ) {
+        this(name, backingType, constructor, comments, visibility, position, List.of());
+    }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/TypeDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/TypeDeclaration.java
@@ -12,7 +12,18 @@ public record TypeDeclaration(String name, List<String> subTypes, List<DataField
                               List<DeriveDirective> derives,
                               List<String> comments,
                               Visibility visibility,
-                              Optional<SourcePosition> position) implements Definition {
+                              Optional<SourcePosition> position,
+                              List<AnnotationUsage> annotations) implements Definition {
+    public TypeDeclaration(String name, List<String> subTypes, List<DataField> fields,
+                           List<String> typeParameters,
+                           Optional<Expression> constructor,
+                           List<DeriveDirective> derives,
+                           List<String> comments,
+                           Visibility visibility,
+                           Optional<SourcePosition> position) {
+        this(name, subTypes, fields, typeParameters, constructor, derives, comments, visibility, position, List.of());
+    }
+
     public TypeDeclaration(String name, List<String> subTypes, List<DataField> fields,
                            List<String> typeParameters,
                            Optional<Expression> constructor,

--- a/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -1,9 +1,15 @@
 package dev.capylang.generator;
 
 import dev.capylang.compiler.CollectionLinkedType;
+import dev.capylang.compiler.CompiledAnnotation;
+import dev.capylang.compiler.CompiledAnnotationValue;
+import dev.capylang.compiler.CompiledDataParentType;
 import dev.capylang.compiler.CompiledDataType;
 import dev.capylang.compiler.CompiledFunction;
+import dev.capylang.compiler.CompiledFunctionType;
+import dev.capylang.compiler.CompiledGenericTypeParameter;
 import dev.capylang.compiler.CompiledModule;
+import dev.capylang.compiler.CompiledObjectType;
 import dev.capylang.compiler.CompiledPrimitiveBackedType;
 import dev.capylang.compiler.CompiledProgram;
 import dev.capylang.compiler.CompiledTupleType;
@@ -16,6 +22,7 @@ import dev.capylang.compiler.parser.ObjectOrientedModule;
 import dev.capylang.generator.java.JavaAstBuilder;
 import dev.capylang.generator.java.JavaClass;
 import dev.capylang.generator.java.JavaConst;
+import dev.capylang.generator.java.JavaDataValueInfo;
 import dev.capylang.generator.java.JavaEnum;
 import dev.capylang.generator.java.JavaMethod;
 import dev.capylang.generator.java.JavaRecord;
@@ -218,14 +225,17 @@ public final class JavaScriptGenerator implements Generator {
             code.append("        return capy.dataToString(this);\n");
             code.append("    }\n");
             code.append("    capybaraDataValueInfo() {\n");
+            var dataValueInfo = record.dataValueInfo();
             code.append("        return capy.dataValueInfo(this, ")
-                    .append(jsString(name))
+                    .append(jsString(dataValueInfo.name()))
                     .append(", ")
-                    .append(jsString(moduleInfo.packageName()))
+                    .append(jsString(dataValueInfo.packageName()))
                     .append(", ")
-                    .append(jsString(moduleInfo.packagePath()))
+                    .append(jsString(dataValueInfo.packagePath()))
                     .append(", ")
-                    .append(jsArray(record.fields().stream().map(JavaRecord.JavaRecordField::name).toList()))
+                    .append(renderDataValueFieldDescriptors(dataValueInfo.fields(), dataValueInfo.packagePath()))
+                    .append(", ")
+                    .append(renderAnnotations(dataValueInfo.annotations()))
                     .append(");\n");
             code.append("    }\n");
             for (var method : record.methods()) {
@@ -270,14 +280,16 @@ public final class JavaScriptGenerator implements Generator {
             var values = javaEnum.values().isEmpty() ? List.of("INSTANCE") : javaEnum.values();
             var code = new StringBuilder();
             if (values.size() == 1 && "INSTANCE".equals(values.getFirst())) {
+                var dataValueInfo = javaEnum.dataValueInfos().getFirst();
                 code.append("const ").append(enumName)
                         .append(" = capy.enumValue(")
                         .append(jsString(enumName)).append(", ")
                         .append(jsString(enumName)).append(", ")
                         .append(jsArray(programContext.parentTypes(enumName))).append(", ")
                         .append("0, [], ")
-                        .append(jsString(moduleInfo.packageName())).append(", ")
-                        .append(jsString(moduleInfo.packagePath()))
+                        .append(jsString(dataValueInfo.packageName())).append(", ")
+                        .append(jsString(dataValueInfo.packagePath())).append(", ")
+                        .append(renderDataValueMetadata(dataValueInfo))
                         .append(");\n");
                 exportNames.add(enumName);
                 return code.toString();
@@ -290,14 +302,16 @@ public final class JavaScriptGenerator implements Generator {
                 var aliases = valueName.equals(value)
                         ? List.<String>of()
                         : List.of(valueName);
+                var dataValueInfo = javaEnum.dataValueInfos().get(i);
                 code.append("        capy.enumValue(")
                         .append(jsString(value)).append(", ")
                         .append(jsString(enumName)).append(", ")
                         .append(jsArray(programContext.parentTypes(valueName))).append(", ")
                         .append(i).append(", ")
                         .append(jsArray(aliases)).append(", ")
-                        .append(jsString(moduleInfo.packageName())).append(", ")
-                        .append(jsString(moduleInfo.packagePath())).append("),\n");
+                        .append(jsString(dataValueInfo.packageName())).append(", ")
+                        .append(jsString(dataValueInfo.packagePath())).append(", ")
+                        .append(renderDataValueMetadata(dataValueInfo)).append("),\n");
             }
             code.append("    ];\n");
             code.append("    return Object.freeze({\n");
@@ -1148,7 +1162,8 @@ public final class JavaScriptGenerator implements Generator {
                    + jsString(reflectionValue.name()) + ", "
                    + jsString(reflectionValue.packageName()) + ", "
                    + jsString(reflectionValue.packagePath()) + ", "
-                   + jsArray(reflectionValue.fields().stream().map(CompiledReflectionValue.Field::name).toList())
+                   + renderReflectionFieldDescriptors(reflectionValue.fields(), reflectionValue.packagePath()) + ", "
+                   + renderAnnotations(reflectionValue.annotations())
                    + ")";
         }
 
@@ -1502,6 +1517,252 @@ public final class JavaScriptGenerator implements Generator {
             }
             return base + "_j" + idx;
         }
+    }
+
+    private static String renderDataValueMetadata(JavaDataValueInfo dataValueInfo) {
+        return "{ fields: "
+               + renderDataValueFieldDescriptors(dataValueInfo.fields(), dataValueInfo.packagePath())
+               + ", annotations: "
+               + renderAnnotations(dataValueInfo.annotations())
+               + " }";
+    }
+
+    private static String renderDataValueFieldDescriptors(List<JavaDataValueInfo.Field> fields, String fallbackPackagePath) {
+        if (fields.isEmpty()) {
+            return "[]";
+        }
+        return fields.stream()
+                .map(field -> "{ name: "
+                              + jsString(field.name())
+                              + ", type: "
+                              + renderReflectionTypeInfo(field.type(), fallbackPackagePath)
+                              + ", annotations: "
+                              + renderAnnotations(field.annotations())
+                              + " }")
+                .collect(joining(", ", "[", "]"));
+    }
+
+    private static String renderReflectionFieldDescriptors(List<CompiledReflectionValue.Field> fields, String fallbackPackagePath) {
+        if (fields.isEmpty()) {
+            return "[]";
+        }
+        return fields.stream()
+                .map(field -> "{ name: "
+                              + jsString(field.name())
+                              + ", type: "
+                              + renderReflectionTypeInfo(field.type(), fallbackPackagePath)
+                              + ", annotations: "
+                              + renderAnnotations(field.annotations())
+                              + " }")
+                .collect(joining(", ", "[", "]"));
+    }
+
+    static String renderReflectionTypeInfo(CompiledType type, String fallbackPackagePath) {
+        return switch (type) {
+            case PrimitiveLinkedType primitive ->
+                    renderDataInfo(primitiveReflectionTypeName(primitive), renderEmptyReflectionPackage(), List.of());
+            case CollectionLinkedType.CompiledList listType ->
+                    "{ kind: 'list', name: 'List', pkg: " + renderEmptyReflectionPackage()
+                    + ", element_type: " + renderReflectionTypeInfo(listType.elementType(), fallbackPackagePath) + " }";
+            case CollectionLinkedType.CompiledSet setType ->
+                    "{ kind: 'set', name: 'Set', pkg: " + renderEmptyReflectionPackage()
+                    + ", element_type: " + renderReflectionTypeInfo(setType.elementType(), fallbackPackagePath) + " }";
+            case CollectionLinkedType.CompiledDict dictType ->
+                    "{ kind: 'dict', name: 'Dict', pkg: " + renderEmptyReflectionPackage()
+                    + ", value_type: " + renderReflectionTypeInfo(dictType.valueType(), fallbackPackagePath) + " }";
+            case CompiledTupleType tupleType -> {
+                var elements = tupleType.elementTypes().stream()
+                        .map(elementType -> renderReflectionTypeInfo(elementType, fallbackPackagePath))
+                        .collect(joining(", ", "[", "]"));
+                yield "{ kind: 'tuple', name: 'Tuple', pkg: " + renderEmptyReflectionPackage()
+                      + ", elements: " + elements + " }";
+            }
+            case CompiledFunctionType functionType -> {
+                var shape = flattenReflectionFunctionType(functionType);
+                var params = shape.parameterTypes().stream()
+                        .map(parameterType -> renderReflectionTypeInfo(parameterType, fallbackPackagePath))
+                        .collect(joining(", ", "[", "]"));
+                yield "{ kind: 'function', name: 'function', pkg: " + renderEmptyReflectionPackage()
+                      + ", params: " + params
+                      + ", return_type: " + renderReflectionTypeInfo(shape.returnType(), fallbackPackagePath)
+                      + " }";
+            }
+            case CompiledGenericTypeParameter genericTypeParameter ->
+                    renderDataInfo(genericTypeParameter.name(), renderEmptyReflectionPackage(), List.of());
+            case CompiledPrimitiveBackedType primitiveBackedType ->
+                    renderReflectionTypeInfo(primitiveBackedType.backingType(), fallbackPackagePath);
+            case CompiledDataParentType parentType ->
+                    renderDataInfo(
+                            simpleReflectionTypeName(parentType.name()),
+                            renderReflectionPackageForType(parentType.name(), fallbackPackagePath),
+                            parentType.annotations()
+                    );
+            case CompiledDataType dataType ->
+                    renderDataInfo(
+                            simpleReflectionTypeName(dataType.name()),
+                            renderReflectionPackageForType(dataType.name(), fallbackPackagePath),
+                            dataType.annotations()
+                    );
+            case CompiledObjectType objectType ->
+                    renderDataInfo(
+                            simpleReflectionTypeName(objectType.name()),
+                            renderReflectionPackageForType(objectType.name(), fallbackPackagePath),
+                            objectType.annotations()
+                    );
+        };
+    }
+
+    private static ReflectionFunctionShape flattenReflectionFunctionType(CompiledFunctionType functionType) {
+        var parameterTypes = new ArrayList<CompiledType>();
+        CompiledType current = functionType;
+        while (current instanceof CompiledFunctionType currentFunctionType) {
+            parameterTypes.add(currentFunctionType.argumentType());
+            current = currentFunctionType.returnType();
+        }
+        return new ReflectionFunctionShape(List.copyOf(parameterTypes), current);
+    }
+
+    private static String renderDataInfo(String name, String pkg, List<CompiledAnnotation> annotations) {
+        return "{ kind: 'data', name: "
+               + jsString(name)
+               + ", pkg: "
+               + pkg
+               + ", annotations: "
+               + renderAnnotations(annotations)
+               + " }";
+    }
+
+    private static String primitiveReflectionTypeName(PrimitiveLinkedType type) {
+        return type == PrimitiveLinkedType.STRING
+                ? "String"
+                : type.name().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    static String renderAnnotations(List<CompiledAnnotation> annotations) {
+        if (annotations == null || annotations.isEmpty()) {
+            return "[]";
+        }
+        return annotations.stream()
+                .map(JavaScriptGenerator::renderAnnotation)
+                .collect(joining(", ", "[", "]"));
+    }
+
+    private static String renderAnnotation(CompiledAnnotation annotation) {
+        var arguments = annotation.arguments().stream()
+                .map(argument -> "{ name: "
+                                 + jsString(argument.name())
+                                 + ", value: "
+                                 + renderAnnotationValue(argument.value())
+                                 + " }")
+                .collect(joining(", ", "[", "]"));
+        return "{ name: "
+               + jsString(annotation.name())
+               + ", pkg: "
+               + renderReflectionPackage(annotation.packageName(), annotation.packagePath())
+               + ", arguments: "
+               + arguments
+               + " }";
+    }
+
+    private static String renderAnnotationValue(CompiledAnnotationValue value) {
+        return switch (value) {
+            case CompiledAnnotationValue.StringValue stringValue ->
+                    "{ kind: 'string', value: " + jsString(normalizeAnnotationStringValue(stringValue.value())) + " }";
+            case CompiledAnnotationValue.IntValue intValue ->
+                    "{ kind: 'int', value: " + stripNumericSuffix(intValue.value()) + " }";
+            case CompiledAnnotationValue.LongValue longValue ->
+                    "{ kind: 'long', value: " + renderLongLiteral(longValue.value()) + " }";
+            case CompiledAnnotationValue.DoubleValue doubleValue ->
+                    "{ kind: 'double', value: " + stripNumericSuffix(doubleValue.value()) + " }";
+            case CompiledAnnotationValue.FloatValue floatValue ->
+                    "{ kind: 'float', value: " + stripNumericSuffix(floatValue.value()) + " }";
+            case CompiledAnnotationValue.BoolValue boolValue ->
+                    "{ kind: 'bool', value: " + boolValue.value() + " }";
+            case CompiledAnnotationValue.TypeNameValue typeNameValue ->
+                    "{ kind: 'type_name', value: " + jsString(typeNameValue.name()) + " }";
+            case CompiledAnnotationValue.NothingValue ignored ->
+                    "{ kind: 'nothing' }";
+        };
+    }
+
+    private static String normalizeAnnotationStringValue(String raw) {
+        if (raw.length() < 2) {
+            return raw;
+        }
+        if (raw.charAt(0) == '"' && raw.charAt(raw.length() - 1) == '"') {
+            return normalizeAnnotationDoubleQuotedContent(raw.substring(1, raw.length() - 1));
+        }
+        if (raw.charAt(0) == '\'' && raw.charAt(raw.length() - 1) == '\'') {
+            return raw.substring(1, raw.length() - 1);
+        }
+        return raw;
+    }
+
+    private static String normalizeAnnotationDoubleQuotedContent(String content) {
+        var normalized = new StringBuilder(content.length());
+        for (var i = 0; i < content.length(); i++) {
+            var ch = content.charAt(i);
+            if (ch == '\\' && i + 1 < content.length()) {
+                var next = content.charAt(i + 1);
+                if (next == '"' || next == '\\') {
+                    normalized.append(next);
+                    i++;
+                    continue;
+                }
+            }
+            normalized.append(ch);
+        }
+        return normalized.toString();
+    }
+
+    private static String renderReflectionPackageForType(String symbolName, String fallbackPackagePath) {
+        var path = reflectionPackagePath(symbolName, fallbackPackagePath);
+        var name = path.isBlank() ? "" : simpleReflectionTypeName(path);
+        return renderReflectionPackage(name, path);
+    }
+
+    private static String renderReflectionPackage(String packageName, String packagePath) {
+        return "{ name: "
+               + jsString(packageName == null ? "" : packageName)
+               + ", path: "
+               + jsString(packagePath == null ? "" : packagePath.replaceFirst("^/", ""))
+               + " }";
+    }
+
+    static String renderEmptyReflectionPackage() {
+        return "{ name: '', path: '' }";
+    }
+
+    private static String reflectionPackagePath(String symbolName, String fallbackPackagePath) {
+        var normalized = symbolName.replace('\\', '/');
+        var dot = normalized.lastIndexOf('.');
+        var slash = normalized.lastIndexOf('/');
+        if (slash >= 0) {
+            if (dot > slash) {
+                return normalized.substring(0, dot).replaceFirst("^/", "");
+            }
+            return normalized.substring(0, slash).replaceFirst("^/", "");
+        }
+        if (dot > 0) {
+            return normalized.substring(0, dot);
+        }
+        return fallbackPackagePath == null ? "" : fallbackPackagePath;
+    }
+
+    private static String simpleReflectionTypeName(String typeName) {
+        var normalized = stripGenericSuffix(typeName);
+        var slash = normalized.lastIndexOf('/');
+        var dot = normalized.lastIndexOf('.');
+        var index = Math.max(slash, dot);
+        return index >= 0 ? normalized.substring(index + 1) : normalized;
+    }
+
+    private static String stripGenericSuffix(String typeName) {
+        var idx = typeName.indexOf('[');
+        return idx >= 0 ? typeName.substring(0, idx) : typeName;
+    }
+
+    private record ReflectionFunctionShape(List<CompiledType> parameterTypes, CompiledType returnType) {
     }
 
     record ModuleInfo(CompiledModule module, JavaClass javaClass, String className, Path relativePath, String packageName, String packagePath) {
@@ -4839,7 +5100,9 @@ public final class JavaScriptGenerator implements Generator {
                         return list(mapper === undefined ? values ?? [] : Array.from(values ?? [], mapper));
                     }
 
-                    function enumValue(name, owner, parents = [], ordinal = 0, aliases = [], packageName = '', packagePath = owner) {
+                    function enumValue(name, owner, parents = [], ordinal = 0, aliases = [], packageName = '', packagePath = owner, metadata = undefined) {
+                        const reflectionFields = metadata && Array.isArray(metadata.fields) ? metadata.fields : [];
+                        const reflectionAnnotations = metadata && Array.isArray(metadata.annotations) ? metadata.annotations : [];
                         const value = {
                             __capybaraType: name,
                             __capybaraTypes: [name, ...aliases, owner, ...parents],
@@ -4848,7 +5111,7 @@ public final class JavaScriptGenerator implements Generator {
                             ordinal,
                             order: ordinal,
                             toString() { return name; },
-                            capybaraDataValueInfo() { return { name, packageName, packagePath, fields: [] }; },
+                            capybaraDataValueInfo() { return dataValueInfo(this, name, packageName, packagePath, reflectionFields, reflectionAnnotations); },
                         };
                         if (parents.includes('Seq') && name === 'End') {
                             Object.assign(value, {
@@ -5501,32 +5764,56 @@ public final class JavaScriptGenerator implements Generator {
                         return typeof value === 'string' ? `"${value}"` : toStringValue(value);
                     }
 
-                        function dataValueInfo(value, name, packageName, packagePath, fieldNames) {
-                            const keys = Array.isArray(fieldNames) && fieldNames.length > 0
-                                ? fieldNames
-                                : nativeArrayFilter.call(Object.keys(value), key => !key.startsWith('__') && typeof value[key] !== 'function');
-                            const fields = nativeArrayMap.call(keys, key => ({ name: key, value: value[key] }));
-                        return { name, packageName, packagePath, fields };
+                    function reflectionPackage(packageName, packagePath) {
+                        return {
+                            name: packageName ?? '',
+                            path: String(packagePath ?? '').replace(/^\\/+/u, ''),
+                        };
                     }
 
-                    function reflection(target, name, packageName, packagePath, fieldNames) {
-                        if (name) {
+                    function reflectionFieldDescriptor(field) {
+                        if (typeof field === 'string') {
+                            return { name: field, type: undefined, annotations: [] };
+                        }
+                        return {
+                            name: field.name,
+                            type: field.type,
+                            annotations: Array.isArray(field.annotations) ? field.annotations : [],
+                        };
+                    }
+
+                    function dataValueInfo(value, name, packageName, packagePath, fieldInfos, annotations = []) {
+                        const descriptors = Array.isArray(fieldInfos)
+                            ? fieldInfos
+                            : nativeArrayFilter.call(Object.keys(value), key => !key.startsWith('__') && typeof value[key] !== 'function');
+                        const fields = nativeArrayMap.call(descriptors, field => {
+                            const descriptor = reflectionFieldDescriptor(field);
                             return {
-                                name,
-                                packageName,
-                                packagePath,
-                                    fields: nativeArrayMap.call(fieldNames, field => ({ name: field, value: target[field] })),
+                                name: descriptor.name,
+                                type: descriptor.type,
+                                value: value[descriptor.name],
+                                annotations: descriptor.annotations,
                             };
+                        });
+                        const pkg = reflectionPackage(packageName, packagePath);
+                        return {
+                            name,
+                            pkg,
+                            packageName: pkg.name,
+                            packagePath: pkg.path,
+                            fields,
+                            annotations: Array.isArray(annotations) ? annotations : [],
+                        };
+                    }
+
+                    function reflection(target, name, packageName, packagePath, fieldInfos, annotations = []) {
+                        if (name) {
+                            return dataValueInfo(target, name, packageName, packagePath, fieldInfos, annotations);
                         }
                         if (target && typeof target.capybaraDataValueInfo === 'function') {
                             return target.capybaraDataValueInfo();
                         }
-                        return {
-                            name,
-                            packageName,
-                            packagePath,
-                                fields: nativeArrayMap.call(fieldNames, field => ({ name: field, value: target[field] })),
-                        };
+                        return dataValueInfo(target, name, packageName, packagePath, fieldInfos, annotations);
                     }
 
                     function writeProgramResult(value) {

--- a/compiler/src/main/java/dev/capylang/generator/ObjectOrientedJavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/ObjectOrientedJavaGenerator.java
@@ -3,6 +3,7 @@ package dev.capylang.generator;
 import dev.capylang.compiler.PrimitiveLinkedType;
 import dev.capylang.compiler.parser.ObjectOriented;
 import dev.capylang.compiler.parser.ObjectOrientedModule;
+import dev.capylang.generator.java.ReflectionValueInfoJava;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -172,6 +173,8 @@ public final class ObjectOrientedJavaGenerator {
     }
 
     private void appendImports(StringBuilder code, ObjectOrientedModule module) {
+        var referencedTypeTokens = referencedTypeTokens(module);
+        var referencedAnnotationNames = referencedAnnotationNames(module);
         var imports = Stream.concat(
                         module.imports().stream()
                 .flatMap(importDeclaration -> importDeclaration.symbols().stream()
@@ -179,6 +182,7 @@ public final class ObjectOrientedJavaGenerator {
                         .filter(symbol -> !importDeclaration.excludedSymbols().contains(symbol))
                         .filter(symbol -> !symbol.isBlank())
                         .filter(symbol -> Character.isUpperCase(symbol.charAt(0)))
+                        .filter(symbol -> !referencedAnnotationNames.contains(symbol) || referencedTypeTokens.contains(symbol))
                         .map(symbol -> renderImportedSymbolReference(module, importDeclaration.moduleName(), symbol))),
                         inferSameModuleImports(module).stream()
                 )
@@ -232,6 +236,29 @@ public final class ObjectOrientedJavaGenerator {
                         method.body().ifPresent(body -> collectTypeTokens(body, references));
                     }
                     case ObjectOriented.InitBlock initBlock -> collectTypeTokens(initBlock.body(), references);
+                }
+            }
+        }
+        return Set.copyOf(references);
+    }
+
+    private Set<String> referencedAnnotationNames(ObjectOrientedModule module) {
+        var references = new HashSet<String>();
+        for (var definition : module.objectOriented().definitions()) {
+            definition.linkedAnnotations().stream()
+                    .map(annotation -> simpleTypeName(annotation.name()))
+                    .forEach(references::add);
+            for (var member : definition.members()) {
+                switch (member) {
+                    case ObjectOriented.FieldDeclaration field -> field.linkedAnnotations().stream()
+                            .map(annotation -> simpleTypeName(annotation.name()))
+                            .forEach(references::add);
+                    case ObjectOriented.MethodDeclaration method -> method.linkedAnnotations().stream()
+                            .map(annotation -> simpleTypeName(annotation.name()))
+                            .forEach(references::add);
+                    case ObjectOriented.InitBlock initBlock -> initBlock.linkedAnnotations().stream()
+                            .map(annotation -> simpleTypeName(annotation.name()))
+                            .forEach(references::add);
                 }
             }
         }
@@ -535,7 +562,8 @@ public final class ObjectOrientedJavaGenerator {
                    + javaString(declaration.name()) + ", "
                    + renderReflectionPackage(module) + ", "
                    + renderReflectionMethods(module, declaration.members(), definitionsByName, full) + ", "
-                   + renderReflectionParents(module, declaration.parents(), definitionsByName, full)
+                   + renderReflectionParents(module, declaration.parents(), definitionsByName, full) + ", "
+                   + ReflectionValueInfoJava.reflectionAnnotations(declaration.linkedAnnotations())
                    + ")";
         }
         if (declaration instanceof ObjectOriented.TraitDeclaration) {
@@ -543,7 +571,8 @@ public final class ObjectOrientedJavaGenerator {
                    + javaString(declaration.name()) + ", "
                    + renderReflectionPackage(module) + ", "
                    + renderReflectionMethods(module, declaration.members(), definitionsByName, full) + ", "
-                   + renderReflectionParents(module, declaration.parents(), definitionsByName, full)
+                   + renderReflectionParents(module, declaration.parents(), definitionsByName, full) + ", "
+                   + ReflectionValueInfoJava.reflectionAnnotations(declaration.linkedAnnotations())
                    + ")";
         }
         var classDeclaration = (ObjectOriented.ClassDeclaration) declaration;
@@ -557,7 +586,8 @@ public final class ObjectOrientedJavaGenerator {
                + classDeclaration.modifiers().contains("open") + ", "
                + renderReflectionFields(module, fields, definitionsByName, full) + ", "
                + renderReflectionMethods(module, declaration.members(), definitionsByName, full) + ", "
-               + renderReflectionParents(module, declaration.parents(), definitionsByName, full)
+               + renderReflectionParents(module, declaration.parents(), definitionsByName, full) + ", "
+               + ReflectionValueInfoJava.reflectionAnnotations(declaration.linkedAnnotations())
                + ")";
     }
 
@@ -594,6 +624,8 @@ public final class ObjectOrientedJavaGenerator {
                 .map(field -> "new capy.metaProg.Reflection.FieldInfo("
                               + javaString(field.name()) + ", "
                               + renderReflectionTypeInfo(module, field.type(), definitionsByName)
+                              + ", "
+                              + ReflectionValueInfoJava.reflectionAnnotations(field.linkedAnnotations())
                               + ")")
                 .collect(Collectors.joining(", ", "java.util.List.<capy.metaProg.Reflection.FieldInfo>of(", ")"));
     }
@@ -629,6 +661,8 @@ public final class ObjectOrientedJavaGenerator {
                + renderReflectionPackage(module) + ", "
                + renderReflectionParams(module, method.parameters(), definitionsByName) + ", "
                + renderReflectionTypeInfo(module, method.returnType(), definitionsByName)
+               + ", "
+               + ReflectionValueInfoJava.reflectionAnnotations(method.linkedAnnotations())
                + ")";
     }
 
@@ -644,6 +678,8 @@ public final class ObjectOrientedJavaGenerator {
                 .map(parameter -> "new capy.metaProg.Reflection.FieldInfo("
                                   + javaString(parameter.name()) + ", "
                                   + renderReflectionTypeInfo(module, parameter.type(), definitionsByName)
+                                  + ", "
+                                  + ReflectionValueInfoJava.reflectionAnnotations(List.of())
                                   + ")")
                 .collect(Collectors.joining(", ", "java.util.List.<capy.metaProg.Reflection.FieldInfo>of(", ")"));
     }
@@ -697,6 +733,8 @@ public final class ObjectOrientedJavaGenerator {
             return "new capy.metaProg.Reflection.DataInfo("
                    + javaString(trimmed) + ", "
                    + renderEmptyReflectionPackage()
+                   + ", "
+                   + ReflectionValueInfoJava.reflectionAnnotations(List.of())
                    + ")";
         }
         var primitiveBackedType = primitiveBackedType(module, trimmed);
@@ -710,6 +748,8 @@ public final class ObjectOrientedJavaGenerator {
         return "new capy.metaProg.Reflection.DataInfo("
                + javaString(simpleTypeName(trimmed)) + ", "
                + renderReflectionPackageForType(module, trimmed)
+               + ", "
+               + ReflectionValueInfoJava.reflectionAnnotations(List.of())
                + ")";
     }
 
@@ -727,7 +767,8 @@ public final class ObjectOrientedJavaGenerator {
                + "false, "
                + "java.util.List.<capy.metaProg.Reflection.FieldInfo>of(), "
                + "java.util.List.<capy.metaProg.Reflection.MethodInfo>of(), "
-               + "java.util.Set.<capy.metaProg.Reflection.AnyInfo>of()"
+               + "java.util.Set.<capy.metaProg.Reflection.AnyInfo>of(), "
+               + ReflectionValueInfoJava.reflectionAnnotations(List.of())
                + ")";
     }
 

--- a/compiler/src/main/java/dev/capylang/generator/ObjectOrientedJavaScriptGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/ObjectOrientedJavaScriptGenerator.java
@@ -1012,6 +1012,8 @@ final class ObjectOrientedJavaScriptGenerator {
                    + renderReflectionMethods(context, declaration.members(), full)
                    + ", parents: "
                    + renderReflectionParents(context, declaration.parents(), full)
+                   + ", annotations: "
+                   + JavaScriptGenerator.renderAnnotations(declaration.linkedAnnotations())
                    + " }";
         }
         if (declaration instanceof ObjectOriented.TraitDeclaration) {
@@ -1023,6 +1025,8 @@ final class ObjectOrientedJavaScriptGenerator {
                    + renderReflectionMethods(context, declaration.members(), full)
                    + ", parents: "
                    + renderReflectionParents(context, declaration.parents(), full)
+                   + ", annotations: "
+                   + JavaScriptGenerator.renderAnnotations(declaration.linkedAnnotations())
                    + " }";
         }
         var classDeclaration = (ObjectOriented.ClassDeclaration) declaration;
@@ -1042,6 +1046,8 @@ final class ObjectOrientedJavaScriptGenerator {
                + renderReflectionMethods(context, declaration.members(), full)
                + ", parents: "
                + renderReflectionParents(context, declaration.parents(), full)
+               + ", annotations: "
+               + JavaScriptGenerator.renderAnnotations(declaration.linkedAnnotations())
                + " }";
     }
 
@@ -1069,6 +1075,8 @@ final class ObjectOrientedJavaScriptGenerator {
                               + JavaScriptGenerator.jsString(field.name())
                               + ", type: "
                               + renderReflectionTypeInfo(context, field.type())
+                              + ", annotations: "
+                              + JavaScriptGenerator.renderAnnotations(field.linkedAnnotations())
                               + " }")
                 .collect(joining(", ", "[", "]"));
     }
@@ -1093,6 +1101,8 @@ final class ObjectOrientedJavaScriptGenerator {
                                + renderReflectionParams(context, method.parameters())
                                + ", return_type: "
                                + renderReflectionTypeInfo(context, method.returnType())
+                               + ", annotations: "
+                               + JavaScriptGenerator.renderAnnotations(method.linkedAnnotations())
                                + " }")
                 .collect(joining(", ", "[", "]"));
     }
@@ -1106,6 +1116,7 @@ final class ObjectOrientedJavaScriptGenerator {
                                   + JavaScriptGenerator.jsString(parameter.name())
                                   + ", type: "
                                   + renderReflectionTypeInfo(context, parameter.type())
+                                  + ", annotations: []"
                                   + " }")
                 .collect(joining(", ", "[", "]"));
     }
@@ -1113,19 +1124,19 @@ final class ObjectOrientedJavaScriptGenerator {
     private String renderReflectionTypeInfo(RenderContext context, String rawType) {
         var trimmed = rawType.trim();
         if (trimmed.endsWith("[]")) {
-            return "{ kind: 'list', name: 'array', pkg: " + renderEmptyReflectionPackage()
+            return "{ kind: 'list', name: 'array', pkg: " + JavaScriptGenerator.renderEmptyReflectionPackage()
                    + ", element_type: " + renderReflectionTypeInfo(context, trimmed.substring(0, trimmed.length() - 2)) + " }";
         }
         if (trimmed.startsWith("List[") && trimmed.endsWith("]")) {
-            return "{ kind: 'list', name: 'List', pkg: " + renderEmptyReflectionPackage()
+            return "{ kind: 'list', name: 'List', pkg: " + JavaScriptGenerator.renderEmptyReflectionPackage()
                    + ", element_type: " + renderReflectionTypeInfo(context, trimmed.substring(5, trimmed.length() - 1)) + " }";
         }
         if (trimmed.startsWith("Set[") && trimmed.endsWith("]")) {
-            return "{ kind: 'set', name: 'Set', pkg: " + renderEmptyReflectionPackage()
+            return "{ kind: 'set', name: 'Set', pkg: " + JavaScriptGenerator.renderEmptyReflectionPackage()
                    + ", element_type: " + renderReflectionTypeInfo(context, trimmed.substring(4, trimmed.length() - 1)) + " }";
         }
         if (trimmed.startsWith("Dict[") && trimmed.endsWith("]")) {
-            return "{ kind: 'dict', name: 'Dict', pkg: " + renderEmptyReflectionPackage()
+            return "{ kind: 'dict', name: 'Dict', pkg: " + JavaScriptGenerator.renderEmptyReflectionPackage()
                    + ", value_type: " + renderReflectionTypeInfo(context, trimmed.substring(5, trimmed.length() - 1)) + " }";
         }
         if (trimmed.startsWith("Tuple[") && trimmed.endsWith("]")) {
@@ -1133,12 +1144,20 @@ final class ObjectOrientedJavaScriptGenerator {
             var elements = splitTopLevel(inner).stream()
                     .map(type -> renderReflectionTypeInfo(context, type))
                     .collect(joining(", ", "[", "]"));
-            return "{ kind: 'tuple', name: 'Tuple', pkg: " + renderEmptyReflectionPackage() + ", elements: " + elements + " }";
+            return "{ kind: 'tuple', name: 'Tuple', pkg: " + JavaScriptGenerator.renderEmptyReflectionPackage() + ", elements: " + elements + " }";
+        }
+        if (isPrimitiveReflectionType(trimmed)) {
+            return "{ kind: 'data', name: "
+                   + JavaScriptGenerator.jsString(trimmed)
+                   + ", pkg: "
+                   + JavaScriptGenerator.renderEmptyReflectionPackage()
+                   + ", annotations: [] }";
         }
         return "{ kind: 'data', name: "
                + JavaScriptGenerator.jsString(JavaScriptGenerator.simpleTypeName(trimmed))
                + ", pkg: "
                + renderReflectionPackageForType(context.module(), trimmed)
+               + ", annotations: []"
                + " }";
     }
 
@@ -1147,7 +1166,7 @@ final class ObjectOrientedJavaScriptGenerator {
                + JavaScriptGenerator.jsString(name)
                + ", pkg: "
                + renderReflectionPackageForType(context.module(), name)
-               + ", open: false, fields: [], methods: [], parents: [] }";
+               + ", open: false, fields: [], methods: [], parents: [], annotations: [] }";
     }
 
     private String renderReflectionPackage(ObjectOrientedModule module) {
@@ -1167,8 +1186,11 @@ final class ObjectOrientedJavaScriptGenerator {
         return renderReflectionPackage(module);
     }
 
-    private String renderEmptyReflectionPackage() {
-        return "{ name: '', path: '' }";
+    private boolean isPrimitiveReflectionType(String type) {
+        return switch (type) {
+            case "byte", "int", "long", "double", "float", "bool", "String", "any", "data", "void", "nothing" -> true;
+            default -> false;
+        };
     }
 
     private boolean isNumericLiteral(String value) {

--- a/compiler/src/main/java/dev/capylang/generator/ObjectOrientedPythonGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/ObjectOrientedPythonGenerator.java
@@ -1043,6 +1043,8 @@ final class ObjectOrientedPythonGenerator {
                    + renderReflectionMethods(context, declaration.members(), full)
                    + ", parents="
                    + renderReflectionParents(context, declaration.parents(), full)
+                   + ", annotations="
+                   + PythonGenerator.renderAnnotations(declaration.linkedAnnotations())
                    + ")";
         }
         if (declaration instanceof ObjectOriented.TraitDeclaration) {
@@ -1054,6 +1056,8 @@ final class ObjectOrientedPythonGenerator {
                    + renderReflectionMethods(context, declaration.members(), full)
                    + ", parents="
                    + renderReflectionParents(context, declaration.parents(), full)
+                   + ", annotations="
+                   + PythonGenerator.renderAnnotations(declaration.linkedAnnotations())
                    + ")";
         }
         var classDeclaration = (ObjectOriented.ClassDeclaration) declaration;
@@ -1073,6 +1077,8 @@ final class ObjectOrientedPythonGenerator {
                + renderReflectionMethods(context, declaration.members(), full)
                + ", parents="
                + renderReflectionParents(context, declaration.parents(), full)
+               + ", annotations="
+               + PythonGenerator.renderAnnotations(declaration.linkedAnnotations())
                + ")";
     }
 
@@ -1100,6 +1106,8 @@ final class ObjectOrientedPythonGenerator {
                               + PythonGenerator.pyString(field.name())
                               + ", "
                               + renderReflectionTypeInfo(context, field.type())
+                              + ", annotations="
+                              + PythonGenerator.renderAnnotations(field.linkedAnnotations())
                               + ")")
                 .collect(joining(", ", "[", "]"));
     }
@@ -1124,6 +1132,8 @@ final class ObjectOrientedPythonGenerator {
                                + renderReflectionParams(context, method.parameters())
                                + ", return_type="
                                + renderReflectionTypeInfo(context, method.returnType())
+                               + ", annotations="
+                               + PythonGenerator.renderAnnotations(method.linkedAnnotations())
                                + ")")
                 .collect(joining(", ", "[", "]"));
     }
@@ -1137,6 +1147,7 @@ final class ObjectOrientedPythonGenerator {
                                   + PythonGenerator.pyString(parameter.name())
                                   + ", "
                                   + renderReflectionTypeInfo(context, parameter.type())
+                                  + ", annotations=[]"
                                   + ")")
                 .collect(joining(", ", "[", "]"));
     }
@@ -1162,10 +1173,18 @@ final class ObjectOrientedPythonGenerator {
                     .collect(joining(", ", "[", "]"));
             return "capy.type_info('tuple', 'Tuple', elements=" + elements + ")";
         }
+        if (isPrimitiveReflectionType(trimmed)) {
+            return "capy.type_info('data', "
+                   + PythonGenerator.pyString(trimmed)
+                   + ", pkg="
+                   + PythonGenerator.renderEmptyReflectionPackage()
+                   + ", annotations=[])";
+        }
         return "capy.type_info('data', "
                + PythonGenerator.pyString(PythonGenerator.simpleTypeName(trimmed))
                + ", pkg="
                + renderReflectionPackageForType(context.module(), trimmed)
+               + ", annotations=[]"
                + ")";
     }
 
@@ -1174,13 +1193,13 @@ final class ObjectOrientedPythonGenerator {
                + PythonGenerator.pyString(name)
                + ", pkg="
                + renderReflectionPackageForType(context.module(), name)
-               + ", open=False, fields=[], methods=[], parents=[])";
+               + ", open=False, fields=[], methods=[], parents=[], annotations=[])";
     }
 
     private String renderReflectionPackage(ObjectOrientedModule module) {
         var path = module.path().replaceFirst("^/", "");
         var name = path.isBlank() ? "" : PythonGenerator.simpleTypeName(path);
-        return "capy.object_info('package', " + PythonGenerator.pyString(name) + ", path=" + PythonGenerator.pyString(path) + ")";
+        return "capy.package_info(" + PythonGenerator.pyString(name) + ", " + PythonGenerator.pyString(path) + ")";
     }
 
     private String renderReflectionPackageForType(ObjectOrientedModule module, String rawType) {
@@ -1189,9 +1208,16 @@ final class ObjectOrientedPythonGenerator {
             var slash = normalized.lastIndexOf('/');
             var path = slash > 0 ? normalized.substring(1, slash) : "";
             var name = path.isBlank() ? "" : PythonGenerator.simpleTypeName(path);
-            return "capy.object_info('package', " + PythonGenerator.pyString(name) + ", path=" + PythonGenerator.pyString(path) + ")";
+            return "capy.package_info(" + PythonGenerator.pyString(name) + ", " + PythonGenerator.pyString(path) + ")";
         }
         return renderReflectionPackage(module);
+    }
+
+    private boolean isPrimitiveReflectionType(String type) {
+        return switch (type) {
+            case "byte", "int", "long", "double", "float", "bool", "String", "any", "data", "void", "nothing" -> true;
+            default -> false;
+        };
     }
 
     private boolean isNumericLiteral(String value) {

--- a/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -1,9 +1,15 @@
 package dev.capylang.generator;
 
 import dev.capylang.compiler.CollectionLinkedType;
+import dev.capylang.compiler.CompiledAnnotation;
+import dev.capylang.compiler.CompiledAnnotationValue;
+import dev.capylang.compiler.CompiledDataParentType;
 import dev.capylang.compiler.CompiledDataType;
 import dev.capylang.compiler.CompiledFunction;
+import dev.capylang.compiler.CompiledFunctionType;
+import dev.capylang.compiler.CompiledGenericTypeParameter;
 import dev.capylang.compiler.CompiledModule;
+import dev.capylang.compiler.CompiledObjectType;
 import dev.capylang.compiler.CompiledPrimitiveBackedType;
 import dev.capylang.compiler.CompiledProgram;
 import dev.capylang.compiler.CompiledTupleType;
@@ -15,6 +21,7 @@ import dev.capylang.compiler.parser.ObjectOrientedModule;
 import dev.capylang.generator.java.JavaAstBuilder;
 import dev.capylang.generator.java.JavaClass;
 import dev.capylang.generator.java.JavaConst;
+import dev.capylang.generator.java.JavaDataValueInfo;
 import dev.capylang.generator.java.JavaEnum;
 import dev.capylang.generator.java.JavaMethod;
 import dev.capylang.generator.java.JavaRecord;
@@ -232,14 +239,17 @@ public final class PythonGenerator implements Generator {
             code.append("    def __str__(self):\n");
             code.append("        return self.toString()\n\n");
             code.append("    def capybaraDataValueInfo(self):\n");
+            var dataValueInfo = record.dataValueInfo();
             code.append("        return capy.data_value_info(self, ")
-                    .append(pyString(capybaraName))
+                    .append(pyString(dataValueInfo.name()))
                     .append(", ")
-                    .append(pyString(moduleInfo.packageName()))
+                    .append(pyString(dataValueInfo.packageName()))
                     .append(", ")
-                    .append(pyString(moduleInfo.packagePath()))
+                    .append(pyString(dataValueInfo.packagePath()))
                     .append(", ")
-                    .append(pyArray(record.fields().stream().map(JavaRecord.JavaRecordField::name).toList()))
+                    .append(renderDataValueFieldDescriptors(dataValueInfo.fields(), dataValueInfo.packagePath()))
+                    .append(", ")
+                    .append(renderAnnotations(dataValueInfo.annotations()))
                     .append(")\n\n");
             for (var method : record.methods()) {
                 code.append(renderFunction(method, false));
@@ -281,14 +291,16 @@ public final class PythonGenerator implements Generator {
             var values = javaEnum.values().isEmpty() ? List.of("INSTANCE") : javaEnum.values();
             var code = new StringBuilder();
             if (values.size() == 1 && "INSTANCE".equals(values.getFirst())) {
+                var dataValueInfo = javaEnum.dataValueInfos().getFirst();
                 code.append(enumName)
                         .append(" = capy.enum_value(")
                         .append(pyString(capybaraName)).append(", ")
                         .append(pyString(capybaraName)).append(", ")
                         .append(pyArray(programContext.parentTypes(enumName))).append(", ")
                         .append("0, [], ")
-                        .append(pyString(moduleInfo.packageName())).append(", ")
-                        .append(pyString(moduleInfo.packagePath()))
+                        .append(pyString(dataValueInfo.packageName())).append(", ")
+                        .append(pyString(dataValueInfo.packagePath())).append(", ")
+                        .append(renderDataValueMetadata(dataValueInfo))
                         .append(")\n");
                 exportNames.add(enumName);
                 return code.toString();
@@ -303,14 +315,16 @@ public final class PythonGenerator implements Generator {
                 if (!valueName.equals(capybaraValueName)) {
                     aliases.add(valueName);
                 }
+                var dataValueInfo = javaEnum.dataValueInfos().get(i);
                 code.append("    capy.enum_value(")
                         .append(pyString(capybaraValueName)).append(", ")
                         .append(pyString(capybaraName)).append(", ")
                         .append(pyArray(programContext.parentTypes(valueName))).append(", ")
                         .append(i).append(", ")
                         .append(pyArray(aliases)).append(", ")
-                        .append(pyString(moduleInfo.packageName())).append(", ")
-                        .append(pyString(moduleInfo.packagePath())).append("),\n");
+                        .append(pyString(dataValueInfo.packageName())).append(", ")
+                        .append(pyString(dataValueInfo.packagePath())).append(", ")
+                        .append(renderDataValueMetadata(dataValueInfo)).append("),\n");
             }
             code.append("]\n");
             code.append("class ").append(enumName).append(":\n");
@@ -1120,7 +1134,8 @@ public final class PythonGenerator implements Generator {
                    + pyString(reflectionValue.name()) + ", "
                    + pyString(reflectionValue.packageName()) + ", "
                    + pyString(reflectionValue.packagePath()) + ", "
-                   + pyArray(reflectionValue.fields().stream().map(CompiledReflectionValue.Field::name).toList())
+                   + renderReflectionFieldDescriptors(reflectionValue.fields(), reflectionValue.packagePath()) + ", "
+                   + renderAnnotations(reflectionValue.annotations())
                    + ")";
         }
 
@@ -1432,6 +1447,252 @@ public final class PythonGenerator implements Generator {
             }
             return base + "_p" + idx;
         }
+    }
+
+    private static String renderDataValueMetadata(JavaDataValueInfo dataValueInfo) {
+        return "{'fields': "
+               + renderDataValueFieldDescriptors(dataValueInfo.fields(), dataValueInfo.packagePath())
+               + ", 'annotations': "
+               + renderAnnotations(dataValueInfo.annotations())
+               + "}";
+    }
+
+    private static String renderDataValueFieldDescriptors(List<JavaDataValueInfo.Field> fields, String fallbackPackagePath) {
+        if (fields.isEmpty()) {
+            return "[]";
+        }
+        return fields.stream()
+                .map(field -> "capy.field_info("
+                              + pyString(field.name())
+                              + ", "
+                              + renderReflectionTypeInfo(field.type(), fallbackPackagePath)
+                              + ", annotations="
+                              + renderAnnotations(field.annotations())
+                              + ")")
+                .collect(joining(", ", "[", "]"));
+    }
+
+    private static String renderReflectionFieldDescriptors(List<CompiledReflectionValue.Field> fields, String fallbackPackagePath) {
+        if (fields.isEmpty()) {
+            return "[]";
+        }
+        return fields.stream()
+                .map(field -> "capy.field_info("
+                              + pyString(field.name())
+                              + ", "
+                              + renderReflectionTypeInfo(field.type(), fallbackPackagePath)
+                              + ", annotations="
+                              + renderAnnotations(field.annotations())
+                              + ")")
+                .collect(joining(", ", "[", "]"));
+    }
+
+    static String renderReflectionTypeInfo(CompiledType type, String fallbackPackagePath) {
+        return switch (type) {
+            case PrimitiveLinkedType primitive ->
+                    renderDataInfo(primitiveReflectionTypeName(primitive), renderEmptyReflectionPackage(), List.of());
+            case CollectionLinkedType.CompiledList listType ->
+                    "capy.type_info('list', 'List', pkg=" + renderEmptyReflectionPackage()
+                    + ", element_type=" + renderReflectionTypeInfo(listType.elementType(), fallbackPackagePath) + ")";
+            case CollectionLinkedType.CompiledSet setType ->
+                    "capy.type_info('set', 'Set', pkg=" + renderEmptyReflectionPackage()
+                    + ", element_type=" + renderReflectionTypeInfo(setType.elementType(), fallbackPackagePath) + ")";
+            case CollectionLinkedType.CompiledDict dictType ->
+                    "capy.type_info('dict', 'Dict', pkg=" + renderEmptyReflectionPackage()
+                    + ", value_type=" + renderReflectionTypeInfo(dictType.valueType(), fallbackPackagePath) + ")";
+            case CompiledTupleType tupleType -> {
+                var elements = tupleType.elementTypes().stream()
+                        .map(elementType -> renderReflectionTypeInfo(elementType, fallbackPackagePath))
+                        .collect(joining(", ", "[", "]"));
+                yield "capy.type_info('tuple', 'Tuple', pkg=" + renderEmptyReflectionPackage()
+                      + ", elements=" + elements + ")";
+            }
+            case CompiledFunctionType functionType -> {
+                var shape = flattenReflectionFunctionType(functionType);
+                var params = shape.parameterTypes().stream()
+                        .map(parameterType -> renderReflectionTypeInfo(parameterType, fallbackPackagePath))
+                        .collect(joining(", ", "[", "]"));
+                yield "capy.type_info('function', 'function', pkg=" + renderEmptyReflectionPackage()
+                      + ", params=" + params
+                      + ", return_type=" + renderReflectionTypeInfo(shape.returnType(), fallbackPackagePath)
+                      + ")";
+            }
+            case CompiledGenericTypeParameter genericTypeParameter ->
+                    renderDataInfo(genericTypeParameter.name(), renderEmptyReflectionPackage(), List.of());
+            case CompiledPrimitiveBackedType primitiveBackedType ->
+                    renderReflectionTypeInfo(primitiveBackedType.backingType(), fallbackPackagePath);
+            case CompiledDataParentType parentType ->
+                    renderDataInfo(
+                            simpleReflectionTypeName(parentType.name()),
+                            renderReflectionPackageForType(parentType.name(), fallbackPackagePath),
+                            parentType.annotations()
+                    );
+            case CompiledDataType dataType ->
+                    renderDataInfo(
+                            simpleReflectionTypeName(dataType.name()),
+                            renderReflectionPackageForType(dataType.name(), fallbackPackagePath),
+                            dataType.annotations()
+                    );
+            case CompiledObjectType objectType ->
+                    renderDataInfo(
+                            simpleReflectionTypeName(objectType.name()),
+                            renderReflectionPackageForType(objectType.name(), fallbackPackagePath),
+                            objectType.annotations()
+                    );
+        };
+    }
+
+    private static ReflectionFunctionShape flattenReflectionFunctionType(CompiledFunctionType functionType) {
+        var parameterTypes = new ArrayList<CompiledType>();
+        CompiledType current = functionType;
+        while (current instanceof CompiledFunctionType currentFunctionType) {
+            parameterTypes.add(currentFunctionType.argumentType());
+            current = currentFunctionType.returnType();
+        }
+        return new ReflectionFunctionShape(List.copyOf(parameterTypes), current);
+    }
+
+    private static String renderDataInfo(String name, String pkg, List<CompiledAnnotation> annotations) {
+        return "capy.type_info('data', "
+               + pyString(name)
+               + ", pkg="
+               + pkg
+               + ", annotations="
+               + renderAnnotations(annotations)
+               + ")";
+    }
+
+    private static String primitiveReflectionTypeName(PrimitiveLinkedType type) {
+        return type == PrimitiveLinkedType.STRING
+                ? "String"
+                : type.name().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    static String renderAnnotations(List<CompiledAnnotation> annotations) {
+        if (annotations == null || annotations.isEmpty()) {
+            return "[]";
+        }
+        return annotations.stream()
+                .map(PythonGenerator::renderAnnotation)
+                .collect(joining(", ", "[", "]"));
+    }
+
+    private static String renderAnnotation(CompiledAnnotation annotation) {
+        var arguments = annotation.arguments().stream()
+                .map(argument -> "capy.annotation_argument_info("
+                                 + pyString(argument.name())
+                                 + ", "
+                                 + renderAnnotationValue(argument.value())
+                                 + ")")
+                .collect(joining(", ", "[", "]"));
+        return "capy.annotation_info("
+               + pyString(annotation.name())
+               + ", pkg="
+               + renderReflectionPackage(annotation.packageName(), annotation.packagePath())
+               + ", arguments="
+               + arguments
+               + ")";
+    }
+
+    private static String renderAnnotationValue(CompiledAnnotationValue value) {
+        return switch (value) {
+            case CompiledAnnotationValue.StringValue stringValue ->
+                    "capy.annotation_value('string', " + pyString(normalizeAnnotationStringValue(stringValue.value())) + ")";
+            case CompiledAnnotationValue.IntValue intValue ->
+                    "capy.annotation_value('int', " + JavaScriptGenerator.stripNumericSuffix(intValue.value()) + ")";
+            case CompiledAnnotationValue.LongValue longValue ->
+                    "capy.annotation_value('long', " + renderLongLiteral(longValue.value()) + ")";
+            case CompiledAnnotationValue.DoubleValue doubleValue ->
+                    "capy.annotation_value('double', " + JavaScriptGenerator.stripNumericSuffix(doubleValue.value()) + ")";
+            case CompiledAnnotationValue.FloatValue floatValue ->
+                    "capy.annotation_value('float', " + JavaScriptGenerator.stripNumericSuffix(floatValue.value()) + ")";
+            case CompiledAnnotationValue.BoolValue boolValue ->
+                    "capy.annotation_value('bool', " + pyBool(boolValue.value()) + ")";
+            case CompiledAnnotationValue.TypeNameValue typeNameValue ->
+                    "capy.annotation_value('type_name', " + pyString(typeNameValue.name()) + ")";
+            case CompiledAnnotationValue.NothingValue ignored ->
+                    "capy.annotation_value('nothing')";
+        };
+    }
+
+    private static String normalizeAnnotationStringValue(String raw) {
+        if (raw.length() < 2) {
+            return raw;
+        }
+        if (raw.charAt(0) == '"' && raw.charAt(raw.length() - 1) == '"') {
+            return normalizeAnnotationDoubleQuotedContent(raw.substring(1, raw.length() - 1));
+        }
+        if (raw.charAt(0) == '\'' && raw.charAt(raw.length() - 1) == '\'') {
+            return raw.substring(1, raw.length() - 1);
+        }
+        return raw;
+    }
+
+    private static String normalizeAnnotationDoubleQuotedContent(String content) {
+        var normalized = new StringBuilder(content.length());
+        for (var i = 0; i < content.length(); i++) {
+            var ch = content.charAt(i);
+            if (ch == '\\' && i + 1 < content.length()) {
+                var next = content.charAt(i + 1);
+                if (next == '"' || next == '\\') {
+                    normalized.append(next);
+                    i++;
+                    continue;
+                }
+            }
+            normalized.append(ch);
+        }
+        return normalized.toString();
+    }
+
+    private static String renderReflectionPackageForType(String symbolName, String fallbackPackagePath) {
+        var path = reflectionPackagePath(symbolName, fallbackPackagePath);
+        var name = path.isBlank() ? "" : simpleReflectionTypeName(path);
+        return renderReflectionPackage(name, path);
+    }
+
+    private static String renderReflectionPackage(String packageName, String packagePath) {
+        return "capy.package_info("
+               + pyString(packageName == null ? "" : packageName)
+               + ", "
+               + pyString(packagePath == null ? "" : packagePath.replaceFirst("^/", ""))
+               + ")";
+    }
+
+    static String renderEmptyReflectionPackage() {
+        return "capy.package_info('', '')";
+    }
+
+    private static String reflectionPackagePath(String symbolName, String fallbackPackagePath) {
+        var normalized = symbolName.replace('\\', '/');
+        var dot = normalized.lastIndexOf('.');
+        var slash = normalized.lastIndexOf('/');
+        if (slash >= 0) {
+            if (dot > slash) {
+                return normalized.substring(0, dot).replaceFirst("^/", "");
+            }
+            return normalized.substring(0, slash).replaceFirst("^/", "");
+        }
+        if (dot > 0) {
+            return normalized.substring(0, dot);
+        }
+        return fallbackPackagePath == null ? "" : fallbackPackagePath;
+    }
+
+    private static String simpleReflectionTypeName(String typeName) {
+        var normalized = stripGenericSuffix(typeName);
+        var slash = normalized.lastIndexOf('/');
+        var dot = normalized.lastIndexOf('.');
+        var index = Math.max(slash, dot);
+        return index >= 0 ? normalized.substring(index + 1) : normalized;
+    }
+
+    private static String stripGenericSuffix(String typeName) {
+        var idx = typeName.indexOf('[');
+        return idx >= 0 ? typeName.substring(0, idx) : typeName;
+    }
+
+    private record ReflectionFunctionShape(List<CompiledType> parameterTypes, CompiledType returnType) {
     }
 
     record ModuleInfo(CompiledModule module, JavaClass javaClass, String className, Path relativePath, String packageName, String packagePath) {
@@ -2874,10 +3135,12 @@ public final class PythonGenerator implements Generator {
                     def dict_(entries=None): return CapyDict(entries)
                     def seq(values, mapper=None): return list(values or []) if mapper is None else [mapper(v) for v in values or []]
 
-                    def enum_value(name, owner, parents=None, ordinal=0, aliases=None, package_name='', package_path=None):
+                    def enum_value(name, owner, parents=None, ordinal=0, aliases=None, package_name='', package_path=None, metadata=None):
                         parents = parents or []
                         aliases = aliases or []
                         package_path = package_path or owner
+                        reflection_fields = metadata.get('fields', []) if isinstance(metadata, dict) else []
+                        reflection_annotations = metadata.get('annotations', []) if isinstance(metadata, dict) else []
                         value = SimpleNamespace(
                             __capybaraType=name,
                             __capybaraTypes=[name] + aliases + [owner] + parents,
@@ -2887,7 +3150,7 @@ public final class PythonGenerator implements Generator {
                             order=ordinal,
                         )
                         value.toString = lambda: name
-                        value.capybaraDataValueInfo = lambda: data_value_info(value, name, package_name, package_path, [])
+                        value.capybaraDataValueInfo = lambda: data_value_info(value, name, package_name, package_path, reflection_fields, reflection_annotations)
                         if owner == 'End' and 'Seq' in parents:
                             value.plus = lambda other: other
                             value.any = lambda pred: False
@@ -3178,13 +3441,34 @@ public final class PythonGenerator implements Generator {
                         if callable(getattr(value, 'toString', None)): return value.toString()
                         return str(value)
 
-                    def data_value_info(target, name, package_name, package_path, fields=None):
+                    def package_info(name='', path=''):
+                        return SimpleNamespace(name=name or '', path=str(path or '').lstrip('/'))
+
+                    def reflection_field_descriptor(field):
+                        if isinstance(field, str):
+                            return SimpleNamespace(name=field, type=None, annotations=[])
+                        return SimpleNamespace(
+                            name=field.name,
+                            type=getattr(field, 'type', None),
+                            annotations=getattr(field, 'annotations', []) if isinstance(getattr(field, 'annotations', []), list) else [],
+                        )
+
+                    def data_value_info(target, name, package_name, package_path, fields=None, annotations=None):
                         fields = fields or []
+                        descriptors = [reflection_field_descriptor(field) for field in fields]
+                        pkg = package_info(package_name, package_path)
                         return SimpleNamespace(
                             name=name,
-                            packageName=package_name,
-                            packagePath=package_path,
-                            fields=[SimpleNamespace(name=field, value=getattr(target, field if hasattr(target, field) else field + '_', None)) for field in fields],
+                            pkg=pkg,
+                            packageName=pkg.name,
+                            packagePath=pkg.path,
+                            fields=[SimpleNamespace(
+                                name=descriptor.name,
+                                type=descriptor.type,
+                                value=getattr(target, descriptor.name if hasattr(target, descriptor.name) else descriptor.name + '_', None),
+                                annotations=descriptor.annotations,
+                            ) for descriptor in descriptors],
+                            annotations=annotations if isinstance(annotations, list) else [],
                         )
 
                     def data_to_string(value):
@@ -3193,12 +3477,12 @@ public final class PythonGenerator implements Generator {
                         body = ', '.join(f'{field.name}: {to_string_value(field.value)}' for field in fields)
                         return f'{info.name} {{ {body} }}' if body else f'{info.name} {{ }}'
 
-                    def reflection(target, name=None, package_name='', package_path='', field_names=None):
+                    def reflection(target, name=None, package_name='', package_path='', field_names=None, annotations=None):
                         if name:
-                            return data_value_info(target, name, package_name, package_path, field_names or [])
+                            return data_value_info(target, name, package_name, package_path, field_names or [], annotations or [])
                         if callable(getattr(target, 'capybaraDataValueInfo', None)):
                             return target.capybaraDataValueInfo()
-                        return data_value_info(target, name, package_name, package_path, field_names or [])
+                        return data_value_info(target, name, package_name, package_path, field_names or [], annotations or [])
 
                     def is_success_like(value):
                         return hasattr(value, 'value') and 'success' in str(capy_type(value) or '').lower()
@@ -3288,15 +3572,19 @@ public final class PythonGenerator implements Generator {
                         return value[normalized]
                     def new_array(length, default_value=None): return [default_value for _ in range(length)]
 
-                    def object_info(kind, name, pkg=None, open=False, fields=None, methods=None, parents=None, **kwargs):
-                        data = dict(kind=kind, name=name, pkg=pkg or SimpleNamespace(name='', path=''), open=open, fields=fields or [], methods=methods or [], parents=parents or [])
+                    def annotation_value(kind, value=None):
+                        return SimpleNamespace(kind=kind, value=value) if value is not None else SimpleNamespace(kind=kind)
+                    def annotation_argument_info(name, value): return SimpleNamespace(name=name, value=value)
+                    def annotation_info(name, pkg=None, arguments=None): return SimpleNamespace(name=name, pkg=pkg or package_info(), arguments=arguments or [])
+                    def object_info(kind, name, pkg=None, open=False, fields=None, methods=None, parents=None, annotations=None, **kwargs):
+                        data = dict(kind=kind, name=name, pkg=pkg or package_info(), open=open, fields=fields or [], methods=methods or [], parents=parents or [], annotations=annotations or [])
                         data.update(kwargs)
                         return SimpleNamespace(**data)
-                    def field_info(name, type): return SimpleNamespace(name=name, type=type)
-                    def method_info(name, pkg=None, params=None, return_type=None): return SimpleNamespace(name=name, pkg=pkg or SimpleNamespace(name='', path=''), params=params or [], return_type=return_type)
-                    def param_info(name, type): return SimpleNamespace(name=name, type=type)
-                    def type_info(kind, name, pkg=None, **kwargs):
-                        data = dict(kind=kind, name=name, pkg=pkg or SimpleNamespace(name='', path=''))
+                    def field_info(name, type, annotations=None): return SimpleNamespace(name=name, type=type, annotations=annotations or [])
+                    def method_info(name, pkg=None, params=None, return_type=None, annotations=None): return SimpleNamespace(name=name, pkg=pkg or package_info(), params=params or [], return_type=return_type, annotations=annotations or [])
+                    def param_info(name, type, annotations=None): return SimpleNamespace(name=name, type=type, annotations=annotations or [])
+                    def type_info(kind, name, pkg=None, annotations=None, **kwargs):
+                        data = dict(kind=kind, name=name, pkg=pkg or package_info(), annotations=annotations or [])
                         data.update(kwargs)
                         return SimpleNamespace(**data)
 

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -1491,7 +1491,12 @@ public class JavaAstBuilder {
                 implementInterfaces,
                 fields,
                 recordTypeParameters,
-                ReflectionValueInfoJava.dataValueInfo(type.name(), reflectionFallbackPackagePath, buildDataValueFields(type)),
+                ReflectionValueInfoJava.dataValueInfo(
+                        type.name(),
+                        reflectionFallbackPackagePath,
+                        buildDataValueFields(type),
+                        type.annotations()
+                ),
                 new TreeSet<JavaMethod>(),
                 buildRecordMethods(type, functionsByOwnerPrefix));
     }
@@ -1501,7 +1506,8 @@ public class JavaAstBuilder {
                 .map(field -> new JavaDataValueInfo.Field(
                         field.name(),
                         field.type(),
-                        dataValueFieldExpression(type, field)))
+                        dataValueFieldExpression(type, field),
+                        field.annotations()))
                 .toList();
     }
 
@@ -1643,7 +1649,12 @@ public class JavaAstBuilder {
                 type.comments(),
                 implementInterfaces,
                 List.of("INSTANCE"),
-                List.of(ReflectionValueInfoJava.dataValueInfo(type.name(), reflectionFallbackPackagePath, List.of()))
+                List.of(ReflectionValueInfoJava.dataValueInfo(
+                        type.name(),
+                        reflectionFallbackPackagePath,
+                        List.of(),
+                        type.annotations()
+                ))
         );
     }
 
@@ -1659,7 +1670,8 @@ public class JavaAstBuilder {
                         .map(subType -> ReflectionValueInfoJava.dataValueInfo(
                                 subType.name(),
                                 ReflectionValueInfoJava.reflectionPackagePath(enumType.name(), reflectionFallbackPackagePath),
-                                List.of()))
+                                List.of(),
+                                enumType.annotations()))
                         .toList()
         );
     }

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaDataValueInfo.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaDataValueInfo.java
@@ -1,6 +1,7 @@
 package dev.capylang.generator.java;
 
 import dev.capylang.compiler.CompiledType;
+import dev.capylang.compiler.CompiledAnnotation;
 
 import java.util.List;
 
@@ -8,12 +9,25 @@ public record JavaDataValueInfo(
         String name,
         String packageName,
         String packagePath,
-        List<Field> fields
+        List<Field> fields,
+        List<CompiledAnnotation> annotations
 ) {
     public JavaDataValueInfo {
         fields = List.copyOf(fields);
+        annotations = annotations == null ? List.of() : List.copyOf(annotations);
     }
 
-    public record Field(String name, CompiledType type, String valueExpression) {
+    public JavaDataValueInfo(String name, String packageName, String packagePath, List<Field> fields) {
+        this(name, packageName, packagePath, fields, List.of());
+    }
+
+    public record Field(String name, CompiledType type, String valueExpression, List<CompiledAnnotation> annotations) {
+        public Field {
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
+        }
+
+        public Field(String name, CompiledType type, String valueExpression) {
+            this(name, type, valueExpression, List.of());
+        }
     }
 }

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -3356,14 +3356,20 @@ public class JavaExpressionEvaluator {
                     current
             ).popExpression();
             current = fieldValue.scope();
-            fields.add(new JavaDataValueInfo.Field(field.name(), field.type(), fieldValue.expression()));
+            fields.add(new JavaDataValueInfo.Field(
+                    field.name(),
+                    field.type(),
+                    fieldValue.expression(),
+                    field.annotations()
+            ));
         }
 
         var expression = ReflectionValueInfoJava.dataValueInfoExpression(new JavaDataValueInfo(
                 reflectionValue.name(),
                 reflectionValue.packageName(),
                 reflectionValue.packagePath(),
-                fields
+                fields,
+                reflectionValue.annotations()
         ));
         return current.addExpression(expression);
     }

--- a/compiler/src/main/java/dev/capylang/generator/java/ReflectionValueInfoJava.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/ReflectionValueInfoJava.java
@@ -1,6 +1,9 @@
 package dev.capylang.generator.java;
 
 import dev.capylang.compiler.CollectionLinkedType;
+import dev.capylang.compiler.CompiledAnnotation;
+import dev.capylang.compiler.CompiledAnnotationArgument;
+import dev.capylang.compiler.CompiledAnnotationValue;
 import dev.capylang.compiler.CompiledDataParentType;
 import dev.capylang.compiler.CompiledDataType;
 import dev.capylang.compiler.CompiledFunctionType;
@@ -22,13 +25,23 @@ public final class ReflectionValueInfoJava {
             String fallbackPackagePath,
             List<JavaDataValueInfo.Field> fields
     ) {
+        return dataValueInfo(typeName, fallbackPackagePath, fields, List.of());
+    }
+
+    public static JavaDataValueInfo dataValueInfo(
+            String typeName,
+            String fallbackPackagePath,
+            List<JavaDataValueInfo.Field> fields,
+            List<CompiledAnnotation> annotations
+    ) {
         var path = reflectionPackagePath(typeName, fallbackPackagePath);
         var packageName = path.isBlank() ? "" : simpleReflectionTypeName(path);
         return new JavaDataValueInfo(
                 simpleReflectionTypeName(typeName),
                 packageName,
                 path,
-                fields
+                fields,
+                annotations
         );
     }
 
@@ -39,7 +52,8 @@ public final class ReflectionValueInfoJava {
             fieldValueInfos.add("new capy.metaProg.Reflection.FieldValueInfo("
                                 + javaString(field.name()) + ", "
                                 + typeInfo + ", "
-                                + field.valueExpression() + ")");
+                                + field.valueExpression() + ", "
+                                + reflectionAnnotations(field.annotations()) + ")");
         }
 
         return "new capy.metaProg.Reflection.DataValueInfo("
@@ -48,6 +62,8 @@ public final class ReflectionValueInfoJava {
                + javaString(dataValueInfo.packageName()) + ", "
                + javaString(dataValueInfo.packagePath()) + "), "
                + reflectionList("capy.metaProg.Reflection.FieldValueInfo", fieldValueInfos)
+               + ", "
+               + reflectionAnnotations(dataValueInfo.annotations())
                + ")";
     }
 
@@ -58,7 +74,8 @@ public final class ReflectionValueInfoJava {
                     + javaString(primitive == PrimitiveLinkedType.STRING
                             ? "String"
                             : primitive.name().toLowerCase(java.util.Locale.ROOT)) + ", "
-                    + reflectionEmptyPackageInfo() + ")";
+                    + reflectionEmptyPackageInfo() + ", "
+                    + reflectionAnnotations(List.of()) + ")";
             case CollectionLinkedType.CompiledList listType ->
                     "new capy.metaProg.Reflection.ListInfo("
                     + javaString("List") + ", "
@@ -100,21 +117,75 @@ public final class ReflectionValueInfoJava {
             case CompiledGenericTypeParameter genericTypeParameter ->
                     "new capy.metaProg.Reflection.DataInfo("
                     + javaString(genericTypeParameter.name()) + ", "
-                    + reflectionEmptyPackageInfo() + ")";
+                    + reflectionEmptyPackageInfo() + ", "
+                    + reflectionAnnotations(List.of()) + ")";
             case CompiledPrimitiveBackedType primitiveBackedType ->
                     reflectionTypeInfo(primitiveBackedType.backingType(), fallbackPackagePath);
             case CompiledDataParentType parentType ->
                     "new capy.metaProg.Reflection.DataInfo("
                     + javaString(simpleReflectionTypeName(parentType.name())) + ", "
-                    + reflectionPackageInfo(parentType.name(), fallbackPackagePath) + ")";
+                    + reflectionPackageInfo(parentType.name(), fallbackPackagePath) + ", "
+                    + reflectionAnnotations(parentType.annotations()) + ")";
             case CompiledDataType dataType ->
                     "new capy.metaProg.Reflection.DataInfo("
                     + javaString(simpleReflectionTypeName(dataType.name())) + ", "
-                    + reflectionPackageInfo(dataType.name(), fallbackPackagePath) + ")";
+                    + reflectionPackageInfo(dataType.name(), fallbackPackagePath) + ", "
+                    + reflectionAnnotations(dataType.annotations()) + ")";
             case CompiledObjectType objectType ->
                     "new capy.metaProg.Reflection.DataInfo("
                     + javaString(simpleReflectionTypeName(objectType.name())) + ", "
-                    + reflectionPackageInfo(objectType.name(), fallbackPackagePath) + ")";
+                    + reflectionPackageInfo(objectType.name(), fallbackPackagePath) + ", "
+                    + reflectionAnnotations(objectType.annotations()) + ")";
+        };
+    }
+
+    public static String reflectionAnnotations(List<CompiledAnnotation> annotations) {
+        return reflectionList(
+                "capy.metaProg.Reflection.AnnotationInfo",
+                annotations.stream()
+                        .map(ReflectionValueInfoJava::reflectionAnnotation)
+                        .toList()
+        );
+    }
+
+    private static String reflectionAnnotation(CompiledAnnotation annotation) {
+        return "new capy.metaProg.Reflection.AnnotationInfo("
+               + javaString(annotation.name()) + ", "
+               + reflectionPackageInfoValues(annotation.packageName(), annotation.packagePath()) + ", "
+               + reflectionList(
+                       "capy.metaProg.Reflection.AnnotationArgumentInfo",
+                       annotation.arguments().stream()
+                               .map(ReflectionValueInfoJava::reflectionAnnotationArgument)
+                               .toList()
+               )
+               + ")";
+    }
+
+    private static String reflectionAnnotationArgument(CompiledAnnotationArgument argument) {
+        return "new capy.metaProg.Reflection.AnnotationArgumentInfo("
+               + javaString(argument.name()) + ", "
+               + reflectionAnnotationValue(argument.value())
+               + ")";
+    }
+
+    private static String reflectionAnnotationValue(CompiledAnnotationValue value) {
+        return switch (value) {
+            case CompiledAnnotationValue.StringValue stringValue ->
+                    "new capy.metaProg.Reflection.AnnotationString(" + normalizeStringLiteral(stringValue.value()) + ")";
+            case CompiledAnnotationValue.IntValue intValue ->
+                    "new capy.metaProg.Reflection.AnnotationInt(" + intValue.value() + ")";
+            case CompiledAnnotationValue.LongValue longValue ->
+                    "new capy.metaProg.Reflection.AnnotationLong(" + longValue.value() + ")";
+            case CompiledAnnotationValue.DoubleValue doubleValue ->
+                    "new capy.metaProg.Reflection.AnnotationDouble(" + doubleValue.value() + ")";
+            case CompiledAnnotationValue.FloatValue floatValue ->
+                    "new capy.metaProg.Reflection.AnnotationFloat(" + floatValue.value() + ")";
+            case CompiledAnnotationValue.BoolValue boolValue ->
+                    "new capy.metaProg.Reflection.AnnotationBool(" + boolValue.value() + ")";
+            case CompiledAnnotationValue.TypeNameValue typeNameValue ->
+                    "new capy.metaProg.Reflection.AnnotationTypeName(" + javaString(typeNameValue.name()) + ")";
+            case CompiledAnnotationValue.NothingValue ignored ->
+                    "new capy.metaProg.Reflection.AnnotationNothing()";
         };
     }
 
@@ -157,6 +228,14 @@ public final class ReflectionValueInfoJava {
         return "new capy.metaProg.Reflection.PackageInfo(" + javaString(name) + ", " + javaString(path) + ")";
     }
 
+    private static String reflectionPackageInfoValues(String packageName, String packagePath) {
+        return "new capy.metaProg.Reflection.PackageInfo("
+               + javaString(packageName == null ? "" : packageName)
+               + ", "
+               + javaString(packagePath == null ? "" : packagePath.replaceFirst("^/", ""))
+               + ")";
+    }
+
     private static String reflectionEmptyPackageInfo() {
         return "new capy.metaProg.Reflection.PackageInfo(\"\", \"\")";
     }
@@ -185,6 +264,37 @@ public final class ReflectionValueInfoJava {
 
     private static String javaString(String value) {
         return "\"" + escapeJavaString(value) + "\"";
+    }
+
+    private static String normalizeStringLiteral(String raw) {
+        if (raw.length() < 2) {
+            return javaString(raw);
+        }
+        if (raw.charAt(0) == '"' && raw.charAt(raw.length() - 1) == '"') {
+            var content = normalizeDoubleQuotedContent(raw.substring(1, raw.length() - 1));
+            return javaString(content);
+        }
+        if (raw.charAt(0) == '\'' && raw.charAt(raw.length() - 1) == '\'') {
+            return javaString(raw.substring(1, raw.length() - 1));
+        }
+        return javaString(raw);
+    }
+
+    private static String normalizeDoubleQuotedContent(String content) {
+        var normalized = new StringBuilder(content.length());
+        for (var i = 0; i < content.length(); i++) {
+            var ch = content.charAt(i);
+            if (ch == '\\' && i + 1 < content.length()) {
+                var next = content.charAt(i + 1);
+                if (next == '"' || next == '\\') {
+                    normalized.append(next);
+                    i++;
+                    continue;
+                }
+            }
+            normalized.append(ch);
+        }
+        return normalized.toString();
     }
 
     private record ReflectionFunctionShape(

--- a/compiler/src/main/java/dev/capylang/generator/java/ValueNameRewriter.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/ValueNameRewriter.java
@@ -332,6 +332,7 @@ public class ValueNameRewriter {
                 linkedReflectionValue.packageName(),
                 linkedReflectionValue.packagePath(),
                 linkedReflectionValue.fields(),
+                linkedReflectionValue.annotations(),
                 linkedReflectionValue.type()
         );
     }

--- a/compiler/src/test/java/dev/capylang/compiler/AnnotationCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/AnnotationCompilerTest.java
@@ -1,0 +1,356 @@
+package dev.capylang.compiler;
+
+import dev.capylang.compiler.parser.ObjectOriented;
+import dev.capylang.compiler.parser.RawModule;
+import dev.capylang.compiler.parser.SourceKind;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class AnnotationCompilerTest {
+    @Test
+    void shouldCompileSameModuleAndImportedAnnotationUsages() {
+        var compiled = compileSuccess(List.of(
+                new RawModule("Annotations", "/capy/test", """
+                        annotation Test on fun {
+                            name: String
+                            retries: int = 0
+                        }
+                        """),
+                new RawModule("Tests", "/foo/app", """
+                        from /capy/test/Annotations import { Test }
+
+                        annotation Local on fun {}
+
+                        @Test(name: "adds values")
+                        @Local()
+                        fun should_add(): bool = true
+                        """)
+        ));
+
+        var annotationsModule = compiled.modules().stream()
+                .filter(module -> module.name().equals("Annotations"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(annotationsModule.annotations()).containsKey("Test");
+    }
+
+    @Test
+    void shouldPersistCompiledAnnotationMetadataOnFunctionsAndTypes() {
+        var modules = List.of(
+                new RawModule("Annotations", "/capy/test", """
+                        annotation Label on fun, data, union, type {
+                            label: String
+                            order: int = 7
+                        }
+
+                        annotation First on data { value: String = "first" }
+                        annotation Second on data { value: String = "second" }
+                        """),
+                new RawModule("Tests", "/foo/app", """
+                        from /capy/test/Annotations import { Label, First, Second }
+
+                        @First()
+                        @Second()
+                        data User { name: String }
+
+                        @Label(order: 2, label: "pet")
+                        union Pet = User
+
+                        @Label(label: "id")
+                        type user_id -> int
+
+                        @Label(order: 3, label: "run")
+                        fun run(id: user_id): User = User { name: "ok" }
+                        """)
+        );
+
+        var compiled = compileSuccess(modules);
+        var repeated = compileSuccess(modules);
+        var module = module(compiled, "Tests");
+
+        var functionAnnotation = function(compiled, "Tests", "run").annotations().getFirst();
+        assertThat(functionAnnotation.name()).isEqualTo("Label");
+        assertThat(functionAnnotation.packageName()).isEqualTo("Annotations");
+        assertThat(functionAnnotation.packagePath()).isEqualTo("/capy/test");
+        assertThat(functionAnnotation.arguments()).extracting(CompiledAnnotationArgument::name)
+                .containsExactly("label", "order");
+        assertThat(functionAnnotation.arguments().getFirst().value())
+                .isInstanceOfSatisfying(CompiledAnnotationValue.StringValue.class,
+                        value -> assertThat(value.value()).isEqualTo("\"run\""));
+        assertThat(functionAnnotation.arguments().get(1).value())
+                .isInstanceOfSatisfying(CompiledAnnotationValue.IntValue.class,
+                        value -> assertThat(value.value()).isEqualTo("3"));
+
+        assertThat(module.types().get("User")).isInstanceOfSatisfying(CompiledDataType.class, user -> {
+            assertThat(user.annotations()).extracting(CompiledAnnotation::name)
+                    .containsExactly("First", "Second");
+            assertThat(user.annotations()).isEqualTo(((CompiledDataType) module(repeated, "Tests").types().get("User")).annotations());
+        });
+        assertThat(module.types().get("Pet")).isInstanceOfSatisfying(CompiledDataParentType.class, pet ->
+                assertThat(pet.annotations()).singleElement().satisfies(annotation ->
+                        assertThat(annotation.arguments()).extracting(CompiledAnnotationArgument::name)
+                                .containsExactly("label", "order")));
+        assertThat(module.types().get("user_id")).isInstanceOfSatisfying(CompiledPrimitiveBackedType.class, userId -> {
+            assertThat(userId.annotations()).singleElement().satisfies(annotation -> {
+                assertThat(annotation.arguments()).extracting(CompiledAnnotationArgument::name)
+                        .containsExactly("label", "order");
+                assertThat(annotation.arguments().get(1).value())
+                        .isInstanceOfSatisfying(CompiledAnnotationValue.IntValue.class,
+                                value -> assertThat(value.value()).isEqualTo("7"));
+            });
+        });
+    }
+
+    @Test
+    void shouldAllowDefaultedAnnotationArgumentsToBeOmitted() {
+        compileSuccess(new RawModule("Tests", "/foo/app", """
+                annotation Test on fun {
+                    name: String = "default"
+                    retries: int = 0
+                }
+
+                @Test
+                fun should_run(): bool = true
+                """));
+    }
+
+    @Test
+    void shouldRejectMissingRequiredAnnotationArgument() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation Test on fun {
+                    name: String
+                }
+
+                @Test()
+                fun should_run(): bool = true
+                """));
+
+        assertThat(error.message()).contains("Missing required annotation argument name for Test");
+    }
+
+    @Test
+    void shouldRejectUnknownAnnotation() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                @Missing()
+                fun should_run(): bool = true
+                """));
+
+        assertThat(error.message()).contains("Unknown annotation Missing");
+    }
+
+    @Test
+    void shouldRejectUnimportedAnnotationFromAnotherModule() {
+        var error = compileFailure(List.of(
+                new RawModule("Annotations", "/capy/test", "annotation Test on fun {}"),
+                new RawModule("Tests", "/foo/app", """
+                        @Test()
+                        fun should_run(): bool = true
+                        """)
+        ));
+
+        assertThat(error.message()).contains("Unknown annotation Test");
+    }
+
+    @Test
+    void shouldRejectInvalidAnnotationTarget() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation Entity on class {}
+
+                @Entity
+                fun should_run(): bool = true
+                """));
+
+        assertThat(error.message()).contains("Annotation Entity is not valid on function declarations");
+    }
+
+    @Test
+    void shouldRejectAnnotationUsageOnAnnotationDeclaration() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation Marker on fun {}
+
+                @Marker()
+                annotation Meta on fun {}
+                """));
+
+        assertThat(error.message()).contains("Annotation Marker is not valid on annotation declarations");
+    }
+
+    @Test
+    void shouldRejectUnknownAnnotationArgument() {
+        var messages = compileFailureMessages(new RawModule("Tests", "/foo/app", """
+                annotation Test on fun {
+                    name: String
+                }
+
+                @Test(label: "wrong")
+                fun should_run(): bool = true
+                """));
+
+        assertThat(messages).anySatisfy(message ->
+                assertThat(message).contains("Unknown annotation argument label for Test"));
+    }
+
+    @Test
+    void shouldRejectDuplicateAnnotationArgument() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation Test on fun {
+                    name: String
+                }
+
+                @Test(name: "one", name: "two")
+                fun should_run(): bool = true
+                """));
+
+        assertThat(error.message()).contains("Duplicate annotation argument name for Test");
+    }
+
+    @Test
+    void shouldRejectWrongAnnotationValueType() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation Retry on fun {
+                    retries: int
+                }
+
+                @Retry(retries: "three")
+                fun should_run(): bool = true
+                """));
+
+        assertThat(error.message()).contains("Annotation argument retries for Retry expects int, got String");
+    }
+
+    @Test
+    void shouldValidateFunctionalMethodTargetSeparatelyFromFunctionTarget() {
+        compileSuccess(new RawModule("Tests", "/foo/app", """
+                annotation MethodOnly on method {}
+
+                data Box {}
+
+                @MethodOnly()
+                fun Box.read(): int = 1
+                """));
+
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation MethodOnly on method {}
+
+                @MethodOnly()
+                fun read(): int = 1
+                """));
+
+        assertThat(error.message()).contains("Annotation MethodOnly is not valid on function declarations");
+    }
+
+    @Test
+    void shouldValidateObjectOrientedClassFieldAndMethodTargets() {
+        var compiled = compileSuccess(List.of(
+                new RawModule("Annotations", "/capy/test", """
+                        annotation Entity on class {}
+                        annotation JsonName on field { value: String }
+                        annotation Endpoint on method {}
+                        """),
+                new RawModule("User", "/foo/app", """
+                        from /capy/test/Annotations import { Entity, JsonName, Endpoint }
+
+                        @Entity
+                        class User(name: String) {
+                            @JsonName(value: "name")
+                            field name: String = name
+
+                            init {}
+
+                            @Endpoint
+                            def label(): String = this.name
+                        }
+                        """, SourceKind.OBJECT_ORIENTED)
+        ));
+        var user = (ObjectOriented.ClassDeclaration) compiled.objectOrientedModules().getFirst()
+                .objectOriented()
+                .definitions()
+                .getFirst();
+        assertThat(user.linkedAnnotations()).extracting(CompiledAnnotation::name)
+                .containsExactly("Entity");
+        assertThat(user.members().getFirst()).isInstanceOfSatisfying(ObjectOriented.FieldDeclaration.class, field ->
+                assertThat(field.linkedAnnotations()).extracting(CompiledAnnotation::name)
+                        .containsExactly("JsonName"));
+        assertThat(user.members().stream()
+                .filter(ObjectOriented.MethodDeclaration.class::isInstance)
+                .map(ObjectOriented.MethodDeclaration.class::cast)
+                .filter(method -> method.name().equals("label"))
+                .findFirst()
+                .orElseThrow()).satisfies(method ->
+                assertThat(method.linkedAnnotations()).extracting(CompiledAnnotation::name)
+                        .containsExactly("Endpoint"));
+
+        var error = compileFailure(List.of(
+                new RawModule("Annotations", "/capy/test", "annotation Entity on class {}"),
+                new RawModule("User", "/foo/app", """
+                        from /capy/test/Annotations import { Entity }
+
+                        class User {
+                            @Entity
+                            field name: String = "name"
+                        }
+                        """, SourceKind.OBJECT_ORIENTED)
+        ));
+
+        assertThat(error.message()).contains("Annotation Entity is not valid on field declarations");
+    }
+
+    private static CompiledProgram compileSuccess(RawModule module) {
+        return compileSuccess(List.of(module));
+    }
+
+    private static CompiledProgram compileSuccess(List<RawModule> modules) {
+        var result = CapybaraCompiler.INSTANCE.compile(modules, new TreeSet<>());
+        if (result instanceof Result.Error<CompiledProgram> error) {
+            fail(error.errors().toString());
+        }
+        return ((Result.Success<CompiledProgram>) result).value();
+    }
+
+    private static Result.Error.SingleError compileFailure(RawModule module) {
+        return compileFailure(List.of(module));
+    }
+
+    private static List<String> compileFailureMessages(RawModule module) {
+        return compileFailureMessages(List.of(module));
+    }
+
+    private static List<String> compileFailureMessages(List<RawModule> modules) {
+        var result = CapybaraCompiler.INSTANCE.compile(modules, new TreeSet<>());
+        if (result instanceof Result.Success<CompiledProgram> success) {
+            fail("Expected compilation to fail but got " + success.value());
+        }
+        return ((Result.Error<CompiledProgram>) result).errors().stream()
+                .map(Result.Error.SingleError::message)
+                .toList();
+    }
+
+    private static Result.Error.SingleError compileFailure(List<RawModule> modules) {
+        var result = CapybaraCompiler.INSTANCE.compile(modules, new TreeSet<>());
+        if (result instanceof Result.Success<CompiledProgram> success) {
+            fail("Expected compilation to fail but got " + success.value());
+        }
+        var errors = ((Result.Error<CompiledProgram>) result).errors();
+        assertThat(errors).isNotEmpty();
+        return errors.first();
+    }
+
+    private static CompiledModule module(CompiledProgram compiled, String name) {
+        return compiled.modules().stream()
+                .filter(module -> module.name().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static CompiledFunction function(CompiledProgram compiled, String moduleName, String name) {
+        return module(compiled, moduleName).functions().stream()
+                .filter(function -> function.name().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/CapybaraCompilerLibrariesTest.java
@@ -368,7 +368,8 @@ class CapybaraCompilerLibrariesTest {
                     DataValueInfo {
                         name: "local",
                         pkg: PackageInfo { name: "", path: "" },
-                        fields: []
+                        fields: [],
+                        annotations: []
                     }
 
                 data User { name: String }
@@ -1277,18 +1278,41 @@ class CapybaraCompilerLibrariesTest {
                     | InterfaceInfo
                     | ObjectInfo
                     | TraitInfo
+                    | MethodInfo
                     | ListInfo
                     | SetInfo
                     | DictInfo
                     | TupleInfo
                     | FunctionTypeInfo
 
-                data DataInfo { name: String, pkg: PackageInfo }
+                union AnnotationValue =
+                    AnnotationString
+                    | AnnotationInt
+                    | AnnotationLong
+                    | AnnotationDouble
+                    | AnnotationFloat
+                    | AnnotationBool
+                    | AnnotationTypeName
+                    | AnnotationNothing
 
-                data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo] }
-                data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo] }
-                data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo] }
-                data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo }
+                data AnnotationString { value: String }
+                data AnnotationInt { value: int }
+                data AnnotationLong { value: long }
+                data AnnotationDouble { value: double }
+                data AnnotationFloat { value: float }
+                data AnnotationBool { value: bool }
+                data AnnotationTypeName { value: String }
+                data AnnotationNothing {}
+
+                data AnnotationArgumentInfo { name: String, value: AnnotationValue }
+                data AnnotationInfo { name: String, pkg: PackageInfo, arguments: List[AnnotationArgumentInfo] }
+
+                data DataInfo { name: String, pkg: PackageInfo, annotations: List[AnnotationInfo] }
+
+                data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+                data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+                data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+                data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo, annotations: List[AnnotationInfo] }
 
                 data ListInfo { element_type: AnyInfo }
                 data SetInfo { element_type: AnyInfo }
@@ -1298,9 +1322,9 @@ class CapybaraCompilerLibrariesTest {
                 data FunctionTypeInfo { params: List[AnyInfo], return_type: AnyInfo }
 
                 data PackageInfo { name: String, path: String }
-                data FieldInfo { name: String, type: AnyInfo }
-                data FieldValueInfo { name: String, type: AnyInfo, value: any }
-                data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo] }
+                data FieldInfo { name: String, type: AnyInfo, annotations: List[AnnotationInfo] }
+                data FieldValueInfo { name: String, type: AnyInfo, value: any, annotations: List[AnnotationInfo] }
+                data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo], annotations: List[AnnotationInfo] }
 
                 fun reflection(obj: data): DataValueInfo = <native>
                 """);

--- a/compiler/src/test/java/dev/capylang/compiler/RecursionCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/RecursionCompilerTest.java
@@ -57,9 +57,64 @@ class RecursionCompilerTest {
                 });
     }
 
+    @Test
+    void shouldUseStdlibRecursiveAnnotationAsTailRecursionContract() {
+        var program = compileProgram(List.of(
+                recursiveAnnotationModule(),
+                new RawModule("Recursion", "/foo/bar", """
+                        from /capy/meta_prog/Recursive import { Recursive }
+
+                        @Recursive
+                        fun sum(n: int, acc: int): int =
+                            if n <= 0 then acc else sum(n - 1, acc + n)
+                        """)
+        ));
+
+        assertThat(function(program, "sum"))
+                .satisfies(function -> {
+                    assertThat(function.recursive()).isTrue();
+                    assertThat(function.tailRecursive()).isTrue();
+                    assertThat(function.annotations()).singleElement().satisfies(annotation -> {
+                        assertThat(annotation.name()).isEqualTo("Recursive");
+                        assertThat(annotation.packageName()).isEqualTo("Recursive");
+                        assertThat(annotation.packagePath()).isEqualTo("/capy/meta_prog");
+                    });
+                });
+    }
+
+    @Test
+    void shouldNotTreatUserAnnotationNamedRecursiveAsTailRecursionContract() {
+        var program = compileProgram("""
+                annotation Recursive on fun {}
+
+                @Recursive
+                fun non_tail_sum(n: int): int =
+                    if n <= 0 then 0 else n + non_tail_sum(n - 1)
+                """);
+
+        assertThat(function(program, "non_tail_sum"))
+                .satisfies(function -> {
+                    assertThat(function.recursive()).isTrue();
+                    assertThat(function.tailRecursive()).isFalse();
+                    assertThat(function.annotations()).singleElement().satisfies(annotation -> {
+                        assertThat(annotation.name()).isEqualTo("Recursive");
+                        assertThat(annotation.packageName()).isEqualTo("Recursion");
+                        assertThat(annotation.packagePath()).isEqualTo("/foo/bar");
+                    });
+                });
+    }
+
     private static CompiledProgram compileProgram(String source) {
+        return compileProgram(List.of(new RawModule("Recursion", "/foo/bar", source)));
+    }
+
+    private static RawModule recursiveAnnotationModule() {
+        return new RawModule("Recursive", "/capy/meta_prog", "annotation Recursive on fun {}");
+    }
+
+    private static CompiledProgram compileProgram(List<RawModule> modules) {
         var result = CapybaraCompiler.INSTANCE.compile(
-                List.of(new RawModule("Recursion", "/foo/bar", source)),
+                modules,
                 new TreeSet<>()
         );
         if (result instanceof Result.Error<CompiledProgram> error) {
@@ -69,7 +124,8 @@ class RecursionCompilerTest {
     }
 
     private static CompiledFunction function(CompiledProgram program, String name) {
-        return program.modules().first().functions().stream()
+        return program.modules().stream()
+                .flatMap(module -> module.functions().stream())
                 .filter(function -> function.name().equals(name))
                 .findFirst()
                 .orElseThrow();

--- a/compiler/src/test/java/dev/capylang/generator/JavaScriptGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/JavaScriptGeneratorTest.java
@@ -257,6 +257,129 @@ class JavaScriptGeneratorTest {
     }
 
     @Test
+    void shouldExposeFunctionalAnnotationReflectionMetadataInCommonJs() throws Exception {
+        var program = compileProgram("""
+                from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+
+                annotation TypeMarker on data {
+                    label: String
+                    order: int = 1
+                }
+
+                annotation FieldMarker on field {
+                    value: String
+                }
+
+                @TypeMarker(label: "entity", order: 7)
+                data User {
+                    @FieldMarker(value: "identifier")
+                    id: String
+                }
+
+                fun reflected(user: User): DataValueInfo = reflection(user)
+                """);
+
+        var generated = new JavaScriptGenerator().generate(program);
+        writeGenerated(generated);
+
+        var main = generated.modules().stream()
+                .filter(module -> module.relativePath().equals(Path.of("foo", "Main.js")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(main.code())
+                .contains("const capy = require(")
+                .contains("module.exports =")
+                .doesNotContain("import ")
+                .doesNotContain("export ");
+
+        var output = runNode("""
+                const m = require('./foo/Main.js');
+                const info = m.reflected(new m.User({ id: 'U-1' }));
+                console.log([
+                    typeof require,
+                    typeof module.exports,
+                    info.annotations[0].name,
+                    info.annotations[0].arguments[0].value.kind,
+                    info.annotations[0].arguments[1].value.value,
+                    info.fields[0].annotations[0].name,
+                    info.fields[0].annotations[0].arguments[0].value.value,
+                    info.fields[0].type.name
+                ].join('|'));
+                """);
+
+        assertThat(output).isEqualTo("function|object|TypeMarker|string|7|FieldMarker|identifier|String");
+    }
+
+    @Test
+    void shouldExposeObjectOrientedAnnotationReflectionMetadataInCommonJs() throws Exception {
+        var program = compileProgram(List.of(
+                new RawModule(
+                        "Markers",
+                        "/foo",
+                        """
+                                annotation TypeMarker on class {
+                                    label: String
+                                }
+
+                                annotation FieldMarker on field {
+                                    value: String
+                                }
+
+                                annotation MethodMarker on method {
+                                    value: String
+                                }
+                                """,
+                        SourceKind.FUNCTIONAL
+                ),
+                new RawModule(
+                        "Thing",
+                        "/foo",
+                        """
+                                from /foo/Markers import { TypeMarker, FieldMarker, MethodMarker }
+
+                                @TypeMarker(label: "entity")
+                                class Thing(name: String) {
+                                    @FieldMarker(value: "display_name")
+                                    field name: String = name
+
+                                    @MethodMarker(value: "greet")
+                                    def greet(): String = this.name
+                                }
+                                """,
+                        SourceKind.OBJECT_ORIENTED
+                )
+        ));
+
+        var generated = new JavaScriptGenerator().generate(program);
+        writeGenerated(generated);
+
+        var thing = generated.modules().stream()
+                .filter(module -> module.relativePath().equals(Path.of("foo", "Thing.js")))
+                .findFirst()
+                .orElseThrow();
+        assertThat(thing.code())
+                .contains("const capy = require(")
+                .contains("module.exports =")
+                .doesNotContain("import ")
+                .doesNotContain("export ");
+
+        var output = runNode("""
+                const { Thing } = require('./foo/Thing.js');
+                const info = Thing.type();
+                console.log([
+                    info.annotations[0].name,
+                    info.annotations[0].arguments[0].value.value,
+                    info.fields[0].annotations[0].name,
+                    info.fields[0].annotations[0].arguments[0].value.value,
+                    info.methods[0].annotations[0].name,
+                    info.methods[0].annotations[0].arguments[0].value.value
+                ].join('|'));
+                """);
+
+        assertThat(output).isEqualTo("TypeMarker|entity|FieldMarker|display_name|MethodMarker|greet");
+    }
+
+    @Test
     void shouldWrapIntArithmeticLikeJava() throws Exception {
         var program = compileProgram("""
                 const MAX_INT: int = 2147483647

--- a/compiler/src/test/java/dev/capylang/generator/ObjectOrientedJavaGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/ObjectOrientedJavaGeneratorTest.java
@@ -830,17 +830,28 @@ class ObjectOrientedJavaGeneratorTest {
                 package capy.metaProg;
 
                 public final class Reflection {
-                    public sealed interface AnyInfo permits DataInfo, InterfaceInfo, ObjectInfo, TraitInfo, ListInfo, SetInfo, DictInfo, TupleInfo, FunctionTypeInfo {}
+                    public sealed interface AnyInfo permits DataInfo, InterfaceInfo, ObjectInfo, TraitInfo, MethodInfo, ListInfo, SetInfo, DictInfo, TupleInfo, FunctionTypeInfo {}
+                    public sealed interface AnnotationValue permits AnnotationString, AnnotationInt, AnnotationLong, AnnotationDouble, AnnotationFloat, AnnotationBool, AnnotationTypeName, AnnotationNothing {}
 
                     public record PackageInfo(String name, String path) {}
-                    public record FieldInfo(String name, AnyInfo type) {}
-                    public record FieldValueInfo(String name, AnyInfo type, Object value) {}
-                    public record DataValueInfo(String name, PackageInfo pkg, java.util.List<FieldValueInfo> fields) {}
-                    public record DataInfo(String name, PackageInfo pkg) implements AnyInfo {}
-                    public record MethodInfo(String name, PackageInfo pkg, java.util.List<FieldInfo> params, AnyInfo return_type) {}
-                    public record InterfaceInfo(String name, PackageInfo pkg, java.util.List<MethodInfo> methods, java.util.Set<AnyInfo> parents) implements AnyInfo {}
-                    public record ObjectInfo(String name, PackageInfo pkg, boolean open, java.util.List<FieldInfo> fields, java.util.List<MethodInfo> methods, java.util.Set<AnyInfo> parents) implements AnyInfo {}
-                    public record TraitInfo(String name, PackageInfo pkg, java.util.List<MethodInfo> methods, java.util.Set<AnyInfo> parents) implements AnyInfo {}
+                    public record AnnotationString(String value) implements AnnotationValue {}
+                    public record AnnotationInt(int value) implements AnnotationValue {}
+                    public record AnnotationLong(long value) implements AnnotationValue {}
+                    public record AnnotationDouble(double value) implements AnnotationValue {}
+                    public record AnnotationFloat(float value) implements AnnotationValue {}
+                    public record AnnotationBool(boolean value) implements AnnotationValue {}
+                    public record AnnotationTypeName(String value) implements AnnotationValue {}
+                    public record AnnotationNothing() implements AnnotationValue {}
+                    public record AnnotationArgumentInfo(String name, AnnotationValue value) {}
+                    public record AnnotationInfo(String name, PackageInfo pkg, java.util.List<AnnotationArgumentInfo> arguments) {}
+                    public record FieldInfo(String name, AnyInfo type, java.util.List<AnnotationInfo> annotations) {}
+                    public record FieldValueInfo(String name, AnyInfo type, Object value, java.util.List<AnnotationInfo> annotations) {}
+                    public record DataValueInfo(String name, PackageInfo pkg, java.util.List<FieldValueInfo> fields, java.util.List<AnnotationInfo> annotations) {}
+                    public record DataInfo(String name, PackageInfo pkg, java.util.List<AnnotationInfo> annotations) implements AnyInfo {}
+                    public record MethodInfo(String name, PackageInfo pkg, java.util.List<FieldInfo> params, AnyInfo return_type, java.util.List<AnnotationInfo> annotations) implements AnyInfo {}
+                    public record InterfaceInfo(String name, PackageInfo pkg, java.util.List<MethodInfo> methods, java.util.Set<AnyInfo> parents, java.util.List<AnnotationInfo> annotations) implements AnyInfo {}
+                    public record ObjectInfo(String name, PackageInfo pkg, boolean open, java.util.List<FieldInfo> fields, java.util.List<MethodInfo> methods, java.util.Set<AnyInfo> parents, java.util.List<AnnotationInfo> annotations) implements AnyInfo {}
+                    public record TraitInfo(String name, PackageInfo pkg, java.util.List<MethodInfo> methods, java.util.Set<AnyInfo> parents, java.util.List<AnnotationInfo> annotations) implements AnyInfo {}
                     public record ListInfo(String name, PackageInfo pkg, AnyInfo element_type) implements AnyInfo {}
                     public record SetInfo(String name, PackageInfo pkg, AnyInfo element_type) implements AnyInfo {}
                     public record DictInfo(String name, PackageInfo pkg, AnyInfo value_type) implements AnyInfo {}

--- a/compiler/src/test/java/dev/capylang/generator/PythonGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/PythonGeneratorTest.java
@@ -185,6 +185,108 @@ class PythonGeneratorTest {
     }
 
     @Test
+    void shouldExposeFunctionalAnnotationReflectionMetadataInPython() throws Exception {
+        var program = compileProgram("""
+                from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+
+                annotation TypeMarker on data {
+                    label: String
+                    order: int = 1
+                }
+
+                annotation FieldMarker on field {
+                    value: String
+                }
+
+                @TypeMarker(label: "entity", order: 7)
+                data User {
+                    @FieldMarker(value: "identifier")
+                    id: String
+                }
+
+                fun reflected(user: User): DataValueInfo = reflection(user)
+                """);
+
+        var generated = new PythonGenerator().generate(program);
+        writeGenerated(generated);
+
+        var output = runPython("""
+                import foo.Main as m
+                info = m.reflected(m.User({'id': 'U-1'}))
+                print('|'.join([
+                    info.annotations[0].name,
+                    info.annotations[0].arguments[0].value.kind,
+                    str(info.annotations[0].arguments[1].value.value),
+                    info.fields[0].annotations[0].name,
+                    info.fields[0].annotations[0].arguments[0].value.value,
+                    info.fields[0].type.name,
+                    info.pkg.path
+                ]))
+                """);
+
+        assertThat(output).isEqualTo("TypeMarker|string|7|FieldMarker|identifier|String|foo/Main");
+    }
+
+    @Test
+    void shouldExposeObjectOrientedAnnotationReflectionMetadataInPython() throws Exception {
+        var program = compileProgram(List.of(
+                new RawModule(
+                        "Markers",
+                        "/foo",
+                        """
+                                annotation TypeMarker on class {
+                                    label: String
+                                }
+
+                                annotation FieldMarker on field {
+                                    value: String
+                                }
+
+                                annotation MethodMarker on method {
+                                    value: String
+                                }
+                                """,
+                        SourceKind.FUNCTIONAL
+                ),
+                new RawModule(
+                        "Thing",
+                        "/foo",
+                        """
+                                from /foo/Markers import { TypeMarker, FieldMarker, MethodMarker }
+
+                                @TypeMarker(label: "entity")
+                                class Thing(name: String) {
+                                    @FieldMarker(value: "display_name")
+                                    field name: String = name
+
+                                    @MethodMarker(value: "greet")
+                                    def greet(): String = this.name
+                                }
+                                """,
+                        SourceKind.OBJECT_ORIENTED
+                )
+        ));
+
+        var generated = new PythonGenerator().generate(program);
+        writeGenerated(generated);
+
+        var output = runPython("""
+                from foo.Thing import Thing
+                info = Thing.type()
+                print('|'.join([
+                    info.annotations[0].name,
+                    info.annotations[0].arguments[0].value.value,
+                    info.fields[0].annotations[0].name,
+                    info.fields[0].annotations[0].arguments[0].value.value,
+                    info.methods[0].annotations[0].name,
+                    info.methods[0].annotations[0].arguments[0].value.value
+                ]))
+                """);
+
+        assertThat(output).isEqualTo("TypeMarker|entity|FieldMarker|display_name|MethodMarker|greet");
+    }
+
+    @Test
     void shouldWrapIntArithmeticLikeJava() throws Exception {
         var program = compileProgram("""
                 const MAX_INT: int = 2147483647

--- a/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -783,12 +783,18 @@ class JavaExpressionEvaluatorTest {
 
     @Test
     void shouldRewriteQualifiedTailRecursiveCallWhenStaticMethodsUseModuleSuffix() {
-        var generatedProgram = new JavaGenerator().generate(compileProgram("Counter", "/foo/bar", """
+        var generatedProgram = new JavaGenerator().generate(compileProgram(List.of(
+                new RawModule("Recursive", "/capy/meta_prog", "annotation Recursive on fun {}"),
+                new RawModule("Counter", "/foo/bar", """
+                from /capy/meta_prog/Recursive import { Recursive }
+
                 data Counter { value: int }
 
-                fun rec sum(n: int, acc: int): int =
+                @Recursive
+                fun sum(n: int, acc: int): int =
                     if n <= 0 then acc else Counter.sum(n - 1, acc + n)
-                """));
+                """)
+        )));
 
         var generated = generatedProgram.modules().stream()
                 .filter(module -> module.relativePath().equals(Path.of("foo", "bar", "CounterModule.java")))
@@ -1488,18 +1494,41 @@ class JavaExpressionEvaluatorTest {
                     | InterfaceInfo
                     | ObjectInfo
                     | TraitInfo
+                    | MethodInfo
                     | ListInfo
                     | SetInfo
                     | DictInfo
                     | TupleInfo
                     | FunctionTypeInfo
 
-                data DataInfo { name: String, pkg: PackageInfo }
+                union AnnotationValue =
+                    AnnotationString
+                    | AnnotationInt
+                    | AnnotationLong
+                    | AnnotationDouble
+                    | AnnotationFloat
+                    | AnnotationBool
+                    | AnnotationTypeName
+                    | AnnotationNothing
 
-                data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo] }
-                data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo] }
-                data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo] }
-                data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo }
+                data AnnotationString { value: String }
+                data AnnotationInt { value: int }
+                data AnnotationLong { value: long }
+                data AnnotationDouble { value: double }
+                data AnnotationFloat { value: float }
+                data AnnotationBool { value: bool }
+                data AnnotationTypeName { value: String }
+                data AnnotationNothing {}
+
+                data AnnotationArgumentInfo { name: String, value: AnnotationValue }
+                data AnnotationInfo { name: String, pkg: PackageInfo, arguments: List[AnnotationArgumentInfo] }
+
+                data DataInfo { name: String, pkg: PackageInfo, annotations: List[AnnotationInfo] }
+
+                data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+                data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+                data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+                data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo, annotations: List[AnnotationInfo] }
 
                 data ListInfo { element_type: AnyInfo }
                 data SetInfo { element_type: AnyInfo }
@@ -1509,9 +1538,9 @@ class JavaExpressionEvaluatorTest {
                 data FunctionTypeInfo { params: List[AnyInfo], return_type: AnyInfo }
 
                 data PackageInfo { name: String, path: String }
-                data FieldInfo { name: String, type: AnyInfo }
-                data FieldValueInfo { name: String, type: AnyInfo, value: any }
-                data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo] }
+                data FieldInfo { name: String, type: AnyInfo, annotations: List[AnnotationInfo] }
+                data FieldValueInfo { name: String, type: AnyInfo, value: any, annotations: List[AnnotationInfo] }
+                data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo], annotations: List[AnnotationInfo] }
 
                 fun reflection(obj: data): DataValueInfo = <native>
                 """);

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -47,6 +47,7 @@ class CapybaraParserTest {
                     case EnumDeclaration enumDeclaration -> enumDeclaration.name().equals(name);
                     case PrimitiveBackedTypeDeclaration primitiveBackedTypeDeclaration ->
                             primitiveBackedTypeDeclaration.name().equals(name);
+                    case AnnotationDeclaration annotationDeclaration -> annotationDeclaration.name().equals(name);
                     default -> false;
                 })
                 .findAny()
@@ -63,6 +64,83 @@ class CapybaraParserTest {
 
         assertThat(module.imports())
                 .containsExactly(new dev.capylang.compiler.ImportDeclaration("/foo/A", List.of(), List.of(), true));
+    }
+
+    @Test
+    @DisplayName("should parse annotation declarations and declaration annotations")
+    void parseAnnotationDeclarationsAndDeclarationAnnotations() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                @Meta
+                annotation Deprecated on fun, method, data, class {
+                    message: String
+                    since: String = ""
+                    replacement: Result[User] = User
+                    order: int = 1
+                    enabled: bool = true
+                    ratio: double = 1.0
+                    scale: float = 1.0f
+                    count: long = 1L
+                    unknown: String = ???
+                }
+
+                @Benchmark
+                fun ping(): int = 1
+
+                /// Parser entrypoint
+                @Deprecated(message: "use parse_v2", since: "1.4")
+                fun parse(raw: String): String = raw
+
+                @Internal()
+                data User { name: String }
+
+                data Box[T] { value: T }
+
+                @A
+                fun Box[T].map(value: T): T = value
+                """));
+
+        var annotation = findDefinition(AnnotationDeclaration.class, "Deprecated", module.functional());
+        assertThat(annotation.annotations()).extracting(AnnotationUsage::name).containsExactly("Meta");
+        assertThat(annotation.targets()).extracting(AnnotationTarget::name)
+                .containsExactly("fun", "method", "data", "class");
+        assertThat(annotation.fields()).extracting(AnnotationFieldDeclaration::name)
+                .containsExactly("message", "since", "replacement", "order", "enabled", "ratio", "scale", "count", "unknown");
+        assertThat(annotation.fields().getFirst().defaultValue()).isEmpty();
+        assertThat(annotation.fields().get(1).defaultValue())
+                .hasValueSatisfying(value -> assertThat(((AnnotationValue.StringValue) value).value()).isEqualTo("\"\""));
+        assertThat(annotation.fields().get(2).defaultValue())
+                .hasValueSatisfying(value -> assertThat(((AnnotationValue.TypeNameValue) value).name()).isEqualTo("User"));
+
+        var markerFunction = findFunction("ping", module.functional());
+        assertThat(markerFunction.annotations()).extracting(AnnotationUsage::name).containsExactly("Benchmark");
+
+        var parse = findFunction("parse", module.functional());
+        assertThat(parse.comments()).containsExactly("Parser entrypoint");
+        assertThat(parse.annotations()).singleElement().satisfies(usage -> {
+            assertThat(usage.name()).isEqualTo("Deprecated");
+            assertThat(usage.arguments()).extracting(AnnotationArgument::name).containsExactly("message", "since");
+            assertThat(usage.arguments().get(0).value())
+                    .isInstanceOfSatisfying(AnnotationValue.StringValue.class, value -> assertThat(value.value()).isEqualTo("\"use parse_v2\""));
+            assertThat(usage.arguments().get(1).value())
+                    .isInstanceOfSatisfying(AnnotationValue.StringValue.class, value -> assertThat(value.value()).isEqualTo("\"1.4\""));
+        });
+
+        var data = findDefinition(DataDeclaration.class, "User", module.functional());
+        assertThat(data.annotations()).extracting(AnnotationUsage::name).containsExactly("Internal");
+
+        var method = findFunction("__method__Box__map", module.functional());
+        assertThat(method.annotations()).extracting(AnnotationUsage::name).containsExactly("A");
+    }
+
+    @Test
+    @DisplayName("should reject comma-separated declaration annotations")
+    void rejectCommaSeparatedDeclarationAnnotations() {
+        var result = new CapybaraParser().parseModule(new RawModule("Test", "/parser", """
+                @A, @B
+                fun broken(): int = 1
+                """));
+
+        assertThat(result).isInstanceOf(Result.Error.class);
     }
 
     private static dev.capylang.compiler.parser.Module parseSuccess(RawModule module) {
@@ -690,6 +768,11 @@ class CapybaraParserTest {
                     case List
                     [String] _ -> 1
                     case _ -> 0
+
+                @LineStartAnnotation()
+                fun annotated_identity(xs: List
+                [String]): List
+                [String] = xs
                 """));
 
         findDefinition(DataDeclaration.class, "Box", module.functional());
@@ -697,6 +780,9 @@ class CapybaraParserTest {
                 .hasValue(new CollectionType.ListType(PrimitiveType.STRING));
         findFunction("box_identity", module.functional());
         findFunction("match_list", module.functional());
+        var annotated = findFunction("annotated_identity", module.functional());
+        assertThat(annotated.returnType()).hasValue(new CollectionType.ListType(PrimitiveType.STRING));
+        assertThat(annotated.annotations()).extracting(AnnotationUsage::name).containsExactly("LineStartAnnotation");
     }
 
     @Test
@@ -764,9 +850,9 @@ class CapybaraParserTest {
         var parser = new CapybaraParser();
         Method method = CapybaraParser.class.getDeclaredMethod("formatParserError", RawModule.class, String.class, String.class);
         method.setAccessible(true);
-                var module = new RawModule("SemVer", "/capy/util", """
+        var module = new RawModule("SemVer", "/capy/util", """
                 fun parse(): int =
-                    fun rec parse_positive_digit(value: int): int = parse_positive_digit(value)
+                    fun parse_positive_digit(value: int): int = parse_positive_digit(value)
                     fun parse_positive_digit(value: int): int = value + 1
                     ---
                     0
@@ -801,30 +887,48 @@ class CapybaraParserTest {
     }
 
     @Test
-    @DisplayName("should parse tail recursive function marker")
+    @DisplayName("should parse recursive annotation usage")
     void parseTailRecursiveFunctionMarker() {
         var module = parseSuccess(new RawModule("Test", "/parser", """
-                fun rec sum(n: int, acc: int): int =
+                @Recursive
+                fun sum(n: int, acc: int): int =
                     if n <= 0 then acc else sum(n - 1, acc + n)
                 """));
 
         var function = findFunction("sum", module.functional());
-        assertThat(function.tailRecursive()).isTrue();
+        assertThat(function.annotations()).extracting(AnnotationUsage::name).containsExactly("Recursive");
+        assertThat(function.tailRecursive()).isFalse();
     }
 
     @Test
-    @DisplayName("should parse tail recursive local function marker")
+    @DisplayName("should parse parenthesized recursive annotation usage")
+    void parseParenthesizedTailRecursiveFunctionMarker() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                @Recursive()
+                fun sum(n: int, acc: int): int =
+                    if n <= 0 then acc else sum(n - 1, acc + n)
+                """));
+
+        var function = findFunction("sum", module.functional());
+        assertThat(function.annotations()).extracting(AnnotationUsage::name).containsExactly("Recursive");
+        assertThat(function.tailRecursive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should parse recursive local function annotation usage")
     void parseTailRecursiveLocalFunctionMarker() {
         var module = parseSuccess(new RawModule("Test", "/parser", """
                 fun sum(n: int): int =
-                    fun rec __sum(n: int, acc: int): int =
+                    @Recursive
+                    fun __sum(n: int, acc: int): int =
                         if n <= 0 then acc else __sum(n - 1, acc + n)
                     ---
                     __sum(n, 0)
                 """));
 
         var localFunction = findFunction("__sum__scope_1_0__local_fun_0_sum", module.functional());
-        assertThat(localFunction.tailRecursive()).isTrue();
+        assertThat(localFunction.annotations()).extracting(AnnotationUsage::name).containsExactly("Recursive");
+        assertThat(localFunction.tailRecursive()).isFalse();
     }
 
     @Test

--- a/compiler/src/test/java/dev/capylang/parser/ObjectOrientedParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/ObjectOrientedParserTest.java
@@ -1,6 +1,7 @@
 package dev.capylang.parser;
 
 import dev.capylang.compiler.Result;
+import dev.capylang.compiler.parser.AnnotationValue;
 import dev.capylang.compiler.parser.ObjectOriented;
 import dev.capylang.compiler.parser.ObjectOrientedModule;
 import dev.capylang.compiler.parser.ObjectOrientedParser;
@@ -12,6 +13,101 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ObjectOrientedParserTest {
+    @Test
+    @DisplayName("should parse declaration annotations")
+    void parseDeclarationAnnotations() {
+        var result = ObjectOrientedParser.INSTANCE.parseModule(new RawModule(
+                "User",
+                "/parser",
+                """
+                        /// User model
+                        @Entity(table: "users")
+                        open class User(name: String) {
+                            @JsonName(value: "user_name")
+                            field name: String = name
+
+                            @Lifecycle
+                            init {}
+
+                            @Deprecated(since: "1.4")
+                            def print(): String = this.name
+                        }
+
+                        @Contract
+                        interface Printable {
+                            @Deprecated(message: "use display")
+                            def print(): String
+                        }
+
+                        @Mixin
+                        trait Named {
+                            @Internal()
+                            field label: String = "unknown"
+                        }
+                        """,
+                SourceKind.OBJECT_ORIENTED
+        ));
+
+        assertThat(result).isInstanceOf(Result.Success.class);
+        var module = ((Result.Success<ObjectOrientedModule>) result).value();
+        assertThat(module.objectOriented().definitions())
+                .extracting(ObjectOriented.TypeDeclaration::name)
+                .containsExactly("User", "Printable", "Named");
+
+        var user = (ObjectOriented.ClassDeclaration) module.objectOriented().definitions().getFirst();
+        assertThat(user.comments()).containsExactly("User model");
+        assertThat(user.annotations()).singleElement().satisfies(annotation -> {
+            assertThat(annotation.name()).isEqualTo("Entity");
+            assertThat(annotation.arguments()).singleElement().satisfies(argument -> {
+                assertThat(argument.name()).isEqualTo("table");
+                assertThat(argument.value()).isInstanceOfSatisfying(
+                        AnnotationValue.StringValue.class,
+                        value -> assertThat(value.value()).isEqualTo("\"users\"")
+                );
+            });
+        });
+
+        var field = (ObjectOriented.FieldDeclaration) user.members().getFirst();
+        assertThat(field.annotations()).singleElement().satisfies(annotation -> {
+            assertThat(annotation.name()).isEqualTo("JsonName");
+            assertThat(annotation.arguments()).singleElement().satisfies(argument -> {
+                assertThat(argument.name()).isEqualTo("value");
+                assertThat(argument.value()).isInstanceOfSatisfying(
+                        AnnotationValue.StringValue.class,
+                        value -> assertThat(value.value()).isEqualTo("\"user_name\"")
+                );
+            });
+        });
+
+        var method = (ObjectOriented.MethodDeclaration) user.members().get(2);
+        assertThat(method.annotations()).singleElement().satisfies(annotation -> {
+            assertThat(annotation.name()).isEqualTo("Deprecated");
+            assertThat(annotation.arguments()).singleElement().satisfies(argument -> {
+                assertThat(argument.name()).isEqualTo("since");
+                assertThat(argument.value()).isInstanceOfSatisfying(
+                        AnnotationValue.StringValue.class,
+                        value -> assertThat(value.value()).isEqualTo("\"1.4\"")
+                );
+            });
+        });
+    }
+
+    @Test
+    @DisplayName("should reject comma-separated declaration annotations")
+    void rejectCommaSeparatedDeclarationAnnotations() {
+        var result = ObjectOrientedParser.INSTANCE.parseModule(new RawModule(
+                "Broken",
+                "/parser",
+                """
+                        @A, @B
+                        class Broken {}
+                        """,
+                SourceKind.OBJECT_ORIENTED
+        ));
+
+        assertThat(result).isInstanceOf(Result.Error.class);
+    }
+
     @Test
     @DisplayName("should parse class trait and interface declarations from .coo source")
     void parseObjectOrientedModule() {

--- a/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
@@ -1,6 +1,7 @@
 from /capy/lang/Option import { * }
 from /capy/lang/Seq import { * }
 from /capy/collection/CollectionTypes import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// Native ordered collection type backed by the runtime List implementation.
 /// List literals use square brackets: [1, 2, 3].
@@ -38,7 +39,8 @@ fun List[T].minus(other: List[T]): List[T] = this - other
 
 /// Returns true when at least one value satisfies `predicate`.
 fun List[T].any(predicate: T => bool): bool =
-    fun rec any_match(list: List[T], idx: int, predicate: T => bool): bool =
+    @Recursive
+    fun any_match(list: List[T], idx: int, predicate: T => bool): bool =
         match list[idx] with
         case None -> false
         case Some { value } ->
@@ -52,7 +54,8 @@ fun List[T].any(predicate: T => bool): bool =
 ///
 /// Empty lists return true.
 fun List[T].all(predicate: T => bool): bool =
-    fun rec all(list: List[T], idx: int, predicate: T => bool, acc: bool): bool =
+    @Recursive
+    fun all(list: List[T], idx: int, predicate: T => bool, acc: bool): bool =
         match list[idx] with
         case None -> acc
         case Some { value } ->
@@ -71,7 +74,8 @@ fun List[T].`?`(value: T): bool = this.contains(value)
 
 /// Combines all values from left to right.
 fun List[T].reduce(initial: R, reducer: (R, T) => R): R =
-    fun rec reduce(list: List[T], idx: int, acc: R, reducer: (R, T) => R): R =
+    @Recursive
+    fun reduce(list: List[T], idx: int, acc: R, reducer: (R, T) => R): R =
         match list[idx] with
         case None -> acc
         case Some { value } -> reduce(list, idx + 1, reducer(acc, value), reducer)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -1,6 +1,7 @@
 from /capy/lang/Result import {*}
 from /capy/lang/Math import { * }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// Calendar month number in the range 1..12.
 type month -> int with constructor {
@@ -129,7 +130,8 @@ fun Date.add_years_months(years: int, months: int): Date =
 
 /// Formats this date as an ISO 8601 calendar date.
 fun Date.to_iso_8601(): String =
-    fun rec pad_left(value: String, size: int): String =
+    @Recursive
+    fun pad_left(value: String, size: int): String =
         if value.size() >= size
         then value
         else pad_left("0" + value, size)
@@ -157,7 +159,8 @@ fun from_iso_8601(iso: String): Result[Date] =
             match ("" + char).to_int() with
             case Success { digit } -> Success { Parse { buffer: value[1, value.size()], value: digit } }
             case Error -> Error { invalid("expected digit, got `" + char + "`") }
-    fun rec parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
+    @Recursive
+    fun parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
         if value.is_empty()
         then Success { Parse { buffer: value, value: parsed } }
         else
@@ -172,14 +175,16 @@ fun from_iso_8601(iso: String): Result[Date] =
         if parse.buffer.is_empty()
         then Success { parse.value }
         else Error { invalid("expected digits for " + label + ", got `" + value + "`") }
-    fun rec drop_prefix(value: String, size: int): String =
+    @Recursive
+    fun drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
             case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
-    fun rec take_prefix(value: String, size: int, acc: String): String =
+    @Recursive
+    fun take_prefix(value: String, size: int, acc: String): String =
         if size <= 0
         then acc
         else

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -6,6 +6,7 @@ from /capy/lang/Result import { * }
 from /capy/lang/Primitives import { * }
 from /capy/lang/Option import { * }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// Combination of a UTC calendar date and time of day.
 data DateTime { date: Date, time: Time }
@@ -134,7 +135,8 @@ fun from_iso_8601(iso: String): Result[DateTime] =
     data Split { left: String, right: String }
     data SplitScan { left: String, right: String, seen_separator: bool }
     fun invalid(message: String): String = "Invalid ISO 8601 date-time format: " + message
-    fun rec scan_split(value: String, scan: SplitScan): Result[Split] =
+    @Recursive
+    fun scan_split(value: String, scan: SplitScan): Result[Split] =
         if value.is_empty()
         then if !scan.seen_separator
             then Error { invalid("expected `T` separator between date and time") }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -1,6 +1,7 @@
 from /capy/lang/Result import { * }
 from /capy/lang/Option import { * }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// [ISO 8601 - Durations](https://en.wikipedia.org/wiki/ISO_860101)
 ///
@@ -133,7 +134,8 @@ fun from_iso_8601(iso: String): Result[Duration] =
         case None -> Error { invalid("unexpected end of string while parsing digits") }
         case Some { '0' } -> Success { Parse { buffer: tail(value), value: 0 } }
         case Some -> parse_positive_digit(value)
-    fun rec parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
+    @Recursive
+    fun parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
         match value[0] with
         case Some { char } ->
             if match char with
@@ -303,7 +305,8 @@ fun from_iso_8601(iso: String): Result[Duration] =
             has_component: true,
             has_time_component: parse.has_time_component | parse.in_time
         }}
-    fun rec parse_designator_duration(parse: DurationParse): Result[Duration] =
+    @Recursive
+    fun parse_designator_duration(parse: DurationParse): Result[Duration] =
         match parse.buffer[0] with
         case None ->
             if !parse.has_component

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -3,6 +3,7 @@ from /capy/date_time/Duration import { * }
 from /capy/lang/Regex import { * }
 from /capy/lang/Result import { * }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// ISO 8601 interval represented using UTC date-time endpoints.
 union Interval =
@@ -52,14 +53,16 @@ fun from_iso_8601(iso: String): Result[Interval] =
     data Split { left: String, right: String }
     data SplitScan { left: String, right: String, seen_separator: bool }
     fun invalid(message: String): String = "Invalid ISO 8601 interval format: " + message
-    fun rec drop_prefix(value: String, size: int): String =
+    @Recursive
+    fun drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
             case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
-    fun rec scan_split(separator: String, value: String, scan: SplitScan): Result[Split] =
+    @Recursive
+    fun scan_split(separator: String, value: String, scan: SplitScan): Result[Split] =
         if value.is_empty()
         then if !scan.seen_separator
             then Error { invalid("expected exactly one `" + separator + "` separator") }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
@@ -1,6 +1,7 @@
 from /capy/lang/Result import {*}
 from /capy/lang/Option import { * }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 const HOURS_IN_DAY: int = 24
 const MINUTES_IN_HOUR: int = 60
@@ -99,7 +100,8 @@ fun Time.add_hours(hours: int): Time = this.add_seconds(hours * SECONDS_IN_HOUR)
 
 /// Formats this time as an ISO 8601 extended time.
 fun Time.to_iso_8601(): String =
-    fun rec pad_left(value: String, size: int): String =
+    @Recursive
+    fun pad_left(value: String, size: int): String =
         if value.size() >= size
         then value
         else pad_left("0" + value, size)
@@ -129,14 +131,16 @@ fun from_iso_8601(iso: String): Result[Time] =
     data Parse[T] { buffer: String, value: T }
     data ZoneParse { buffer: String, offset_minutes: Option[offset_minutes] }
     fun invalid(message: String): String = "Invalid ISO 8601 time format: " + message
-    fun rec drop_prefix(value: String, size: int): String =
+    @Recursive
+    fun drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
             match value[0] with
             case None -> ""
             case Some { _ } -> drop_prefix(value[1, value.size()], size - 1)
-    fun rec take_prefix(value: String, size: int, acc: String): String =
+    @Recursive
+    fun take_prefix(value: String, size: int, acc: String): String =
         if size <= 0
         then acc
         else
@@ -151,7 +155,8 @@ fun from_iso_8601(iso: String): Result[Time] =
             match ("" + char).to_int() with
             case Success { digit } -> Success { Parse { buffer: value[1, value.size()], value: digit } }
             case Error -> Error { invalid("expected digit, got `" + char + "`") }
-    fun rec parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
+    @Recursive
+    fun parse_rest_digits(value: String, parsed: int): Result[Parse[int]] =
         if value.is_empty()
         then Success { Parse { buffer: value, value: parsed } }
         else

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -4,6 +4,7 @@ from /capy/collection/CollectionTypes import { * }
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 enum PathRoot { RELATIVE, ABSOLUTE, HOME }
 
@@ -14,7 +15,8 @@ data Path {
 }
 
 fun from_string(path_string: String): Path =
-    fun rec segments(value: String, current: String, acc: List[String]): List[String] =
+    @Recursive
+    fun segments(value: String, current: String, acc: List[String]): List[String] =
         match value[0] with
         case None ->
             if current == ""
@@ -90,7 +92,8 @@ fun Path.is_absolute(): bool =
 fun Path.is_root(): bool = this.segments.size() == EMPTY
 
 fun Path.normalize(): Path =
-    fun rec normalize_path(root: PathRoot, segments: List[String], acc: List[String]): List[String] =
+    @Recursive
+    fun normalize_path(root: PathRoot, segments: List[String], acc: List[String]): List[String] =
         match segments[0] with
         case None -> acc
         case Some { seg } ->

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -1,7 +1,9 @@
 from /capy/lang/Option import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 fun digits(number: int): int =
-    fun rec digits(number: int, acc: int): int =
+    @Recursive
+    fun digits(number: int, acc: int): int =
         if number < 10
         then acc
         else digits(number / 10, acc + 1)
@@ -60,7 +62,8 @@ fun min(a: int, b: int): int = if a < b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun min(values: List[int]): Option[int] =
-    fun rec min(min: int, values: List[int]): int =
+    @Recursive
+    fun min(min: int, values: List[int]): int =
         match values[0] with
         case None -> min
         case Some { v } -> if min < v then min(min, values[1:]) else min(v, values[1:])
@@ -76,7 +79,8 @@ fun max(a: int, b: int): int = if a > b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun max(values: List[int]): Option[int] =
-    fun rec max(max: int, values: List[int]): int =
+    @Recursive
+    fun max(max: int, values: List[int]): int =
         match values[0] with
         case None -> max
         case Some { v } -> if max < v then max(v, values[1:]) else max(max, values[1:])
@@ -92,7 +96,8 @@ fun min(a: long, b: long): long = if a < b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun min(values: List[long]): Option[long] =
-    fun rec min(min: long, values: List[long]): long =
+    @Recursive
+    fun min(min: long, values: List[long]): long =
         match values[0] with
         case None -> min
         case Some { v } -> if min < v then min(min, values[1:]) else min(v, values[1:])
@@ -108,7 +113,8 @@ fun max(a: long, b: long): long = if a > b then a else b
 ///
 /// Returns `None` when the List is empty.
 fun max(values: List[long]): Option[long] =
-    fun rec max(max: long, values: List[long]): long =
+    @Recursive
+    fun max(max: long, values: List[long]): long =
         match values[0] with
         case None -> max
         case Some { v } -> if max < v then max(v, values[1:]) else max(max, values[1:])

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
@@ -5,6 +5,7 @@ from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 from /capy/lang/Seq import { * }
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 data Regex { pattern: String, flags: String }
 data Match { group_value: String }
@@ -12,7 +13,8 @@ data Match { group_value: String }
 fun from_literal(pattern: String, flags: String): Regex = Regex { pattern, flags }
 
 private fun drop_prefix(value: String, size: int): String =
-    fun rec drop_prefix(value: String, size: int): String =
+    @Recursive
+    fun drop_prefix(value: String, size: int): String =
         if size <= 0
         then value
         else
@@ -23,7 +25,8 @@ private fun drop_prefix(value: String, size: int): String =
     drop_prefix(value, size)
 
 private fun find_all(pattern: String, input: String, acc: List[Match]): List[Match] =
-    fun rec find_all(pattern: String, input: String, acc: List[Match]): List[Match] =
+    @Recursive
+    fun find_all(pattern: String, input: String, acc: List[Match]): List[Match] =
         if pattern == ""
         then acc
         else
@@ -37,7 +40,8 @@ private fun find_all(pattern: String, input: String, acc: List[Match]): List[Mat
     find_all(pattern, input, acc)
 
 private fun split(pattern: String, input: String, current: String, acc: List[String]): List[String] =
-    fun rec split(pattern: String, input: String, current: String, acc: List[String]): List[String] =
+    @Recursive
+    fun split(pattern: String, input: String, current: String, acc: List[String]): List[String] =
         if pattern == ""
         then [input]
         else

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Seq.cfun
@@ -2,6 +2,7 @@ from /capy/collection/CollectionTypes import { * }
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 union Seq[T] = Cons[T] | End
 data Cons[T] { value: T, rest: () => Seq[T] }
@@ -46,7 +47,8 @@ fun powers_of_2_seq() = powers_seq(2)
 ///
 /// This method is safe to use with infinite sequences.
 fun Seq[T].take(n: size): List[T] =
-    fun rec take(seq: Seq[T], n: int, list: List[T]): List[T] =
+    @Recursive
+    fun take(seq: Seq[T], n: int, list: List[T]): List[T] =
         if n <=0
         then list
         else
@@ -60,7 +62,8 @@ fun Seq[T].take(n: size): List[T] =
 ///
 /// Important: calling this on an infinite sequence does not terminate.
 fun Seq[T].as_list(): List[T] =
-    fun rec as_list(seq: Seq[T], list: List[T]): List[T] =
+    @Recursive
+    fun as_list(seq: Seq[T], list: List[T]): List[T] =
         match seq with
         case End -> list
         case Cons { value, rest } -> as_list(rest(), list + value)
@@ -130,7 +133,8 @@ fun Seq[T].reject(pred: T => bool): Seq[T] =
 
 /// Skips the first `n` elements of the sequence.
 fun Seq[T].drop(n: size): Seq[T] =
-    fun rec drop(seq: Seq[T], n: int) =
+    @Recursive
+    fun drop(seq: Seq[T], n: int) =
         if n <= 0
         then seq
         else
@@ -148,7 +152,8 @@ fun Seq[T].drop(n: size): Seq[T] =
 ///
 /// The first element that satisfies `pred` is included in the result.
 fun Seq[T].drop_until(pred: T => bool): Seq[T] =
-    fun rec drop_until(seq: Seq[T], pred: T => bool) =
+    @Recursive
+    fun drop_until(seq: Seq[T], pred: T => bool) =
         match seq with
         case End -> End {}
         case Cons { value, rest } ->
@@ -219,7 +224,8 @@ fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
     flat_map(this, map)
 
 fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
-    fun rec reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
+    @Recursive
+    fun reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
         match seq with
         case End -> acc
         case Cons { value, rest } -> reduce(rest(), reducer(acc, value), reducer)

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -5,6 +5,7 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 from /capy/lang/Seq import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// Native String type backed by the runtime String implementation.
 /// String literals use quotes: "hello".
@@ -57,7 +58,8 @@ fun String.plus(value: any): String = this + value
 
 /// Returns true when at least one character satisfies `predicate`.
 fun String.any(predicate: String => bool): bool =
-    fun rec any_match(value: String, idx: int, predicate: String => bool): bool =
+    @Recursive
+    fun any_match(value: String, idx: int, predicate: String => bool): bool =
         match value[idx] with
         case None -> false
         case Some { char } ->
@@ -69,7 +71,8 @@ fun String.any(predicate: String => bool): bool =
 
 /// Returns true when at least one character and index pair satisfies `predicate`.
 fun String.any(predicate: (String, int) => bool): bool =
-    fun rec any_match(value: String, idx: int, predicate: (String, int) => bool): bool =
+    @Recursive
+    fun any_match(value: String, idx: int, predicate: (String, int) => bool): bool =
         match value[idx] with
         case None -> false
         case Some { char } ->
@@ -83,7 +86,8 @@ fun String.any(predicate: (String, int) => bool): bool =
 ///
 /// Empty strings return true.
 fun String.all(predicate: String => bool): bool =
-    fun rec all(value: String, idx: int, predicate: String => bool): bool =
+    @Recursive
+    fun all(value: String, idx: int, predicate: String => bool): bool =
         match value[idx] with
         case None -> true
         case Some { char } ->
@@ -97,7 +101,8 @@ fun String.all(predicate: String => bool): bool =
 ///
 /// Empty strings return true.
 fun String.all(predicate: (String, int) => bool): bool =
-    fun rec all(value: String, idx: int, predicate: (String, int) => bool): bool =
+    @Recursive
+    fun all(value: String, idx: int, predicate: (String, int) => bool): bool =
         match value[idx] with
         case None -> true
         case Some { char } ->
@@ -121,7 +126,8 @@ fun String.`?`(part: String): bool = this.contains(part)
 
 /// Combines all characters from left to right.
 fun String.reduce(initial: R, reducer: (R, String) => R): R =
-    fun rec reduce(value: String, idx: int, acc: R, reducer: (R, String) => R): R =
+    @Recursive
+    fun reduce(value: String, idx: int, acc: R, reducer: (R, String) => R): R =
         match value[idx] with
         case None -> acc
         case Some { char } -> reduce(value, idx + 1, reducer(acc, char), reducer)
@@ -192,13 +198,15 @@ fun String.end_with(part: String): bool =
 fun String.trim(): String =
     fun is_trim_whitespace(char: String): bool =
         char == " " | char == '\t' | char == '\n' | char == '\r' | char == '\f'
-    fun rec trim_left(value: String): String =
+    @Recursive
+    fun trim_left(value: String): String =
         if value.size() == EMPTY
         then ""
         else if is_trim_whitespace(value[0, 1])
             then trim_left(value[1, value.size()])
             else value
-    fun rec trim_right(value: String): String =
+    @Recursive
+    fun trim_right(value: String): String =
         if value.size() == EMPTY
         then ""
         else if is_trim_whitespace(value[value.size().value - 1, value.size()])

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Annotations.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Annotations.cfun
@@ -1,0 +1,5 @@
+/// Marks a declaration as deprecated while preserving it for compatibility.
+annotation Deprecated on fun, method, const, data, union, enum, type, deriver, class, interface, trait, field, init {
+    message: String
+    since: String = ""
+}

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Recursive.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Recursive.cfun
@@ -1,0 +1,2 @@
+/// Marks a function as a compiler-verified direct tail-recursion contract.
+annotation Recursive on fun {}

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Reflection.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Reflection.cfun
@@ -14,14 +14,41 @@ union CooInfo =
 // COMMON
 data PackageInfo { name: String, path: String }
 
+union AnnotationValue =
+    AnnotationString
+    | AnnotationInt
+    | AnnotationLong
+    | AnnotationDouble
+    | AnnotationFloat
+    | AnnotationBool
+    | AnnotationTypeName
+    | AnnotationNothing
+
+data AnnotationString { value: String }
+data AnnotationInt { value: int }
+data AnnotationLong { value: long }
+data AnnotationDouble { value: double }
+data AnnotationFloat { value: float }
+data AnnotationBool { value: bool }
+data AnnotationTypeName { value: String }
+data AnnotationNothing {}
+
+data AnnotationArgumentInfo { name: String, value: AnnotationValue }
+
+data AnnotationInfo {
+    name: String,
+    pkg: PackageInfo,
+    arguments: List[AnnotationArgumentInfo]
+}
+
 // CFUN
 data FunctionTypeInfo { params: List[AnyInfo], return_type: AnyInfo }
 
-data DataInfo { name: String, pkg: PackageInfo }
+data DataInfo { name: String, pkg: PackageInfo, annotations: List[AnnotationInfo] }
 
-data FieldInfo { name: String, type: AnyInfo }
-data FieldValueInfo { name: String, type: AnyInfo, value: any }
-data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo] }
+data FieldInfo { name: String, type: AnyInfo, annotations: List[AnnotationInfo] }
+data FieldValueInfo { name: String, type: AnyInfo, value: any, annotations: List[AnnotationInfo] }
+data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo], annotations: List[AnnotationInfo] }
 
 // CFUN > COLLECTIONS
 data ListInfo { element_type: AnyInfo }
@@ -30,10 +57,10 @@ data DictInfo { value_type: AnyInfo }
 data TupleInfo { elements: List[AnyInfo] }
 
 // COO
-data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo] }
-data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo] }
-data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo] }
-data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo }
+data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo, annotations: List[AnnotationInfo] }
 
 /// Returns reflection metadata and field values for a concrete data value.
 fun reflection(obj: data): DataValueInfo = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -7,6 +7,7 @@ from /capy/lang/Result import { * }
 from /capy/lang/Seq import { * }
 from /capy/lang/String import { * }
 from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
+from /capy/meta_prog/Recursive import { Recursive }
 
 union Json = JsonObject | JsonArray | JsonValue
 data JsonObject { value: Dict[Json] }
@@ -178,7 +179,8 @@ fun deserialize(json: String): Result[JsonObject] =
 private data Parse[T] { value: T, parsing_string: String }
 private fun Parse[T].pop(): Tuple[Option[String], Parse[T]] = (this.parsing_string[0], Parse { this.value, this.parsing_string[1, this.parsing_string.size()] })
 
-private fun rec deserialize_json(json: String): Result[Parse[Json]] =
+@Recursive
+private fun deserialize_json(json: String): Result[Parse[Json]] =
     match json[0] with
     case None -> Error { "Expected JSON, but got end of string" }
     case Some { first_char } when is_white_space(first_char) -> deserialize_json(drop_white_space(json[1, json.size()]))
@@ -193,7 +195,8 @@ private fun rec deserialize_json(json: String): Result[Parse[Json]] =
         case _ -> Error { "Do not know what to do with char `" + first_char + "`!" }
 
 private fun deserialize_json_array(json: String): Result[Parse[JsonArray]] =
-    fun rec deserialize_json_array(parse: Parse[JsonArray]): Result[Parse[JsonArray]] =
+    @Recursive
+    fun deserialize_json_array(parse: Parse[JsonArray]): Result[Parse[JsonArray]] =
         match parse.parsing_string[0] with
         case None -> Error { "Expected `,` or `]`, but got end of string!" }
         case Some { ']' } -> Success { parse.pop()[1] }
@@ -254,7 +257,8 @@ private fun deserialize_json_bool(json: String): Result[Parse[JsonBool]] =
     }
 
 private fun deserialize_json_number(json: String): Result[Parse[JsonNumber]] =
-    fun rec parse_number(parse: Parse[String]): Result[Parse[String]] =
+    @Recursive
+    fun parse_number(parse: Parse[String]): Result[Parse[String]] =
         match parse.parsing_string[0] with
         case None -> Error { 'Expected `-[0-9]`, but got empty string!' }
         case Some { first_char } ->
@@ -308,7 +312,8 @@ private fun deserialize_json_object(json: String): Result[Parse[JsonObject]] =
     case Some { v } -> Error { message: "Expected `{`, but got `" + v + "`."}
 
 private fun deserialize_key_values(json: String): Result[Parse[Dict[Json]]] =
-    fun rec deserialize_key_values(json: String, acc: Dict[Json]): Result[Parse[Dict[Json]]] =
+    @Recursive
+    fun deserialize_key_values(json: String, acc: Dict[Json]): Result[Parse[Dict[Json]]] =
         match json[0] with
         case None -> Error { "Expected `,` or `}`, but got empty string!" }
         case Some { "}" } -> Success { Parse { acc, json[1, json.size()] } }
@@ -363,7 +368,8 @@ private fun parse_string(json: String): Result[Parse[String]] =
     /// - `\r` - carriage return
     /// - `\t` - horizontal tab
     /// - `\\uXXXX` - 4 HEX digits
-    fun rec parse_string_until_quotation(parse: Parse[String], escape: bool): Result[Parse[String]] =
+    @Recursive
+    fun parse_string_until_quotation(parse: Parse[String], escape: bool): Result[Parse[String]] =
         if escape
         then
             match parse.parsing_string[0] with
@@ -393,14 +399,16 @@ private fun parse_string(json: String): Result[Parse[String]] =
     case Some { v } -> Error { message: "parse_string: Expected `\"`, but got `" + v + "`." }
     case None -> Error { message: "parse_string: Expected JSON string, got end of string." }
 
-private fun rec drop_white_space(s: String): String =
+@Recursive
+private fun drop_white_space(s: String): String =
     match s[0] with
     case Some { c } when is_white_space(c) -> drop_white_space(s[1, s.size()])
     case _ -> s
 
 private fun is_white_space(s: String): bool =
     const white_spaces = { " ", "\r", "\n", "\t" }
-    fun rec is_white_space(s: String, white_spaces: Set[String]): bool =
+    @Recursive
+    fun is_white_space(s: String, white_spaces: Set[String]): bool =
         match s[0] with
         case None -> true
         case Some { c } ->

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -16,6 +16,7 @@ from /capy/lang/Math import { floor_div, HALF_EVEN, round }
 from /capy/lang/System import { nano_time }
 from /capy/lang/TimeUnit import { * }
 from /capy/serialization/Json import { JsonString, stringify }
+from /capy/meta_prog/Recursive import { Recursive }
 
 data TestFile { file_name: String, test_cases: List[TestCase], timestamp_millis: long }
 data TestCase { name: String, result: TestResult, assertions_count: int, execution_time: double, assert_supplier: () => Assert }
@@ -364,7 +365,8 @@ private fun team_city_messages_case(test_case: TestCase): List[String] =
     ]
 
 fun team_city_escape(value: String): String =
-    fun rec team_city_escape(value: String, acc: String): String =
+    @Recursive
+    fun team_city_escape(value: String, acc: String): String =
         match value[0] with
         case None -> acc
         case Some { '\'' } -> team_city_escape(value[1, value.size()], acc + "|'")
@@ -412,7 +414,8 @@ private fun stale_output_files(output_dir: Path, manifest_file: Path, expected_f
     )
 
 private fun stale_files(files: List[Path], expected_files: List[Path]): List[Path] =
-    fun rec stale_files(files: List[Path], expected_files: List[Path], acc: List[Path]): List[Path] =
+    @Recursive
+    fun stale_files(files: List[Path], expected_files: List[Path], acc: List[Path]): List[Path] =
         match files[0] with
         case None -> acc
         case Some { file } ->
@@ -466,7 +469,8 @@ private fun manifest_content(paths: List[Path]): String =
     paths |> '', (acc, path) => acc + path_to_manifest_line(path.normalize()) + '\n'
 
 private fun manifest_paths(content: String): List[Path] =
-    fun rec lines(value: String, current: String, acc: List[String]): List[String] =
+    @Recursive
+    fun lines(value: String, current: String, acc: List[String]): List[String] =
         match value[0] with
         case None ->
             if current.is_empty()
@@ -518,7 +522,8 @@ private fun list_regular_files_from_entries(entries: List[Path]): Effect[Result[
 private fun relative_to(base: Path, path: Path): Path =
     from_string(path_segments_to_string(drop_prefix_segments(base.normalize().segments, path.normalize().segments)))
 
-private fun rec drop_prefix_segments(prefix: List[String], segments: List[String]): List[String] =
+@Recursive
+private fun drop_prefix_segments(prefix: List[String], segments: List[String]): List[String] =
     match prefix[0] with
     case None -> segments
     case Some { expected } ->
@@ -536,7 +541,8 @@ private fun path_to_manifest_line(path: Path): String =
     path_segments_to_string(path.normalize().segments)
 
 private fun path_segments_to_string(segments: List[String]): String =
-    fun rec path_segments_to_string(segments: List[String], acc: String): String =
+    @Recursive
+    fun path_segments_to_string(segments: List[String], acc: String): String =
         match segments[0] with
         case None -> acc
         case Some { segment } ->

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -1,6 +1,7 @@
 from /capy/lang/Option import { Option, Some, None }
 from /capy/lang/Result import {*}
 from /capy/lang/String import { * }
+from /capy/meta_prog/Recursive import { Recursive }
 
 /// Semantic version major component, greater than or equal to zero.
 type major -> int with constructor {
@@ -187,7 +188,8 @@ fun parse_semver(version: String): Result[SemVer] =
         fun parse_dot_separated_pre_release_identifiers(version: String): Result[Parse[String]] =
             let parse <- parse_pre_release_identifier(version)
             parse_dot_separated_pre_release_identifiers_rest(parse.buffer, parse.value)
-        fun rec parse_dot_separated_pre_release_identifiers_rest(version: String, parsed: String): Result[Parse[String]] =
+        @Recursive
+        fun parse_dot_separated_pre_release_identifiers_rest(version: String, parsed: String): Result[Parse[String]] =
             match version[0] with
             case None -> Success { Parse { buffer: version, value: parsed } }
             case Some { char } when char == '.' -> {
@@ -219,7 +221,8 @@ fun parse_semver(version: String): Result[SemVer] =
         fun parse_dot_separated_build_identifiers(version: String): Result[Parse[String]] =
             let parse_identifier <- parse_dot_separated_build_identifier(version)
             parse_dot_separated_build_identifiers_rest(parse_identifier.buffer, parse_identifier.value)
-        fun rec parse_dot_separated_build_identifiers_rest(version: String, parsed: String): Result[Parse[String]] =
+        @Recursive
+        fun parse_dot_separated_build_identifiers_rest(version: String, parsed: String): Result[Parse[String]] =
             match version[0] with
             case None -> Success { Parse { buffer: version, value: parsed } }
             case Some { char } when char == '.' -> {
@@ -271,7 +274,8 @@ fun parse_semver(version: String): Result[SemVer] =
         fun parse_identifier_characters(version: String): Result[Parse[String]] =
             let pic <- parse_identifier_character(version)
             parse_identifier_characters_rest(pic.buffer, pic.value)
-        fun rec parse_identifier_characters_rest(version: String, parsed: String): Result[Parse[String]] =
+        @Recursive
+        fun parse_identifier_characters_rest(version: String, parsed: String): Result[Parse[String]] =
             match parse_identifier_character(version) with
             case Success { parse } -> parse_identifier_characters_rest(parse.buffer, parsed + parse.value)
             case Error -> Success { Parse { buffer: version, value: parsed } }
@@ -301,7 +305,8 @@ fun parse_semver(version: String): Result[SemVer] =
         fun parse_digits(version: String): Result[Parse[int]] =
             let parse <- parse_digit(version)
             parse_digits_rest(parse.buffer, parse.value)
-        fun rec parse_digits_rest(version: String, parsed: int): Result[Parse[int]] =
+        @Recursive
+        fun parse_digits_rest(version: String, parsed: int): Result[Parse[int]] =
             match parse_digit(version) with
             case Success { parse } -> parse_digits_rest(parse.buffer, parsed * 10 + parse.value)
             case Error -> Success { Parse { buffer: version, value: parsed } }
@@ -309,7 +314,8 @@ fun parse_semver(version: String): Result[SemVer] =
         fun parse_digits_as_string(version: String): Result[Parse[String]] =
             let parse <- parse_digit_as_string(version)
             parse_digits_as_string_rest(parse.buffer, parse.value)
-        fun rec parse_digits_as_string_rest(version: String, parsed: String): Result[Parse[String]] =
+        @Recursive
+        fun parse_digits_as_string_rest(version: String, parsed: String): Result[Parse[String]] =
             match parse_digit_as_string(version) with
             case Success { parse } -> parse_digits_as_string_rest(parse.buffer, parsed + parse.value)
             case Error -> Success { Parse { buffer: version, value: parsed } }


### PR DESCRIPTION
## Summary

Closes #177.

Adds first-class declaration annotations using declaration prefixes:

```cfun
@Deprecated(message: "use parse_v2", since: "1.4")
fun parse(raw: String): Result[User] = parse_v2(raw)

@Test(name: "parses user")
fun should_parse_user(): bool = true
```

Adds `.cfun` annotation definitions:

```cfun
annotation Deprecated on fun, method, class, interface, trait {
    message: String
    since: String = ""
}

annotation JsonName on field {
    value: String
}
```

Annotations with no explicit arguments may omit empty parentheses, so `@Recursive` and `@Internal` are the canonical marker-style forms. Parenthesized empty calls such as `@Recursive()` remain valid for compatibility.

Also extends reflection metadata so annotated data, fields, OO types, and methods can expose normalized annotation metadata.

This PR removes the old `fun rec` keyword form and replaces it with the standard library compiler annotation:

```cfun
from /capy/meta_prog/Recursive import { Recursive }

@Recursive
fun sum_to(n: int, acc: int): int =
    if n <= 0 then acc else sum_to(n - 1, acc + n)
```

## Impacted Modules

- `compiler`: Functional/OO grammar, parser AST, annotation validation, linked/compiled metadata, recursion contract validation, reflection value compilation.
- `capy`: Java/JS/Python e2e coverage for annotation reflection, `@Recursive` recursion behavior, import syntax, and compile-error diagnostics.
- `lib/capybara-lib`: reflection metadata model updates, standard `Deprecated` and `Recursive` annotations, and standard library recursion markers importing `Recursive`.
- `Intellij`: syntax highlighting updates for `@Name`, `@Name(...)` annotations and removal of `rec` keyword highlighting.
- Docs/ADR: declaration annotations ADR, recursion ADR, and README syntax documentation.

## Behavior Notes

- Annotation usage is `@Name(...)`; annotations with no explicit arguments may use `@Name`.
- Arguments use named syntax inside parentheses: `key: value`.
- Comma-separated prefixes such as `@A, @B` or `@A(), @B()` and positional calls such as `@Label("bad")` are invalid.
- Annotation definitions are ordinary `.cfun` declarations and must be visible/imported.
- Annotation metadata does not execute code and does not affect equality/stringification.
- `Recursive` is declared in `/capy/meta_prog/Recursive.cfun`; `@Recursive` must resolve through normal annotation visibility.
- Only the standard `/capy/meta_prog/Recursive.Recursive` annotation carries the compiler tail-recursion contract.
- User-defined annotations named `Recursive` are ordinary metadata and do not trigger recursion validation.
- Standard `@Recursive` replaces `fun rec` for top-level and local `.cfun` functions.
- Standard `@Recursive` is rejected on `.cfun` type methods and `.coo` methods.
- User-defined annotations remain invalid on local definitions; local functions accept only the standard `@Recursive` marker.
- Existing explicit language contracts such as `derive` and OO `override` remain separate semantics.

## Commands Run

- `python3 -m json.tool Intellij/syntaxes/capybara.tmLanguage.json >/tmp/capybara-tmlanguage-json-check && echo json-ok`
- `git diff --check`
- `./gradlew :compiler:classes :capy:compileJava :compiler:test --no-parallel --no-configuration-cache`
- `./gradlew :lib:capybara-lib:compileCapybara :capy:e2e-cfun :capy:e2e-cfun-js :capy:e2e-cfun-python :capy:e2e-coo :capy:e2e-coo-js :capy:e2e-coo-python --no-parallel --no-configuration-cache`
- `./gradlew :lib:capybara-lib:compileCapybara :capy:e2e-cfun :capy:e2e-coo --no-parallel --no-configuration-cache`
