### PR TITLE
fix(#185): return effects from COO method calls

### DIFF
--- a/capy/src/e2e-coo-java-native/capybara/dev/capylang/test/ClockCapyTest.cfun
+++ b/capy/src/e2e-coo-java-native/capybara/dev/capylang/test/ClockCapyTest.cfun
@@ -12,9 +12,11 @@ fun tests(): Effect[TestFile] =
 
 fun java_native_provider_bootstrap_resolves_backend(): Effect[Assert] =
     let clock <- system_clock()
-    assert_that(clock.now_millis()).is_equal_to(12345L)
+    let millis <- clock.now_millis()
+    assert_that(millis).is_equal_to(12345L)
 
 fun native_provider_can_be_injected_through_generated_interface(): Effect[Assert] =
     let clock <- system_clock()
     let domain <- NativeProviderDomain(clock)
-    assert_that(domain.read()).is_equal_to(12345L)
+    let millis <- domain.read()
+    assert_that(millis).is_equal_to(12345L)

--- a/capy/src/e2e-coo-js-native/capybara/dev/capylang/test/ClockCapyTest.cfun
+++ b/capy/src/e2e-coo-js-native/capybara/dev/capylang/test/ClockCapyTest.cfun
@@ -12,9 +12,11 @@ fun tests(): Effect[TestFile] =
 
 fun javascript_native_provider_bootstrap_resolves_backend(): Effect[Assert] =
     let clock <- system_clock()
-    assert_that(clock.now_millis()).is_equal_to(12345L)
+    let millis <- clock.now_millis()
+    assert_that(millis).is_equal_to(12345L)
 
 fun native_provider_can_be_injected_through_generated_interface(): Effect[Assert] =
     let clock <- system_clock()
     let domain <- NativeProviderDomain(clock)
-    assert_that(domain.read()).is_equal_to(12345L)
+    let millis <- domain.read()
+    assert_that(millis).is_equal_to(12345L)

--- a/capy/src/e2e-coo-py-native/capybara/dev/capylang/test/ClockCapyTest.cfun
+++ b/capy/src/e2e-coo-py-native/capybara/dev/capylang/test/ClockCapyTest.cfun
@@ -12,9 +12,11 @@ fun tests(): Effect[TestFile] =
 
 fun python_native_provider_bootstrap_resolves_backend(): Effect[Assert] =
     let clock <- system_clock()
-    assert_that(clock.now_millis()).is_equal_to(12345L)
+    let millis <- clock.now_millis()
+    assert_that(millis).is_equal_to(12345L)
 
 fun native_provider_can_be_injected_through_generated_interface(): Effect[Assert] =
     let clock <- system_clock()
     let domain <- NativeProviderDomain(clock)
-    assert_that(domain.read()).is_equal_to(12345L)
+    let millis <- domain.read()
+    assert_that(millis).is_equal_to(12345L)

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/NativeWiringCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/NativeWiringCapyTest.cfun
@@ -12,9 +12,11 @@ fun tests(): Effect[TestFile] =
 
 fun native_provider_effect_resolves_host_provider(): Effect[Assert] =
     let clock <- system_native_clock()
-    assert_that(clock.now_millis()).is_equal_to(12345L)
+    let millis <- clock.now_millis()
+    assert_that(millis).is_equal_to(12345L)
 
 fun native_provider_can_be_passed_to_domain_code(): Effect[Assert] =
     let clock <- system_native_clock()
     let consumer <- NativeClockConsumer(clock)
-    assert_that(consumer.read()).is_equal_to(12345L)
+    let millis <- consumer.read()
+    assert_that(millis).is_equal_to(12345L)

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectConstructionInteropCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectConstructionInteropCapyTest.cfun
@@ -14,8 +14,8 @@ fun tests(): Effect[TestFile] =
 fun functional_object_construction_is_delayed_and_repeatable(): Effect[Assert] =
     // The legacy host tests also assert exact stdout capture, generated class identity,
     // fresh object identity, CommonJS wiring, and label() results. Capybara .cfun tests
-    // can sequence OO construction effects across backends, but cannot capture stdout,
-    // compare backend object identity, or invoke OO instance methods portably.
+    // can sequence OO construction effects across backends, but cannot capture stdout
+    // or compare backend object identity portably.
     let person_runs <- runs_person_effect("Ada")
     let person_runs_twice <- runs_person_effect_twice("Ada")
     assert_all([

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectMethodInterop.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectMethodInterop.cfun
@@ -1,0 +1,6 @@
+from /capy/lang/Effect import { * }
+
+fun invoke_foo(x: int): Effect[String] =
+    let foo <- Foo()
+    let result <- foo.foo(x)
+    result

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectMethodInterop.coo
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectMethodInterop.coo
@@ -1,0 +1,9 @@
+class Foo {
+    def foo(x: int): String {
+        if x == 5 {
+            return "number is 5"
+        } else {
+            return "unexpected"
+        }
+    }
+}

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectMethodInteropCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectMethodInteropCapyTest.cfun
@@ -1,0 +1,14 @@
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+from /capy/lang/Effect import { * }
+from ObjectMethodInterop import { * }
+
+fun tests(): Effect[TestFile] =
+    let assertion <- invoke_foo_returns_effect()
+    test_file("/dev/capylang/test/ObjectMethodInterop.cfun", [
+        test("invoke_foo returns the OO method result", () => assertion),
+    ])
+
+fun invoke_foo_returns_effect(): Effect[Assert] =
+    let result <- invoke_foo(5)
+    assert_that(result).is_equal_to("number is 5")

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedFpInteropCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedFpInteropCapyTest.cfun
@@ -41,8 +41,8 @@ fun pet_interactor_is_constructible_and_exposes_expected_methods(): Effect[Asser
 
 fun fp_functions_create_and_match_interop_pets(): Assert =
     // Legacy OO host tests also assert generated class identity from PetInteractor.
-    // Capybara .cfun tests can construct and reflect OO values but cannot invoke
-    // OO instance methods portably, so this test observes the same FP values.
+    // Capybara .cfun tests keep this coverage on the FP values because generated
+    // class identity is still a host-level concern.
     assert_all([
         assert_that(pet_text(make_dog("Capy"))).is_equal_to("dog:Capy"),
         assert_that(interop_dog_name(make_dog("Bara"))).is_equal_to("Bara"),

--- a/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -2329,15 +2329,19 @@ public class CapybaraExpressionCompiler {
             parameterTypes.add(parameterType.orElseThrow());
             parameterNames.add(parameter.name());
         }
-        var returnType = objectMethodType(method.returnType());
-        if (returnType.isEmpty()) {
+        var rawReturnType = objectMethodType(method.returnType());
+        if (rawReturnType.isEmpty()) {
+            return Optional.empty();
+        }
+        var returnType = effectTypeFor(rawReturnType.orElseThrow());
+        if (returnType == null) {
             return Optional.empty();
         }
         return Optional.of(new FunctionSignature(
                 METHOD_DECL_PREFIX + ownerType.name() + "__" + method.name(),
                 List.copyOf(parameterTypes),
                 List.copyOf(parameterNames),
-                returnType.orElseThrow()
+                returnType
         ));
     }
 

--- a/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -936,7 +936,11 @@ public final class JavaScriptGenerator implements Generator {
             var emittedName = receiverType instanceof CompiledObjectType
                     ? objectMethodIdentifier(methodName)
                     : emittedMethodName(functionCall);
-            return "(" + receiver + ")." + emittedName + "(" + String.join(", ", tailArgs) + ")";
+            var invocation = "(" + receiver + ")." + emittedName + "(" + String.join(", ", tailArgs) + ")";
+            if (receiverType instanceof CompiledObjectType && isEffectType(functionCall.type())) {
+                return "capy.delay(() => " + invocation + ")";
+            }
+            return invocation;
         }
 
         private Optional<String> primitiveBackedMethodTarget(CompiledFunctionCall functionCall) {
@@ -6983,6 +6987,17 @@ public final class JavaScriptGenerator implements Generator {
                || name.endsWith("/Option")
                || name.endsWith(".Option")
                || name.endsWith("/Option.Option");
+    }
+
+    private static boolean isEffectType(CompiledType type) {
+        if (!(type instanceof GenericDataType genericDataType)) {
+            return false;
+        }
+        var name = genericDataType.name();
+        return "Effect".equals(name)
+               || name.endsWith("/Effect")
+               || name.endsWith(".Effect")
+               || name.endsWith("/Effect.Effect");
     }
 
     static String simpleTypeName(String typeName) {

--- a/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -957,7 +957,11 @@ public final class PythonGenerator implements Generator {
             var emittedName = receiverType instanceof CompiledObjectType
                     ? objectMethodIdentifier(methodName)
                     : pyIdentifier(emittedMethodName(functionCall));
-            return "(" + receiver + ")." + emittedName + "(" + String.join(", ", tailArgs) + ")";
+            var invocation = "(" + receiver + ")." + emittedName + "(" + String.join(", ", tailArgs) + ")";
+            if (receiverType instanceof CompiledObjectType && isEffectType(functionCall.type())) {
+                return "capy.delay(lambda: " + invocation + ")";
+            }
+            return invocation;
         }
 
         private Optional<String> primitiveBackedMethodTarget(CompiledFunctionCall functionCall) {
@@ -5477,6 +5481,17 @@ public final class PythonGenerator implements Generator {
                || name.endsWith("/Option")
                || name.endsWith(".Option")
                || name.endsWith("/Option.Option");
+    }
+
+    private static boolean isEffectType(CompiledType type) {
+        if (!(type instanceof GenericDataType genericDataType)) {
+            return false;
+        }
+        var name = genericDataType.name();
+        return "Effect".equals(name)
+               || name.endsWith("/Effect")
+               || name.endsWith(".Effect")
+               || name.endsWith("/Effect.Effect");
     }
 
     static String simpleTypeName(String typeName) {

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -568,7 +568,11 @@ public class JavaExpressionEvaluator {
                             .mapToObj(i -> coercePrimitiveCallArgument(functionCall.arguments().get(i).type(), args.get(i)))
                             .collect(java.util.stream.Collectors.joining(", "))
                     : "";
-            return current.addExpression(typedReceiver + "." + normalizedMethodName + "(" + invokeArgs + ")");
+            var invocation = typedReceiver + "." + normalizedMethodName + "(" + invokeArgs + ")";
+            if (receiverType instanceof dev.capylang.compiler.CompiledObjectType && isEffectType(functionCall.type())) {
+                return current.addExpression("capy.lang.Effect.delay(() -> (" + invocation + "))");
+            }
+            return current.addExpression(invocation);
         }
 
         var callArgs = java.util.stream.IntStream.range(0, args.size())
@@ -4157,6 +4161,16 @@ public class JavaExpressionEvaluator {
             return false;
         }
         return isOptionTypeName(genericDataType.name());
+    }
+
+    private static boolean isEffectType(dev.capylang.compiler.CompiledType type) {
+        if (!(type instanceof dev.capylang.compiler.GenericDataType genericDataType)) {
+            return false;
+        }
+        var normalized = normalizeQualifiedTypeName(genericDataType.name());
+        return "Effect".equals(genericDataType.name())
+               || normalized.endsWith("/Effect.Effect")
+               || normalized.endsWith("/Effect");
     }
 
     private static boolean isOptionTypeName(String typeName) {

--- a/compiler/src/test/java/dev/capylang/compiler/ObjectOrientedCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/ObjectOrientedCompilerTest.java
@@ -407,21 +407,27 @@ class ObjectOrientedCompilerTest {
     @Test
     void shouldLinkImportedObjectOrientedMethodsFromFunctionalCode() {
         var result = CapybaraCompiler.INSTANCE.compile(List.of(
+                effectModule(),
                 constructiblesModule(),
                 new RawModule(
                         "ObjectUse",
                         "/foo/app",
                         """
+                                from /capy/lang/Effect import { * }
                                 from Constructibles import { * }
 
-                                fun printable_label(printable: Printable): String =
+                                fun printable_label(printable: Printable): Effect[String] =
                                     printable.label()
 
-                                fun person_label(person: Person): String =
+                                fun person_label(person: Person): Effect[String] =
                                     person.label()
 
-                                fun inherited_label(person: Person): String =
+                                fun inherited_label(person: Person): Effect[String] =
                                     person.decorate("Ada")
+
+                                fun bind_person_label(person: Person): Effect[String] =
+                                    let label <- person.label()
+                                    label
                                 """
                 )
         ), new TreeSet<>());
@@ -429,14 +435,27 @@ class ObjectOrientedCompilerTest {
         assertThat(result).isInstanceOf(Result.Success.class);
         var program = ((Result.Success<CompiledProgram>) result).value();
         assertThat(compiledFunction(program, "ObjectUse", "printable_label").expression())
-                .isInstanceOfSatisfying(CompiledFunctionCall.class, call ->
-                        assertThat(call.name()).isEqualTo("__method__Printable__label"));
+                .isInstanceOfSatisfying(CompiledFunctionCall.class, call -> {
+                    assertThat(call.name()).isEqualTo("__method__Printable__label");
+                    assertThat(call.returnType()).isInstanceOfSatisfying(CompiledDataParentType.class, effect ->
+                            assertThat(effect.typeParameters()).containsExactly("String"));
+                });
         assertThat(compiledFunction(program, "ObjectUse", "person_label").expression())
-                .isInstanceOfSatisfying(CompiledFunctionCall.class, call ->
-                        assertThat(call.name()).isEqualTo("__method__Person__label"));
+                .isInstanceOfSatisfying(CompiledFunctionCall.class, call -> {
+                    assertThat(call.name()).isEqualTo("__method__Person__label");
+                    assertThat(call.returnType()).isInstanceOfSatisfying(CompiledDataParentType.class, effect ->
+                            assertThat(effect.typeParameters()).containsExactly("String"));
+                });
         assertThat(compiledFunction(program, "ObjectUse", "inherited_label").expression())
-                .isInstanceOfSatisfying(CompiledFunctionCall.class, call ->
-                        assertThat(call.name()).isEqualTo("__method__NamedTrait__decorate"));
+                .isInstanceOfSatisfying(CompiledFunctionCall.class, call -> {
+                    assertThat(call.name()).isEqualTo("__method__NamedTrait__decorate");
+                    assertThat(call.returnType()).isInstanceOfSatisfying(CompiledDataParentType.class, effect ->
+                            assertThat(effect.typeParameters()).containsExactly("String"));
+                });
+        assertThat(compiledFunction(program, "ObjectUse", "bind_person_label").expression())
+                .isInstanceOfSatisfying(CompiledEffectBindExpression.class, bind ->
+                        assertThat(bind.source()).isInstanceOfSatisfying(CompiledFunctionCall.class, call ->
+                                assertThat(call.name()).isEqualTo("__method__Person__label")));
     }
 
     @Test
@@ -451,6 +470,20 @@ class ObjectOrientedCompilerTest {
         assertThat(errorMessages(result))
                 .anySatisfy(message -> assertThat(message)
                         .contains("Object construction of Person returns Effect[Person], but Person was expected"));
+    }
+
+    @Test
+    void shouldRejectPureObjectOrientedMethodInvocation() {
+        var result = compileInvalid("""
+                from Constructibles import { Person }
+
+                fun bad(person: Person): String =
+                    person.label()
+                """);
+
+        assertThat(errorMessages(result))
+                .anySatisfy(message -> assertThat(message)
+                        .contains("Expected `String`, got `Effect[String]`"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Type imported COO instance method calls from .cfun as Effect[originalReturnType].
- Delay object method invocations in Java, JavaScript, and Python generators.
- Add COO/CFun e2e coverage for binding an OO method result, and update existing COO/native e2e tests to bind method effects.

## Notes
- This PR is stacked on feat/174-native-provider-wiring because #185 depends on the COO method metadata and resolver work from that branch.

## Tests
- ./gradlew --no-daemon --max-workers=1 :compiler:test --tests dev.capylang.compiler.ObjectOrientedCompilerTest
- ./gradlew --no-daemon --max-workers=1 :capy:e2e-coo :capy:e2e-coo-js
- ./gradlew --no-daemon --max-workers=1 :capy:e2e-coo-python
- ./gradlew --no-daemon --max-workers=1 :capy:e2e-coo-java-native :capy:e2e-coo-js-native :capy:e2e-coo-python-native