### PR TITLE
chore(#184): split self-hosting plan into tasks

### DIFF
--- a/.ai/TASK-1.md
+++ b/.ai/TASK-1.md
@@ -1,0 +1,50 @@
+# TASK-1: Record self-hosting ADR and baseline gates
+
+Issue: #184
+
+## Goal
+
+Create the architecture decision record and baseline evidence required before
+any compiler or CLI implementation moves from Java to Capybara.
+
+## Scope
+
+- Add ADR `Self-hosted Compiler and CLI v1`.
+- Define permanent Java islands:
+  - ANTLR grammars and generated parser runtime.
+  - Stable parser DTO/schema facade.
+  - Native provider host implementations.
+  - Minimal JVM runtime glue needed to load generated Capybara code.
+- State that launching semantics move to Capybara:
+  `fun main(args: List[String]): Effect[Program]`.
+- State that production Gradle/package/user entrypoints must eventually invoke
+  Java generated from Capybara source, not retained hand-written Java
+  entrypoints.
+- Update native-provider and OO ADR notes if needed.
+- Freeze current behavior with parity/golden fixtures.
+
+## Deliverables
+
+- ADR for self-hosting architecture.
+- Golden fixtures for parser diagnostics, compile diagnostics, linked JSON,
+  generated Java/JS/Python output, native provider catalog/bootstrap output,
+  and CLI exit/stderr behavior.
+- Baseline timing notes for:
+  - `./gradlew :compiler:test :compiler:integrationTest`
+  - `./gradlew :capy:e2eTests`
+  - `./gradlew clean test`
+
+## Acceptance Criteria
+
+- ADR is accepted.
+- Current full suite is green before any cutover.
+- Any known unstable output is documented.
+- No implementation behavior changes are introduced.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+chore(#184): record self-hosting architecture and baseline gates
+```

--- a/.ai/TASK-10.md
+++ b/.ai/TASK-10.md
@@ -1,0 +1,40 @@
+# TASK-10: Port Java generation to Capybara
+
+Issue: #184
+
+## Goal
+
+Move backend-independent generation planning and Java backend emission into
+Capybara while preserving generated output behavior.
+
+## Scope
+
+- Port generated file model and output ordering.
+- Port backend-independent generation plan.
+- Port Java backend emitter.
+- Port Java native provider bootstrap emitter.
+- Preserve stale-output manifest model where it affects Java generation.
+
+## Requirements
+
+- Preserve current package/class/file paths.
+- Preserve reflection metadata shape.
+- Preserve tail-recursive lowering behavior.
+- Preserve runtime helper behavior until replaced by explicit provider-backed
+  equivalents.
+- Keep output deterministic.
+
+## Acceptance Criteria
+
+- Java generator unit tests pass.
+- Normalized generated Java output parity tests pass.
+- Java e2e suites pass.
+- Native provider Java e2e passes.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port Java generation to Capybara
+```

--- a/.ai/TASK-11.md
+++ b/.ai/TASK-11.md
@@ -1,0 +1,42 @@
+# TASK-11: Port JavaScript generation to Capybara
+
+Issue: #184
+
+## Goal
+
+Move JavaScript CommonJS backend emission and JavaScript native provider
+bootstrap generation into Capybara.
+
+## Scope
+
+- Port JavaScript CommonJS backend emitter.
+- Port JavaScript native provider bootstrap emitter.
+- Preserve generated `dev/capylang/native_providers.js` behavior.
+- Preserve JS fixture-copy/module-resolution behavior until a replacement is
+  implemented.
+
+## Requirements
+
+- Keep generated output CommonJS-compatible.
+- Use `'use strict'`, `require(...)`, and `module.exports`.
+- Do not switch to ESM in this migration.
+- Avoid syntax requiring newer Node than the pinned Gradle Node version.
+- Preserve lazy OO construction semantics:
+  effect creation must not allocate, and each effect run must allocate a fresh
+  instance when construction is modeled as an effect.
+
+## Acceptance Criteria
+
+- JavaScript generator unit tests pass.
+- Normalized generated JS output parity tests pass.
+- `:capy:jsTests` passes.
+- `:capy:e2e-cfun-js`, `:capy:e2e-coo-js`, and
+  `:capy:e2e-coo-js-native` pass.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port JavaScript generation to Capybara
+```

--- a/.ai/TASK-12.md
+++ b/.ai/TASK-12.md
@@ -1,0 +1,39 @@
+# TASK-12: Port Python generation to Capybara
+
+Issue: #184
+
+## Goal
+
+Move Python backend emission and Python native provider bootstrap generation
+into Capybara.
+
+## Scope
+
+- Port Python backend emitter.
+- Port Python native provider bootstrap emitter.
+- Preserve generated package/module layout.
+- Preserve native provider import/class lookup behavior.
+- Preserve current test runner behavior.
+
+## Requirements
+
+- Output paths remain stable.
+- Runtime helper semantics remain compatible.
+- Native provider diagnostics remain compatible.
+- Generated Python behavior stays equivalent to current Java implementation.
+
+## Acceptance Criteria
+
+- Python generator unit tests pass.
+- Normalized generated Python output parity tests pass.
+- `:capy:pythonTests` passes.
+- `:capy:e2e-cfun-python`, `:capy:e2e-coo-python`, and
+  `:capy:e2e-coo-python-native` pass.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port Python generation to Capybara
+```

--- a/.ai/TASK-13.md
+++ b/.ai/TASK-13.md
@@ -1,0 +1,57 @@
+# TASK-13: Move capy CLI entrypoint to Capybara
+
+Issue: #184
+
+## Goal
+
+Move CLI command workflow and launch semantics to Capybara, with Gradle and
+packaged CLIs invoking Java generated from Capybara source.
+
+## Scope
+
+- Implement `fun main(args: List[String]): Effect[Program]`.
+- Model:
+  - `Command`
+  - `CommandArgs`
+  - `CommandResult`
+  - `CommandRouter`
+  - `CompileRequest`
+  - `GenerateRequest`
+  - `CompileGenerateRequest`
+  - `PackageRequest`
+  - `BuildInfo`
+  - `OutputManifest`
+  - `CliDiagnostic`
+- Move command parsing, option normalization, path planning, compile/generate
+  orchestration, package orchestration, output pruning, build-info writing,
+  Java compilation/test execution decisions, logging, and error formatting.
+- Update Gradle in-process tasks to invoke generated Java compiled from
+  Capybara, not old hand-written `dev.capylang.Capy`.
+
+## Design Rules
+
+- `CommandRouter` owns only command selection and dispatch.
+- Request objects own command-specific normalization and invariants.
+- Command handlers own exactly one workflow each.
+- File deletion and writes stay in host/provider shell code.
+- No production hand-written Java CLI facade remains after this task.
+
+## Acceptance Criteria
+
+- Exit codes remain:
+  - `0` success
+  - `1` usage error
+  - `2` unexpected failure
+  - `100` compilation error
+- stdout/stderr and command help behavior remain compatible.
+- `:capy:test`, `:capy:jsTests`, `:capy:pythonTests`, and
+  `:capy:e2eTests` pass.
+- Gradle in-process compile/test tasks invoke generated Capybara-compiled Java.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): move capy CLI entrypoint to Capybara
+```

--- a/.ai/TASK-14.md
+++ b/.ai/TASK-14.md
@@ -1,0 +1,49 @@
+# TASK-14: Harden self-hosting native providers
+
+Issue: #184
+
+## Goal
+
+Expose all host access introduced by self-hosting through deterministic,
+ADR-compliant native provider contracts.
+
+## Scope
+
+- Define provider interfaces for:
+  - parser;
+  - filesystem;
+  - environment;
+  - console;
+  - clock;
+  - JSON/YAML;
+  - ZIP/package writing;
+  - Java compiler;
+  - test execution.
+- Choose stable qualifiers and lifetimes.
+- Preserve source `@NativeProvider` as preferred provider declaration path.
+- Keep `--native-wiring` JSON as compatibility input.
+
+## Diagnostics To Preserve
+
+- `NotWired`
+- `DuplicateProvider`
+- `TypeMismatch`
+- `UnsupportedBackend`
+- `InvocationFailure`
+
+## Acceptance Criteria
+
+- Java, JS, and Python native provider e2e suites pass.
+- No mutable runtime provider registration path is introduced.
+- No direct `.coo` host imports are introduced.
+- Tests cover annotation wiring, manifest fallback, duplicate providers,
+  missing backend bindings, unsupported factory/lifetime, malformed manifests,
+  unused manifest entries, and provider call shadowing.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): harden self-hosting native providers
+```

--- a/.ai/TASK-15.md
+++ b/.ai/TASK-15.md
@@ -1,0 +1,48 @@
+# TASK-15: Switch compiler and CLI to self-hosted path
+
+Issue: #184
+
+## Goal
+
+Cut over production compiler and CLI ownership to the self-hosted Capybara
+implementation after deterministic bootstrap parity is proven.
+
+## Bootstrap Stages
+
+1. Stage 0: existing Java compiler builds Capybara compiler sources.
+2. Stage 1: generated Capybara compiler compiles the same compiler sources.
+3. Stage 2: Stage 1 compiler compiles the same sources again.
+4. Compare Stage 1 and Stage 2:
+   - linked outputs;
+   - generated Java;
+   - generated JS/Python if applicable;
+   - native provider catalogs, manifests, and backend bootstrap modules;
+   - CLI command contract outputs for compile, generate, compile-generate, and
+     package flows;
+   - diagnostics for invalid fixtures.
+
+## Cutover Rules
+
+- Do not delete old Java semantic/generator code until Stage 1/2 parity is
+  stable.
+- Old Java paths may remain only behind a test-only parity harness.
+- Production Gradle tasks, package manifests, and user-facing invocations must
+  point at Capybara-compiled Java entrypoints.
+- Removal happens in small commits by subsystem.
+
+## Acceptance Criteria
+
+- Self-hosted compiler passes full repository tests.
+- Stage 1/2 output is stable.
+- Native provider bootstrap and manifest compatibility are stable.
+- CLI contract parity is stable.
+- Gradle and packaged CLI entrypoints invoke generated Java from Capybara
+  source.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): switch compiler and CLI to self-hosted path
+```

--- a/.ai/TASK-16.md
+++ b/.ai/TASK-16.md
@@ -1,0 +1,42 @@
+# TASK-16: Remove migrated Java compiler and CLI code
+
+Issue: #184
+
+## Goal
+
+Remove obsolete production Java implementation code after the self-hosted path
+is stable.
+
+## Scope
+
+- Remove migrated Java semantic logic.
+- Remove migrated Java generator logic.
+- Remove hand-written Java CLI launcher from the production path.
+- Keep only permanent Java islands:
+  - ANTLR parser facade;
+  - host provider implementations;
+  - required runtime helpers.
+- Remove temporary Java parity harnesses unless the self-hosting ADR explicitly
+  keeps them.
+- Update `README.md`, `DEV_README.md`, `capy/CAPYBARA_E2E_TESTS.md`, and ADR
+  status notes.
+- Simplify Gradle wiring if old dual-run paths are no longer needed.
+
+## Acceptance Criteria
+
+- No dual implementation remains outside intentional compatibility shims.
+- Dependency graph is simpler.
+- Full test gate passes:
+  - `./gradlew clean test`
+  - `./gradlew :capy:e2eTests`
+  - `:capy:jsTests`
+  - `:capy:pythonTests`
+  - stdlib compile/test gates
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+chore(#184): remove migrated Java compiler and CLI code
+```

