### PR TITLE
fix(#191): avoid double exe native output

### DIFF
--- a/capy/build.gradle
+++ b/capy/build.gradle
@@ -939,6 +939,7 @@ tasks.register('nativeCompile', Exec) {
     dependsOn jarTask
 
     def outputDir = layout.buildDirectory.dir('native/nativeCompile')
+    def nativeImageOutput = outputDir.map { it.file(nativeBinaryBaseName).asFile }
     def outputBinary = outputDir.map { it.file(nativeBinaryName).asFile }
 
     inputs.files(nativeRuntimeClasspath)
@@ -957,13 +958,14 @@ tasks.register('nativeCompile', Exec) {
 
         var output = outputBinary.get()
         output.parentFile.mkdirs()
+        var imageOutput = nativeImageOutput.get()
 
         commandLine(
                 nativeImage.absolutePath,
                 '--no-fallback',
                 '-cp', nativeRuntimeClasspath.asPath,
                 mainClassName.get(),
-                output.absolutePath
+                imageOutput.absolutePath
         )
     }
 }


### PR DESCRIPTION
## Summary
- keep the Gradle nativeCompile output declaration as the platform binary name
- pass an extensionless image name to GraalVM so Windows produces capyc-<version>.exe instead of capyc-<version>.exe.exe

## Validation
- GRAALVM_HOME=<fake native-image> ./gradlew :capy:nativeCompile --no-daemon --configuration-cache
- Fresh Release run 26625913019 now gets past native compilation; Windows failed later because the binary was produced as .exe.exe

Refs #191