### PR TITLE
fix(#184): correct inferred COO peer imports

### DIFF
--- a/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -53,6 +53,7 @@ public final class JavaGenerator implements Generator {
         var primitiveBackedTypeInfo = primitiveBackedTypeInfo(program);
         var singletonTypeInfo = singletonTypeInfo(program);
         var nativeProviderInfos = nativeProviderInfos(program);
+        var topLevelTypeReferences = topLevelTypeReferences(program);
         var astBuilder = new JavaAstBuilder(functionNameOverrides, enumValueOwnerOverrides, program);
         JavaExpressionEvaluator.setFunctionNameOverrides(functionNameOverrides);
         JavaExpressionEvaluator.setStaticExtensionMethodOwners(staticExtensionMethodOwners);
@@ -66,7 +67,8 @@ public final class JavaGenerator implements Generator {
                 singletonTypeInfo,
                 nativeProviderInfos.stream()
                         .map(JavaGenerator::objectOrientedNativeProviderInfo)
-                        .toList()
+                        .toList(),
+                topLevelTypeReferences
         );
         modules.addAll(time(timings::addSourceRenderNanos, () -> objectOrientedJavaGenerator.generate(program.objectOrientedModules())));
         modules.addAll(nativeProviderBootstrapModules(nativeProviderInfos));
@@ -739,6 +741,28 @@ public final class JavaGenerator implements Generator {
             }
         }
         return !hasNameConflict || hasOwnerInterface;
+    }
+
+    private Set<String> topLevelTypeReferences(CompiledProgram program) {
+        var references = new TreeSet<String>();
+        for (var module : program.modules()) {
+            if (!staticMethodsAreNestedInOwner(module)) {
+                var packageName = buildJavaPackageName(module.path());
+                module.types().values().stream()
+                        .map(type -> normalizeJavaIdentifier(simpleTypeName(type.name()), true))
+                        .map(typeName -> packageName.isBlank() ? typeName : packageName + "." + typeName)
+                        .forEach(references::add);
+            }
+        }
+        for (var module : program.objectOrientedModules()) {
+            var packageName = buildJavaPackageName(module.path());
+            module.objectOriented().definitions().stream()
+                    .map(ObjectOriented.TypeDeclaration::name)
+                    .map(typeName -> normalizeJavaIdentifier(typeName, true))
+                    .map(typeName -> packageName.isBlank() ? typeName : packageName + "." + typeName)
+                    .forEach(references::add);
+        }
+        return Set.copyOf(references);
     }
 
     private String buildJavaPackageName(String rawPath) {

--- a/compiler/src/main/java/dev/capylang/generator/ObjectOrientedJavaGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/ObjectOrientedJavaGenerator.java
@@ -26,6 +26,7 @@ public final class ObjectOrientedJavaGenerator {
     private final Map<String, PrimitiveBackedTypeInfo> primitiveBackedTypes;
     private final Map<String, SingletonTypeInfo> singletonTypes;
     private final Map<String, List<NativeProviderInfo>> nativeProvidersByModule;
+    private final Set<String> topLevelTypeReferences;
     private int syntheticCounter = 0;
 
     public ObjectOrientedJavaGenerator() {
@@ -48,6 +49,15 @@ public final class ObjectOrientedJavaGenerator {
             Map<String, SingletonTypeInfo> singletonTypes,
             Collection<NativeProviderInfo> nativeProviders
     ) {
+        this(primitiveBackedTypes, singletonTypes, nativeProviders, Set.of());
+    }
+
+    public ObjectOrientedJavaGenerator(
+            Map<String, PrimitiveBackedTypeInfo> primitiveBackedTypes,
+            Map<String, SingletonTypeInfo> singletonTypes,
+            Collection<NativeProviderInfo> nativeProviders,
+            Collection<String> topLevelTypeReferences
+    ) {
         this.primitiveBackedTypes = Map.copyOf(primitiveBackedTypes);
         this.singletonTypes = Map.copyOf(singletonTypes);
         this.nativeProvidersByModule = nativeProviders.stream()
@@ -56,6 +66,7 @@ public final class ObjectOrientedJavaGenerator {
                         LinkedHashMap::new,
                         Collectors.toUnmodifiableList()
                 ));
+        this.topLevelTypeReferences = Set.copyOf(topLevelTypeReferences);
     }
 
     public List<GeneratedModule> generate(List<ObjectOrientedModule> modules) {
@@ -217,16 +228,26 @@ public final class ObjectOrientedJavaGenerator {
                 .filter(symbol -> !"*".equals(symbol))
                 .filter(symbol -> !symbol.isBlank())
                 .collect(Collectors.toUnmodifiableSet());
-        var ownerReference = renderOwnerReference(normalizePackageName(module.path()), module.name());
+        var packageName = normalizePackageName(module.path());
+        var ownerReference = renderOwnerReference(packageName, module.name());
         return referencedTypeTokens(module).stream()
                 .filter(symbol -> !localDefinitions.contains(symbol))
                 .filter(symbol -> !module.name().equals(symbol))
                 .filter(symbol -> !explicitlyImportedSymbols.contains(symbol))
                 .filter(symbol -> !isBuiltInTypeToken(symbol))
-                .map(symbol -> ownerReference + "." + symbol)
+                .map(symbol -> inferSameModuleImportReference(packageName, ownerReference, symbol))
+                .flatMap(Optional::stream)
                 .distinct()
                 .sorted()
                 .toList();
+    }
+
+    private Optional<String> inferSameModuleImportReference(String packageName, String ownerReference, String symbol) {
+        var peerReference = packageName.isBlank() ? symbol : packageName + "." + symbol;
+        if (topLevelTypeReferences.contains(peerReference)) {
+            return packageName.isBlank() ? Optional.empty() : Optional.of(peerReference);
+        }
+        return Optional.of(ownerReference + "." + symbol);
     }
 
     private boolean isBuiltInTypeToken(String symbol) {

--- a/compiler/src/test/java/dev/capylang/generator/ObjectOrientedJavaGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/ObjectOrientedJavaGeneratorTest.java
@@ -965,6 +965,57 @@ class ObjectOrientedJavaGeneratorTest {
         compileGeneratedJava(generatedProgram);
     }
 
+    @Test
+    void shouldInferPeerImportsForObjectOrientedInterfaceTypesInSamePackage() throws Exception {
+        var program = compileProgram(List.of(
+                new RawModule(
+                        "RawModule",
+                        "/dev/capylang/compiler/parser",
+                        """
+                                data RawModule { name: String }
+                                """,
+                        SourceKind.FUNCTIONAL
+                ),
+                new RawModule(
+                        "ParsedProgram",
+                        "/dev/capylang/compiler/parser",
+                        """
+                                from RawModule import { RawModule }
+
+                                data ParsedProgram { modules: List[RawModule] }
+                                """,
+                        SourceKind.FUNCTIONAL
+                ),
+                new RawModule(
+                        "CapybaraParser",
+                        "/dev/capylang/compiler/parser",
+                        """
+                                interface CapybaraParser {
+                                    def parse(modules: List[RawModule]): ParsedProgram
+                                }
+                                """,
+                        SourceKind.OBJECT_ORIENTED
+                )
+        ));
+
+        var generatedProgram = new JavaGenerator().generate(program);
+        var parserModule = generatedProgram.modules().stream()
+                .filter(module -> module.relativePath().equals(Path.of(
+                        "dev", "capylang", "compiler", "parser", "CapybaraParser.java"
+                )))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(parserModule.code())
+                .contains("import dev.capylang.compiler.parser.ParsedProgram;")
+                .contains("import dev.capylang.compiler.parser.RawModule;")
+                .contains("ParsedProgram parse(java.util.List<RawModule> modules);")
+                .doesNotContain("CapybaraParser.ParsedProgram")
+                .doesNotContain("CapybaraParser.RawModule");
+
+        compileGeneratedJava(generatedProgram);
+    }
+
 
     @Test
     void shouldIgnoreSingleQuotedLiteralsDuringInferredImportScan() throws Exception {


### PR DESCRIPTION
## Summary
- fix COO same-package import inference for top-level peer generated types
- preserve existing same-owner functional data imports
- add a regression covering the CapybaraParser/RawModule/ParsedProgram bootstrap shape

## Tests
- env GRADLE_USER_HOME=/tmp/capy-gradle-release ./gradlew --no-daemon --project-cache-dir /tmp/capy-gradle-release-project-cache :compiler:test --tests dev.capylang.generator.ObjectOrientedJavaGeneratorTest
- env GRADLE_USER_HOME=/tmp/capy-gradle-release ./gradlew --no-daemon --project-cache-dir /tmp/capy-gradle-release-project-cache clean check