--- a/.ai/TASK-2.md
+++ b/.ai/TASK-2.md
@@ -1,0 +1,40 @@
+# TASK-2: Add self-hosting source-set scaffolding
+
+Issue: #184
+
+## Goal
+
+Add Capybara source roots for future compiler and CLI implementation without
+changing production behavior.
+
+## Scope
+
+- Add Gradle wiring for `compiler/src/main/capybara`.
+- Add Gradle wiring for `capy/src/main/capybara`.
+- Generate Java from those sources into build directories before Java
+  compilation.
+- Keep generated classes internal during this phase.
+- Add a trivial pure Capybara module and Java-side test proving generated code
+  is callable.
+- Ensure stdlib bootstrap does not recursively load the compiler being built.
+
+## Deliverables
+
+- Build wiring for compiler Capybara sources.
+- Build wiring for capy Capybara sources.
+- Minimal generated-code call test.
+- No committed generated output.
+
+## Acceptance Criteria
+
+- No user-visible behavior changes.
+- `./gradlew :compiler:test :capy:test` passes.
+- Generated Java remains under `build/generated/...`.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): add self-hosting source-set scaffolding
+```

--- a/.ai/TASK-3.md
+++ b/.ai/TASK-3.md
@@ -1,0 +1,46 @@
+# TASK-3: Define linked artifact and compiler contract schemas
+
+Issue: #184
+
+## Goal
+
+Define stable, language-neutral contracts before moving compiler logic to
+Capybara.
+
+## Scope
+
+- Define a versioned linked JSON schema or compatibility shim.
+- Define Capybara codecs for:
+  - linked modules;
+  - compiled modules;
+  - compiled expressions;
+  - OO modules;
+  - native provider catalogs;
+  - diagnostics;
+  - generated program metadata.
+- Preserve old-to-new and new-to-old compatibility during migration.
+- Define backend-neutral generated program IR.
+- Define deterministic ordering for modules, imports, diagnostics, generated
+  files, native providers, and duplicate errors.
+
+## Deliverables
+
+- Documented linked artifact schema.
+- Compatibility shim or versioned reader/writer.
+- Round-trip tests against Java-produced artifacts.
+- Contract parity tests against current Java output.
+
+## Acceptance Criteria
+
+- Migrated code can read old Java-produced linked modules.
+- Java compatibility paths can read migrated linked modules during transition.
+- Unsupported schema versions fail with clear diagnostics.
+- Current Jackson default typing is not the long-term self-hosted contract.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): define self-hosted compiler artifact contracts
+```

