### PR TITLE
release: 0.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 group=dev.capylang
-version=0.3.1
+version=0.3.2-SNAPSHOT
 antlrVersion=4.13.2
 junitVersion=5.13.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 group=dev.capylang
-version=0.3.1-SNAPSHOT
+version=0.3.1
 antlrVersion=4.13.2
 junitVersion=5.13.4


### PR DESCRIPTION
## Summary
- recover release workflow commits after branch rules blocked the automated push
- add `release: 0.3.1` version commit
- bump release branch to `0.3.2-SNAPSHOT`

## Context
The Release workflow run 27269460852 built artifacts and published packages, but failed when pushing to `release/0.3.x` because release branch changes must be made through a pull request.

## Tests
- Release workflow Build & Check gate passed before artifact publication
- Local `clean check` passed before the release workflow was dispatched