### PR TITLE
feat(#187): support repeatable annotations

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflection.cfun
@@ -1,5 +1,5 @@
 from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
-from AnnotationReflectionDefinitions import { ImportedAnnotationMarker, ImportedDataLabel, ImportedFieldName, ImportedFunctionLabel, ImportedMethodLabel }
+from AnnotationReflectionDefinitions import { ImportedAnnotationMarker, ImportedDataLabel, ImportedFieldName, ImportedFunctionLabel, ImportedMethodLabel, ImportedRepeatableLabel }
 
 annotation LocalDataLabel on data {
     label: String
@@ -18,6 +18,14 @@ data AnnotatedCustomer {
     display: String
 }
 
+@ImportedRepeatableLabel(value: "data-primary")
+@ImportedRepeatableLabel(value: "data-secondary")
+data RepeatableAnnotatedCustomer {
+    @ImportedRepeatableLabel(value: "field-primary")
+    @ImportedRepeatableLabel(value: "field-secondary")
+    id: String
+}
+
 @ImportedFunctionLabel(value: "factory")
 fun make_annotated_customer(id: String, display: String): AnnotatedCustomer =
     AnnotatedCustomer { id, display }
@@ -30,3 +38,6 @@ fun annotation_reflection_sample(): DataValueInfo =
 
 fun annotation_reflection_data(customer: AnnotatedCustomer): DataValueInfo =
     reflection(customer)
+
+fun repeatable_annotation_reflection_sample(): DataValueInfo =
+    reflection(RepeatableAnnotatedCustomer { id: "R-1" })

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflectionCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflectionCapyTest.cfun
@@ -10,6 +10,7 @@ fun tests(): Effect[TestFile] =
     test_file("/dev/capylang/test/AnnotationReflection.cfun", [
         test("reflects functional declaration annotations", () => reflects_functional_declaration_annotations()),
         test("reflects functional field annotations", () => reflects_functional_field_annotations()),
+        test("reflects repeated functional annotations", () => reflects_repeated_functional_annotations()),
     ])
 
 fun reflects_functional_declaration_annotations(): Assert =
@@ -41,6 +42,18 @@ fun reflects_functional_field_annotations(): Assert =
         assert_that(ar_field_string_value(info, 1)).is_equal_to("Bea"),
     ])
 
+fun reflects_repeated_functional_annotations(): Assert =
+    let info = repeatable_annotation_reflection_sample()
+    assert_all([
+        assert_that(info.name).is_equal_to("RepeatableAnnotatedCustomer"),
+        assert_that(ar_annotation_names(info.annotations)).is_equal_to(["ImportedRepeatableLabel", "ImportedRepeatableLabel"]),
+        assert_that(ar_annotation_string(info.annotations[0], "value")).is_equal_to("data-primary"),
+        assert_that(ar_annotation_string(info.annotations[1], "value")).is_equal_to("data-secondary"),
+        assert_that(ar_field_annotation_names(info, 0)).is_equal_to(["ImportedRepeatableLabel", "ImportedRepeatableLabel"]),
+        assert_that(ar_field_annotation_string(info, 0, 0, "value")).is_equal_to("field-primary"),
+        assert_that(ar_field_annotation_string(info, 0, 1, "value")).is_equal_to("field-secondary"),
+    ])
+
 private fun ar_field_names(info: DataValueInfo): List[String] =
     ar_field_names_at(info.fields, 0, [])
 
@@ -68,6 +81,9 @@ private fun ar_field_string_value(info: DataValueInfo, field_idx: int): String =
             case _ -> ""
         }
     case None -> ""
+
+private fun ar_field_annotation_string(info: DataValueInfo, field_idx: int, annotation_idx: int, name: String): String =
+    ar_annotation_string(ar_field_annotation(info, field_idx, annotation_idx), name)
 
 private fun ar_annotation_names(annotations: List[AnnotationInfo]): List[String] =
     ar_annotation_names_at(annotations, 0, [])

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflectionDefinitions.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/AnnotationReflectionDefinitions.cfun
@@ -6,6 +6,10 @@ annotation ImportedDataLabel on data {
     active: bool = true
 }
 
+multiple annotation ImportedRepeatableLabel on data, field {
+    value: String
+}
+
 annotation ImportedFieldName on field {
     value: String
 }

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotationDefinitions.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotationDefinitions.cfun
@@ -4,6 +4,10 @@ annotation OoTypeLabel on class, interface, trait {
     label: String
 }
 