--- a/.ai/TASK-4.md
+++ b/.ai/TASK-4.md
@@ -1,0 +1,51 @@
+# TASK-4: Add Java ANTLR parser facade and Capybara DTO adapters
+
+Issue: #184
+
+## Goal
+
+Keep ANTLR Java-owned while exposing stable parser DTOs that Capybara compiler
+code can consume.
+
+## Scope
+
+- Create Java parser facade interfaces for:
+  - parsing `.cfun` modules;
+  - parsing `.coo` modules;
+  - import extraction with stable line numbers;
+  - parse diagnostics with source file and line/column.
+- Wrap the parser facade behind `@NativeProvider` contracts for Capybara
+  callers.
+- Define parser DTO/schema values independent from Java records and generated
+  Capybara class names.
+- Add Capybara adapters from parser DTOs to compiler AST/IR.
+- Preserve current parser diagnostics unless intentionally changed.
+
+## Parser Golden Coverage
+
+- `TYPE { ... }` data construction.
+- `TYPE.field(...)`.
+- `NAME(...)`.
+- generics at line start and `LINE_START_LBRACK`.
+- list/set/dict literals.
+- `=>`, `|>`, reduce/lambda forms.
+- match branches and guards.
+- `if then else`.
+- unary/postfix/infix precedence.
+- empty index/slice cases.
+- `.coo` arrays, `this`, `super`, calls, blocks, and exception statements.
+
+## Acceptance Criteria
+
+- ANTLR grammars regenerate without new warnings/conflicts, or every
+  intentional conflict is documented with regression tests.
+- Parser facade feeds Capybara IR without semantic changes.
+- Parser error snapshots remain stable.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): add parser facade for self-hosted compiler
+```

--- a/.ai/TASK-5.md
+++ b/.ai/TASK-5.md
@@ -1,0 +1,45 @@
+# TASK-5: Model compiler core IR in Capybara
+
+Issue: #184
+
+## Goal
+
+Model compiler-domain values in `.cfun` and make invalid states
+unrepresentable where practical.
+
+## Scope
+
+- Inventory Java model classes before porting.
+- Classify each Java model:
+  - product-only records/value classes -> Capybara `data`;
+  - sealed/interface alternatives -> Capybara `union` with one case per
+    variant;
+  - Java enums -> Capybara `enum` when they are closed symbolic sets;
+  - behavior/host-resource classes -> `.coo` shell object or `NativeProvider`
+    boundary, not `.cfun data`.
+- Model module identity, imports, declarations, compiled types, expressions,
+  diagnostics, and native provider declarations/catalog.
+- Provide a no-op/pass-through compiler pipeline over stable DTO/schema
+  boundaries.
+
+## Deliverables
+
+- Capybara IR definitions.
+- Record-to-`data` and hierarchy-to-`union` mapping table in ADR or migration
+  notes.
+- Adapter round-trip tests.
+- No production cutover.
+
+## Acceptance Criteria
+
+- Capybara IR round-trips through adapters for representative fixtures.
+- Parity harness can compare Java legacy structures with Capybara structures.
+- Generated Capybara class shapes are not used as public Java-island contracts.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): model compiler core IR in Capybara
+```