+multiple annotation OoRepeatableLabel on class, interface, trait, field, method {
+    value: String
+}
+
 annotation OoFieldName on field {
     value: String
 }

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotations.coo
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotations.coo
@@ -1,4 +1,4 @@
-from /dev/capylang/test/ObjectOrientedAnnotationDefinitions import { OoAnnotationMarker, OoTypeLabel, OoFieldName, OoMethodName }
+from /dev/capylang/test/ObjectOrientedAnnotationDefinitions import { OoAnnotationMarker, OoTypeLabel, OoFieldName, OoMethodName, OoRepeatableLabel }
 from /capy/meta_prog/Annotations import { Deprecated }
 
 @OoAnnotationMarker
@@ -29,4 +29,16 @@ class AnnotatedWidget(name: String): AnnotatedContract, AnnotatedNaming {
     @OoMethodName(value: "render")
     @Deprecated(message: "use render_label", since: "3.1")
     override def render(): String = this.prefix(this.name)
+}
+
+@OoRepeatableLabel(value: "class-primary")
+@OoRepeatableLabel(value: "class-secondary")
+class RepeatableAnnotatedWidget(name: String) {
+    @OoRepeatableLabel(value: "field-primary")
+    @OoRepeatableLabel(value: "field-secondary")
+    field name: String = name
+
+    @OoRepeatableLabel(value: "method-primary")
+    @OoRepeatableLabel(value: "method-secondary")
+    def render(): String = this.name
 }

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotationsCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectOrientedAnnotationsCapyTest.cfun
@@ -6,12 +6,13 @@ from /capy/lang/Seq import { * }
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/meta_prog/Reflection import { * }
-from ObjectOrientedAnnotations import { AnnotatedContract, AnnotatedNaming, AnnotatedWidget }
+from ObjectOrientedAnnotations import { AnnotatedContract, AnnotatedNaming, AnnotatedWidget, RepeatableAnnotatedWidget }
 
 fun tests(): Effect[TestFile] =
     test_file("/dev/capylang/test/ObjectOrientedAnnotations.coo", [
         test("reflects interface and trait annotations", () => ooa_reflects_interface_and_trait_annotations()),
         test("reflects class field and method annotations", () => ooa_reflects_class_field_and_method_annotations()),
+        test("reflects repeated object-oriented annotations", () => ooa_reflects_repeated_object_oriented_annotations()),
     ])
 
 fun ooa_reflects_interface_and_trait_annotations(): Assert =
@@ -55,6 +56,20 @@ fun ooa_reflects_class_field_and_method_annotations(): Assert =
         assert_that(ooa_method_annotation_string(widget.methods, 0, 0, "value")).is_equal_to("render"),
         assert_that(ooa_method_annotation_string(widget.methods, 0, 1, "message")).is_equal_to("use render_label"),
         assert_that(ooa_method_annotation_string(widget.methods, 0, 1, "since")).is_equal_to("3.1"),
+    ])
+
+fun ooa_reflects_repeated_object_oriented_annotations(): Assert =
+    let widget = RepeatableAnnotatedWidget.type()
+    assert_all([
+        assert_that(ooa_annotation_names(widget.annotations)).is_equal_to(["OoRepeatableLabel", "OoRepeatableLabel"]),
+        assert_that(ooa_annotation_string(widget.annotations[0], "value")).is_equal_to("class-primary"),
+        assert_that(ooa_annotation_string(widget.annotations[1], "value")).is_equal_to("class-secondary"),
+        assert_that(ooa_field_annotation_names(widget.fields, 0)).is_equal_to(["OoRepeatableLabel", "OoRepeatableLabel"]),
+        assert_that(ooa_field_annotation_string(widget.fields, 0, 0, "value")).is_equal_to("field-primary"),
+        assert_that(ooa_field_annotation_string(widget.fields, 0, 1, "value")).is_equal_to("field-secondary"),
+        assert_that(ooa_method_annotation_names(widget.methods, 0)).is_equal_to(["OoRepeatableLabel", "OoRepeatableLabel"]),
+        assert_that(ooa_method_annotation_string(widget.methods, 0, 0, "value")).is_equal_to("method-primary"),
+        assert_that(ooa_method_annotation_string(widget.methods, 0, 1, "value")).is_equal_to("method-secondary"),
     ])
 
 private fun ooa_annotation_names(annotations: List[AnnotationInfo]): List[String] =

--- a/compiler/src/main/antlr/Functional.g4
+++ b/compiler/src/main/antlr/Functional.g4
@@ -92,7 +92,10 @@ annotationTypeReference
     | lowerQualifiedType
     ;
 annotationDeclaration
-    : docComment* annotationBlock* VISIBILITY? annotationKeyword TYPE annotationTargetClause annotationBody
+    : docComment* annotationBlock* VISIBILITY? multipleModifier? annotationKeyword TYPE annotationTargetClause annotationBody
+    ;
+multipleModifier
+    : { "multiple".equals(_input.LT(1).getText()) }? NAME
     ;
 annotationKeyword
     : { "annotation".equals(_input.LT(1).getText()) }? NAME

--- a/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/compiler/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -2172,6 +2172,7 @@ public class CapybaraCompiler {
             String normalizedFile,
             TreeSet<Result.Error.SingleError> errors
     ) {
+        var recursiveUsages = new ArrayList<AnnotationUsage>();
         for (var usage : usages) {
             var availableAnnotation = availableAnnotations.get(usage.name());
             if (availableAnnotation == null) {
@@ -2186,15 +2187,16 @@ public class CapybaraCompiler {
                 ));
                 continue;
             }
-            validateAnnotationUsageList(
-                    List.of(usage),
-                    Optional.of(AnnotationSemanticTarget.FUNCTION),
-                    AnnotationSemanticTarget.FUNCTION.displayName,
-                    availableAnnotations,
-                    normalizedFile,
-                    errors
-            );
+            recursiveUsages.add(usage);
         }