--- a/.ai/TASK-6.md
+++ b/.ai/TASK-6.md
@@ -1,0 +1,40 @@
+# TASK-6: Port module linking passes to Capybara
+
+Issue: #184
+
+## Goal
+
+Move module identity, source descriptor classification, import resolution, and
+declaration indexing into pure `.cfun` passes.
+
+## Scope
+
+- Port module/path normalization and canonical module identity.
+- Port source descriptor and extension classification from already discovered
+  immutable inputs.
+- Port import resolution.
+- Port declaration indexes and duplicate detection.
+- Keep source discovery, directory walking, and file reads in `.coo` or
+  `NativeProvider` shell code.
+
+## FP Requirements
+
+- Each pass is pure `.cfun`.
+- Each pass returns `Result[Output]`.
+- Symbol tables, caches, and contexts are explicit inputs/outputs.
+- Diagnostics are deterministic values with stable ordering.
+
+## Acceptance Criteria
+
+- Dual-run parity tests pass for each migrated pass.
+- Compile-error tests for touched diagnostics pass.
+- Minimal cross-backend e2e canary passes when behavior can affect backends.
+- `./gradlew :compiler:test :compiler:integrationTest` passes.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port module linking passes to Capybara
+```

--- a/.ai/TASK-7.md
+++ b/.ai/TASK-7.md
@@ -1,0 +1,43 @@
+# TASK-7: Port type and provider validation passes
+
+Issue: #184
+
+## Goal
+
+Move type linking, annotation validation, and native provider catalog validation
+into `.cfun`.
+
+## Scope
+
+- Port type linking.
+- Port declaration annotation validation.
+- Preserve `@Recursive` as the only v1 annotation with compiler behavior.
+- Port native provider catalog validation.
+- Preserve source `@NativeProvider` as preferred declaration path.
+- Keep `--native-wiring` JSON as compatibility input.
+
+## Native Provider Diagnostics
+
+Preserve stable diagnostic terms:
+
+- `NotWired`
+- `DuplicateProvider`
+- `TypeMismatch`
+- `UnsupportedBackend`
+- `InvocationFailure`
+
+## Acceptance Criteria
+
+- Duplicate and ambiguous cases fail deterministically.
+- Provider symbol shadowing by locals/methods does not rewrite calls.
+- Provider annotation and manifest compatibility tests pass.
+- Compile-error tests for touched diagnostics pass.
+- Cross-backend e2e canary passes when backend behavior can be affected.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port type and provider validation passes
+```