+        validateAnnotationUsageList(
+                recursiveUsages,
+                Optional.of(AnnotationSemanticTarget.FUNCTION),
+                AnnotationSemanticTarget.FUNCTION.displayName,
+                availableAnnotations,
+                normalizedFile,
+                errors
+        );
     }
 
     private void validateObjectOrientedAnnotationUsages(
@@ -2269,6 +2271,7 @@ public class CapybaraCompiler {
             String normalizedFile,
             TreeSet<Result.Error.SingleError> errors
     ) {
+        var singleUseAnnotations = new HashMap<String, AnnotationUsage>();
         for (var usage : usages) {
             var availableAnnotation = availableAnnotations.get(usage.name());
             if (availableAnnotation == null) {
@@ -2298,8 +2301,24 @@ public class CapybaraCompiler {
                 ));
                 continue;
             }
+            if (!annotation.multiple()) {
+                var previous = singleUseAnnotations.putIfAbsent(annotationUsageKey(availableAnnotation), usage);
+                if (previous != null) {
+                    errors.add(errorAt(
+                            "Annotation " + annotation.name() + " cannot be applied multiple times",
+                            usage.position(),
+                            normalizedFile
+                    ));
+                }
+            }
             validateAnnotationArguments(usage, annotation, normalizedFile, errors);
         }
+    }
+
+    private String annotationUsageKey(AvailableAnnotation annotation) {
+        return normalizedAnnotationModulePath(annotation.ownerModule().path())
+               + "/" + annotation.ownerModule().name()
+               + "." + annotation.annotation().name();
     }
 
     private String unknownAnnotationMessage(String name) {

--- a/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationDeclaration.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/AnnotationDeclaration.java
@@ -9,6 +9,7 @@ public record AnnotationDeclaration(
         String name,
         List<AnnotationTarget> targets,
         List<AnnotationFieldDeclaration> fields,
+        boolean multiple,
         List<String> comments,
         Visibility visibility,
         Optional<SourcePosition> position,
@@ -22,6 +23,6 @@ public record AnnotationDeclaration(
             Visibility visibility,
             Optional<SourcePosition> position
     ) {
-        this(name, targets, fields, comments, visibility, position, List.of());
+        this(name, targets, fields, false, comments, visibility, position, List.of());
     }
 }

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -558,6 +558,7 @@ public class CapybaraParser {
                 context.annotationBody().annotationFieldDeclaration().stream()
                         .map(this::annotationFieldDeclaration)
                         .toList(),
+                context.multipleModifier() != null,
                 context.docComment().stream()
                         .map(comment -> stripDocComment(comment.getText()))
                         .toList(),

--- a/compiler/src/test/java/dev/capylang/compiler/AnnotationCompilerTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/AnnotationCompilerTest.java
@@ -120,6 +120,36 @@ class AnnotationCompilerTest {
     }
 
     @Test
+    void shouldRejectRepeatedSingleUseAnnotation() {
+        var error = compileFailure(new RawModule("Tests", "/foo/app", """
+                annotation Deprecated on fun {}
+
+                @Deprecated
+                @Deprecated
+                fun should_run(): bool = true
+                """));
+
+        assertThat(error.message()).contains("Annotation Deprecated cannot be applied multiple times");
+    }
+
+    @Test
+    void shouldAllowRepeatedMultipleAnnotation() {
+        var compiled = compileSuccess(new RawModule("Tests", "/foo/app", """
+                multiple annotation Tag on fun {
+                    value: String
+                }
+
+                @Tag(value: "slow")
+                @Tag(value: "integration")
+                fun should_run(): bool = true
+                """));
+
+        assertThat(function(compiled, "Tests", "should_run").annotations())
+                .extracting(CompiledAnnotation::name)
+                .containsExactly("Tag", "Tag");
+    }
+
+    @Test
     void shouldRejectMissingRequiredAnnotationArgument() {
         var error = compileFailure(new RawModule("Tests", "/foo/app", """
                 annotation Test on fun {

--- a/compiler/src/test/java/dev/capylang/compiler/compilation_error/CompilationErrorTest.java
+++ b/compiler/src/test/java/dev/capylang/compiler/compilation_error/CompilationErrorTest.java
@@ -401,6 +401,22 @@ public class CompilationErrorTest {
     }
 
     @Test
+    void shouldRejectRepeatedSingleUseAnnotation() {
+        var errors = compileProgram("""
+                        annotation Deprecated on fun {}
+
+                        @Deprecated
+                        @Deprecated
+                        fun should_run(): bool = true
+                        """,
+                "annotation_repeated_single_use");
+
+        assertThat(errors)
+                .anySatisfy(error -> assertThat(error.message())
+                        .contains("Annotation Deprecated cannot be applied multiple times"));
+    }
+
+    @Test
     void shouldRejectUnknownFunctionalAnnotation() {
         var errors = compileProgram("""
                         @Missing()

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -83,6 +83,8 @@ class CapybaraParserTest {
                     unknown: String = ???
                 }
 
+                multiple annotation Repeatable on fun {}
+
                 @Benchmark
                 fun ping(): int = 1
 
@@ -100,6 +102,7 @@ class CapybaraParserTest {
                 """));
 
         var annotation = findDefinition(AnnotationDeclaration.class, "Deprecated", module.functional());
+        assertThat(annotation.multiple()).isFalse();
         assertThat(annotation.annotations()).extracting(AnnotationUsage::name).containsExactly("Meta");
         assertThat(annotation.targets()).extracting(AnnotationTarget::name)
                 .containsExactly("fun", "method", "data", "class");
@@ -110,6 +113,8 @@ class CapybaraParserTest {
                 .hasValueSatisfying(value -> assertThat(((AnnotationValue.StringValue) value).value()).isEqualTo("\"\""));
         assertThat(annotation.fields().get(2).defaultValue())
                 .hasValueSatisfying(value -> assertThat(((AnnotationValue.TypeNameValue) value).name()).isEqualTo("User"));
+
+        assertThat(findDefinition(AnnotationDeclaration.class, "Repeatable", module.functional()).multiple()).isTrue();
 
         var markerFunction = findFunction("ping", module.functional());
         assertThat(markerFunction.annotations()).extracting(AnnotationUsage::name).containsExactly("Benchmark");


### PR DESCRIPTION
## What changed and why
- Added `multiple annotation Foo on ...` syntax to mark annotations as repeatable.
- Single-use annotations now fail compilation when applied more than once to the same declaration.
- Added parser, compiler, and compilation-error coverage for repeatable and single-use annotation behavior.

## Impacted modules
- `compiler`

## Commands run
- `./gradlew :compiler:test`
- `./gradlew :capy:e2eTests`

## Sample
```cfun
annotation Deprecated on fun {}

@Deprecated
@Deprecated
fun x(x: int) = "Number {x}"
```

The repeated usage now fails unless the annotation is declared with `multiple`, for example:

```cfun
multiple annotation Foo on fun {}
```

Closes #187