--- a/.ai/TASK-8.md
+++ b/.ai/TASK-8.md
@@ -1,0 +1,41 @@
+# TASK-8: Port expression compiler passes
+
+Issue: #184
+
+## Goal
+
+Move derive expansion, expression type checking, recursion checks, and
+main/test detection into `.cfun`.
+
+## Scope
+
+- Port derive expansion.
+- Port expression type checking.
+- Port object construction and interop checks.
+- Port `@Recursive` direct tail-recursion validation.
+- Port main and test detection.
+
+## Boundary Rules
+
+- `.cfun` construction of `.coo` values remains effectful:
+  `Person(...)` or generated bridge calls must type as `Effect[Person]`, never
+  `Person`.
+- Pure object construction must be rejected.
+- OO exceptions remain user-program runtime failures, not implicit
+  `Result.Error`.
+- Compiler semantic and validation failures remain deterministic diagnostics.
+
+## Acceptance Criteria
+
+- Dual-run parity tests pass for each migrated expression pass.
+- Compile-error tests for invalid programs pass.
+- Cross-backend e2e canaries cover `.cfun` and mixed `.cfun`/`.coo` paths.
+- `./gradlew :compiler:test :compiler:integrationTest` passes.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port expression compiler passes
+```

--- a/.ai/TASK-9.md
+++ b/.ai/TASK-9.md
@@ -1,0 +1,46 @@
+# TASK-9: Port OO validation to Capybara
+
+Issue: #184
+
+## Goal
+
+Move OO validation and interop modeling without weakening `.coo` design or
+leaking statementful OO semantics into `.cfun`.
+
+## Scope
+
+- Replace or formalize raw-string expression validation from
+  `ObjectOrientedParser` and `ObjectOrientedValidator`.
+- Model OO validation for:
+  - field initialization;
+  - visibility;
+  - override/final/open/abstract rules;
+  - mutable locals and assignment;
+  - call-only statements;
+  - entrypoint restrictions;
+  - constructor/init restrictions;
+  - trait limitations.
+- Validate `.cfun`/`.coo` interop through explicit effect boundaries.
+
+## OO Requirements
+
+- Keep `.cfun` compiler core free of OO statement semantics.
+- Keep user-program OO exceptions as runtime failures.
+- Compiler validation failures must be compile diagnostics.
+- Avoid anemic wrappers and god objects.
+
+## Acceptance Criteria
+
+- `.coo` compiler tests pass.
+- OO compile-error tests pass.
+- Java, JavaScript, and Python e2e behavior remains equivalent.
+- Mixed `.cfun`/`.coo` compile-error tests cover invalid construction,
+  unsupported targets, wrong arity/types, and effect-boundary violations.
+
+## Commit Save Point
+
+Commit after this task with:
+
+```text
+feat(#184): port OO validation to Capybara
+```


### PR DESCRIPTION
## Summary
- Split the #184 self-hosting plan into TASK-1 through TASK-16 under `.ai/`.
- Preserved issue-scoped commit save points and acceptance criteria in each task.
- Kept the tasks aligned with the Capybara launching requirement: `fun main(args: List[String]): Effect[Program]` compiled to Java, with no retained production hand-written Java entrypoint.

## Verification
- Documentation/task split only; no code tests run yet.
- Performance and Build & Check timing comparison will be checked after PR creation.

Closes #184