### PR TITLE
feat(#203): add List.sort

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/collection/ListCollection.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/collection/ListCollection.cfun
@@ -1,6 +1,7 @@
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
+from /capy/lang/Ordering import { * }
 
 fun static_list(): List[int] = [1,2,3]
 
@@ -30,6 +31,8 @@ fun is_empty(l: List[int]): bool = l.is_empty()
 
 data ListHolder { values: List[int] }
 
+data SortedItem { label: String, priority: int }
+
 fun not_is_empty(l: List[int]): bool = !l.is_empty()
 
 fun not_nested_is_empty(holder: ListHolder): bool = !holder.values.is_empty()
@@ -39,3 +42,40 @@ fun size(l: List[int]): int = l.size()
 fun let_named_list(): int =
     let list: List[int] = [1, 2, 3, 4]
     list.size()
+
+fun sort_ints_ascending(): List[int] =
+    [5, 1, 4, 1, 3].sort(:compare_int_ascending)
+
+fun sort_ints_descending(): List[int] =
+    [5, 1, 4, 1, 3].sort(:compare_int_descending)
+
+fun sort_ints_with_duplicates(): List[int] =
+    [2, 3, 2, 1, 3].sort(:compare_int_ascending)
+
+fun sort_empty_ints(): List[int] =
+    let empty: List[int] = []
+    empty.sort(:compare_int_ascending)
+
+fun sort_single_int(): List[int] =
+    [9].sort(:compare_int_ascending)
+
+fun sort_items_by_priority(): List[SortedItem] =
+    [
+        SortedItem { label: "second", priority: 2 },
+        SortedItem { label: "first-a", priority: 1 },
+        SortedItem { label: "first-b", priority: 1 },
+        SortedItem { label: "third", priority: 3 },
+    ].sort(:compare_item_priority)
+
+private fun compare_int_ascending(left: int, right: int): Ordering =
+    if left < right
+    then LESS
+    else if left > right
+        then GREATER
+        else EQUAL
+
+private fun compare_int_descending(left: int, right: int): Ordering =
+    compare_int_ascending(right, left)
+
+private fun compare_item_priority(left: SortedItem, right: SortedItem): Ordering =
+    compare_int_ascending(left.priority, right.priority)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/collection/ListCollectionCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/collection/ListCollectionCapyTest.cfun
@@ -23,6 +23,12 @@ fun tests(): Effect[TestFile] =
         test("not_nested_is_empty reads nested list field", () => list_collection_not_nested_is_empty_reads_nested_list_field()),
         test("size returns list size", () => list_collection_size_returns_list_size()),
         test("let_named_list returns local list size", () => list_collection_let_named_list_returns_local_list_size()),
+        test("sort_ints_ascending returns sorted list", () => list_collection_sort_ints_ascending_returns_sorted_list()),
+        test("sort_ints_descending returns reverse sorted list", () => list_collection_sort_ints_descending_returns_reverse_sorted_list()),
+        test("sort_ints_with_duplicates preserves duplicates", () => list_collection_sort_ints_with_duplicates_preserves_duplicates()),
+        test("sort_empty_ints returns empty list", () => list_collection_sort_empty_ints_returns_empty_list()),
+        test("sort_single_int returns single item list", () => list_collection_sort_single_int_returns_single_item_list()),
+        test("sort_items_by_priority sorts custom data stably", () => list_collection_sort_items_by_priority_sorts_custom_data_stably()),
     ])
 
 private fun list_collection_static_list_returns_expected_values(): Assert =
@@ -126,3 +132,26 @@ private fun list_collection_size_returns_list_size(): Assert =
 
 private fun list_collection_let_named_list_returns_local_list_size(): Assert =
     assert_that(let_named_list()).is_equal_to(4)
+
+private fun list_collection_sort_ints_ascending_returns_sorted_list(): Assert =
+    assert_that(sort_ints_ascending()).is_equal_to([1, 1, 3, 4, 5])
+
+private fun list_collection_sort_ints_descending_returns_reverse_sorted_list(): Assert =
+    assert_that(sort_ints_descending()).is_equal_to([5, 4, 3, 1, 1])
+
+private fun list_collection_sort_ints_with_duplicates_preserves_duplicates(): Assert =
+    assert_that(sort_ints_with_duplicates()).is_equal_to([1, 2, 2, 3, 3])
+
+private fun list_collection_sort_empty_ints_returns_empty_list(): Assert =
+    assert_that(sort_empty_ints()).is_empty()
+
+private fun list_collection_sort_single_int_returns_single_item_list(): Assert =
+    assert_that(sort_single_int()).is_equal_to([9])
+
+private fun list_collection_sort_items_by_priority_sorts_custom_data_stably(): Assert =
+    assert_that(sort_items_by_priority()).is_equal_to([
+        SortedItem { label: "first-a", priority: 1 },
+        SortedItem { label: "first-b", priority: 1 },
+        SortedItem { label: "second", priority: 2 },
+        SortedItem { label: "third", priority: 3 },
+    ])

--- a/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -74,6 +74,7 @@ public final class JavaScriptGenerator implements Generator {
             "capy/io/IO",
             "capy/io/Stdout",
             "capy/lang/Effect",
+            "capy/lang/Ordering",
             "capy/lang/Option",
             "capy/lang/Primitives",
             "capy/lang/Regex",
@@ -938,6 +939,10 @@ public final class JavaScriptGenerator implements Generator {
             }
             if (("reduce".equals(methodName) || "|>".equals(methodName) || "pipe_greater".equals(methodName)) && tailArgs.size() >= 2 && isCollectionType(receiverType)) {
                 return "capy.reduceCollection(" + receiver + ", " + tailArgs.get(0) + ", " + tailArgs.get(1) + ")";
+            }
+            if ("sort".equals(methodName) && tailArgs.size() == 1 && receiverType instanceof CollectionLinkedType.CompiledList) {
+                require("capy.collection.List");
+                return moduleVar("capy.collection.List") + ".sort(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (isPrimitiveConversion(methodName)) {
                 return renderConversion(methodName, receiver, receiverType, functionCall.type());
@@ -2821,6 +2826,8 @@ public final class JavaScriptGenerator implements Generator {
             exports.put("capy.lang.Option", Set.of("Some", "None"));
             exports.put("capy.lang.Result", Set.of("Success", "Error"));
             exports.put("capy.lang.Effect", Set.of("pure", "delay"));
+            exports.put("capy.lang.Ordering", Set.of("Ordering", "LESS", "EQUAL", "GREATER", "fromInt", "from_int", "reverse", "thenOrdering", "then_ordering"));
+            exports.put("capy.lang.OrderingModule", Set.of("Ordering", "LESS", "EQUAL", "GREATER", "fromInt", "from_int", "reverse", "thenOrdering", "then_ordering"));
             exports.put("capy.lang.Program", Set.of(
                     "Success", "Failed", "__constructor__primitive__failed_exit_code",
                     "next__name_next__failed_exit_code", "previous__name_previous__failed_exit_code",
@@ -2849,7 +2856,7 @@ public final class JavaScriptGenerator implements Generator {
                     "digits", "floor_div", "floorDiv", "floor_mod", "floorMod", "min", "max",
                     "RoundMode", "FLOOR", "CEILING", "HALF_UP", "HALF_DOWN", "HALF_EVEN", "round"
             ));
-            exports.put("capy.collection.List", Set.of("size", "get", "is_empty", "plus", "minus", "contains", "any", "all", "map", "filter", "reject", "flat_map", "flatMap", "reduce"));
+            exports.put("capy.collection.List", Set.of("size", "get", "is_empty", "plus", "minus", "contains", "any", "all", "map", "filter", "reject", "flat_map", "flatMap", "reduce", "sort"));
             exports.put("capy.collection.Set", Set.of("size", "to_list", "is_empty", "plus", "minus", "contains", "any", "all", "map", "filter", "reject", "flat_map", "flatMap", "reduce"));
             exports.put("capy.collection.Dict", Set.of("size", "entries", "get", "is_empty", "plus", "minus", "contains_key", "any", "all", "map", "filter", "reject", "reduce"));
             exports.put("capy.collection.Tuple", Set.of("get"));
@@ -2905,6 +2912,9 @@ public final class JavaScriptGenerator implements Generator {
             fields.put("None", List.of());
             fields.put("Success", List.of("value"));
             fields.put("Error", List.of("message"));
+            fields.put("LESS", List.of());
+            fields.put("EQUAL", List.of());
+            fields.put("GREATER", List.of());
             fields.put("_UnsafeEffect", List.of("unsafe_thunk"));
             fields.put("Cons", List.of("value", "rest"));
             fields.put("End", List.of());
@@ -2919,6 +2929,8 @@ public final class JavaScriptGenerator implements Generator {
                     new GeneratedModule(Path.of("capy", "lang", "Option.js"), runtimeForwarder("../../dev/capylang/capybara.js", "Some", "None")),
                     new GeneratedModule(Path.of("capy", "lang", "Result.js"), runtimeForwarder("../../dev/capylang/capybara.js", "Success", "Error")),
                     new GeneratedModule(Path.of("capy", "lang", "Effect.js"), runtimeForwarder("../../dev/capylang/capybara.js", "pure", "delay")),
+                    new GeneratedModule(Path.of("capy", "lang", "Ordering.js"), orderingRuntime()),
+                    new GeneratedModule(Path.of("capy", "lang", "OrderingModule.js"), orderingModuleRuntime()),
                     new GeneratedModule(Path.of("capy", "lang", "Program.js"), programRuntime()),
                     new GeneratedModule(Path.of("capy", "lang", "Primitives.js"), primitivesRuntime()),
                     new GeneratedModule(Path.of("capy", "lang", "String.js"), stringRuntime()),
@@ -2950,6 +2962,8 @@ public final class JavaScriptGenerator implements Generator {
                     "capy.lang.Option",
                     "capy.lang.Result",
                     "capy.lang.Effect",
+                    "capy.lang.Ordering",
+                    "capy.lang.OrderingModule",
                     "capy.lang.Program",
                     "capy.lang.Primitives",
                     "capy.lang.String",
@@ -2982,6 +2996,72 @@ public final class JavaScriptGenerator implements Generator {
                    + "module.exports = {\n"
                    + Stream.of(names).map(name -> "    " + name + ": capy." + name + ",").collect(joining("\n"))
                    + "\n};\n";
+        }
+
+        private static String orderingModuleRuntime() {
+            return "'use strict';\n"
+                   + "module.exports = require('./Ordering.js');\n";
+        }
+
+        private static String orderingRuntime() {
+            return """
+                    'use strict';
+                    const capy = require('../../dev/capylang/capybara.js');
+
+                    const Ordering = (() => {
+                        const values = [
+                            capy.enumValue('LESS', 'Ordering', ['Ordering'], 0, [], 'capy.lang', 'capy/lang/Ordering', { fields: [], annotations: [] }),
+                            capy.enumValue('EQUAL', 'Ordering', ['Ordering'], 1, [], 'capy.lang', 'capy/lang/Ordering', { fields: [], annotations: [] }),
+                            capy.enumValue('GREATER', 'Ordering', ['Ordering'], 2, [], 'capy.lang', 'capy/lang/Ordering', { fields: [], annotations: [] }),
+                        ];
+                        return Object.freeze({
+                            LESS: values[0],
+                            EQUAL: values[1],
+                            GREATER: values[2],
+                            values,
+                            valuesSet: () => capy.set(values),
+                            parse: value => capy.parseEnum(value, values, 'Ordering'),
+                        });
+                    })();
+                    const LESS = Ordering.LESS;
+                    const EQUAL = Ordering.EQUAL;
+                    const GREATER = Ordering.GREATER;
+
+                    function fromInt(value) {
+                        return value < 0 ? LESS : (value > 0 ? GREATER : EQUAL);
+                    }
+                    const from_int = fromInt;
+
+                    function reverse(ordering) {
+                        if (capy.isType(ordering, 'LESS')) {
+                            return GREATER;
+                        }
+                        if (capy.isType(ordering, 'EQUAL')) {
+                            return EQUAL;
+                        }
+                        if (capy.isType(ordering, 'GREATER')) {
+                            return LESS;
+                        }
+                        throw new Error('Non-exhaustive match expression');
+                    }
+
+                    function thenOrdering(ordering, other) {
+                        return capy.isType(ordering, 'EQUAL') ? other : ordering;
+                    }
+                    const then_ordering = thenOrdering;
+
+                    module.exports = {
+                        Ordering,
+                        LESS,
+                        EQUAL,
+                        GREATER,
+                        fromInt,
+                        from_int,
+                        reverse,
+                        thenOrdering,
+                        then_ordering,
+                    };
+                    """;
         }
 
         private static String primitivesRuntime() {
@@ -3190,6 +3270,7 @@ public final class JavaScriptGenerator implements Generator {
                    + "    flat_map: capy.flatMapCollection,\n"
                    + "    flatMap: capy.flatMapCollection,\n"
                    + "    reduce: capy.reduceCollection,\n"
+                   + "    sort: capy.listSort,\n"
                    + "};\n";
         }
 
@@ -6225,7 +6306,37 @@ public final class JavaScriptGenerator implements Generator {
 
                         function listMinus(left, right) {
                             return list(nativeArrayFilter.call(left, item => !contains(right, item)));
+                    }
+
+                    function listSort(values, compare) {
+                        const input = list(values);
+                        if (input.length <= 1) {
+                            return input;
                         }
+                        const mid = Math.floor(input.length / 2);
+                        return listSortMerge(
+                            listSort(input.slice(0, mid), compare),
+                            listSort(input.slice(mid), compare),
+                            compare
+                        );
+                    }
+
+                    function listSortMerge(left, right, compare) {
+                        const result = [];
+                        let leftIdx = 0;
+                        let rightIdx = 0;
+                        while (leftIdx < left.length && rightIdx < right.length) {
+                            const ordering = invoke(compare, left[leftIdx], right[rightIdx]);
+                            if (ordering && ordering.name === 'GREATER') {
+                                result.push(right[rightIdx]);
+                                rightIdx += 1;
+                            } else {
+                                result.push(left[leftIdx]);
+                                leftIdx += 1;
+                            }
+                        }
+                        return list(result.concat(left.slice(leftIdx), right.slice(rightIdx)));
+                    }
 
                     function setAppend(valueSet, value) {
                         const result = set(valueSet);
@@ -6765,6 +6876,7 @@ public final class JavaScriptGenerator implements Generator {
                         listPlus,
                         listRemove,
                         listMinus,
+                        listSort,
                         setAppend,
                         setPlus,
                         setRemove,

--- a/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/compiler/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -75,6 +75,7 @@ public final class PythonGenerator implements Generator {
             "capy/io/IO",
             "capy/io/Stdout",
             "capy/lang/Effect",
+            "capy/lang/Ordering",
             "capy/lang/Option",
             "capy/lang/Primitives",
             "capy/lang/Regex",
@@ -928,6 +929,10 @@ public final class PythonGenerator implements Generator {
             }
             if (("reduce".equals(methodName) || "|>".equals(methodName) || "pipe_greater".equals(methodName)) && tailArgs.size() >= 2 && isCollectionType(receiverType)) {
                 return "capy.reduce_collection(" + receiver + ", " + tailArgs.get(0) + ", " + tailArgs.get(1) + ")";
+            }
+            if ("sort".equals(methodName) && tailArgs.size() == 1 && receiverType instanceof CollectionLinkedType.CompiledList) {
+                require("capy.collection.List");
+                return moduleVar("capy.collection.List") + ".sort(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (isPrimitiveConversion(methodName)) {
                 return renderConversion(methodName, receiver, receiverType, functionCall.type());
@@ -2725,6 +2730,8 @@ public final class PythonGenerator implements Generator {
             exports.put("capy.lang.Option", Set.of("Some", "None_"));
             exports.put("capy.lang.Result", Set.of("Success", "Error"));
             exports.put("capy.lang.Effect", Set.of("pure", "delay"));
+            exports.put("capy.lang.Ordering", Set.of("Ordering", "LESS", "EQUAL", "GREATER", "fromInt", "from_int", "reverse", "thenOrdering", "then_ordering"));
+            exports.put("capy.lang.OrderingModule", Set.of("Ordering", "LESS", "EQUAL", "GREATER", "fromInt", "from_int", "reverse", "thenOrdering", "then_ordering"));
             exports.put("capy.lang.Program", Set.of(
                     "Success", "Failed", "__constructor__primitive__failed_exit_code", "capy__constructorPrimitiveFailedExitCode",
                     "next__name_next__failed_exit_code", "previous__name_previous__failed_exit_code",
@@ -2754,7 +2761,7 @@ public final class PythonGenerator implements Generator {
                     "digits", "floor_div", "floorDiv", "floor_mod", "floorMod", "min", "max",
                     "RoundMode", "FLOOR", "CEILING", "HALF_UP", "HALF_DOWN", "HALF_EVEN", "round"
             ));
-            exports.put("capy.collection.List", Set.of("size", "get", "is_empty", "plus", "minus", "contains", "any", "all", "map", "filter", "reject", "flat_map", "flatMap", "reduce"));
+            exports.put("capy.collection.List", Set.of("size", "get", "is_empty", "plus", "minus", "contains", "any", "all", "map", "filter", "reject", "flat_map", "flatMap", "reduce", "sort"));
             exports.put("capy.collection.Set", Set.of("size", "to_list", "is_empty", "plus", "minus", "contains", "any", "all", "map", "filter", "reject", "flat_map", "flatMap", "reduce"));
             exports.put("capy.collection.Dict", Set.of("size", "entries", "get", "is_empty", "plus", "minus", "contains_key", "any", "all", "map", "filter", "reject", "reduce"));
             exports.put("capy.collection.Tuple", Set.of("get"));
@@ -2804,6 +2811,9 @@ public final class PythonGenerator implements Generator {
             fields.put("None_", List.of());
             fields.put("Success", List.of("value"));
             fields.put("Error", List.of("message"));
+            fields.put("LESS", List.of());
+            fields.put("EQUAL", List.of());
+            fields.put("GREATER", List.of());
             fields.put("_UnsafeEffect", List.of("unsafe_thunk"));
             fields.put("Cons", List.of("value", "rest"));
             fields.put("End", List.of());
@@ -2818,6 +2828,8 @@ public final class PythonGenerator implements Generator {
                     new GeneratedModule(Path.of("capy", "lang", "Option.py"), runtimeForwarder("Some", "None_")),
                     new GeneratedModule(Path.of("capy", "lang", "Result.py"), runtimeForwarder("Success", "Error")),
                     new GeneratedModule(Path.of("capy", "lang", "Effect.py"), runtimeForwarder("pure", "delay")),
+                    new GeneratedModule(Path.of("capy", "lang", "Ordering.py"), orderingRuntime()),
+                    new GeneratedModule(Path.of("capy", "lang", "OrderingModule.py"), orderingModuleRuntime()),
                     new GeneratedModule(Path.of("capy", "lang", "Program.py"), programRuntime()),
                     new GeneratedModule(Path.of("capy", "lang", "Primitives.py"), primitivesRuntime()),
                     new GeneratedModule(Path.of("capy", "lang", "String.py"), stringRuntime()),
@@ -2849,6 +2861,8 @@ public final class PythonGenerator implements Generator {
                     "capy.lang.Option",
                     "capy.lang.Result",
                     "capy.lang.Effect",
+                    "capy.lang.Ordering",
+                    "capy.lang.OrderingModule",
                     "capy.lang.Program",
                     "capy.lang.Primitives",
                     "capy.lang.String",
@@ -2878,6 +2892,58 @@ public final class PythonGenerator implements Generator {
         private static String runtimeForwarder(String... names) {
             return "# Generated by Capybara. Do not edit.\n"
                    + "from dev.capylang.capybara import " + String.join(", ", names) + "\n";
+        }
+
+        private static String orderingModuleRuntime() {
+            return "# Generated by Capybara. Do not edit.\n"
+                   + "from capy.lang.Ordering import *\n";
+        }
+
+        private static String orderingRuntime() {
+            return """
+                    # Generated by Capybara. Do not edit.
+                    import dev.capylang.capybara as capy
+
+                    _Ordering_values = [
+                        capy.enum_value('LESS', 'Ordering', ['Ordering'], 0, [], 'capy.lang', 'capy/lang/Ordering', {'fields': [], 'annotations': []}),
+                        capy.enum_value('EQUAL', 'Ordering', ['Ordering'], 1, [], 'capy.lang', 'capy/lang/Ordering', {'fields': [], 'annotations': []}),
+                        capy.enum_value('GREATER', 'Ordering', ['Ordering'], 2, [], 'capy.lang', 'capy/lang/Ordering', {'fields': [], 'annotations': []}),
+                    ]
+                    class Ordering:
+                        values = _Ordering_values
+                        LESS = values[0]
+                        EQUAL = values[1]
+                        GREATER = values[2]
+
+                        @staticmethod
+                        def valuesSet():
+                            return capy.set_(Ordering.values)
+
+                        @staticmethod
+                        def parse(value):
+                            return capy.parse_enum(value, Ordering.values, 'Ordering')
+
+                    LESS = Ordering.LESS
+                    EQUAL = Ordering.EQUAL
+                    GREATER = Ordering.GREATER
+
+                    def fromInt(value):
+                        return LESS if value < 0 else (GREATER if value > 0 else EQUAL)
+                    from_int = fromInt
+
+                    def reverse(ordering):
+                        if capy.is_type(ordering, 'LESS'):
+                            return GREATER
+                        if capy.is_type(ordering, 'EQUAL'):
+                            return EQUAL
+                        if capy.is_type(ordering, 'GREATER'):
+                            return LESS
+                        raise ValueError('Non-exhaustive match expression')
+
+                    def thenOrdering(ordering, other):
+                        return other if capy.is_type(ordering, 'EQUAL') else ordering
+                    then_ordering = thenOrdering
+                    """;
         }
 
         private static String primitivesRuntime() {
@@ -3042,6 +3108,7 @@ public final class PythonGenerator implements Generator {
                     flat_map = capy.flat_map_collection
                     flatMap = capy.flat_map_collection
                     reduce = capy.reduce_collection
+                    sort = capy.list_sort
                     """;
         }
 
@@ -4051,6 +4118,7 @@ public final class PythonGenerator implements Generator {
                         def reduce_left(self, initial, reducer): return self.reduce(initial, reducer)
                         def pipeGreater(self, initial, reducer): return reduce_collection(self, initial, reducer)
                         def pipe_greater(self, initial, reducer): return self.pipeGreater(initial, reducer)
+                        def sort(self, compare): return list_sort(self, compare)
 
                     class CapySet:
                         def __init__(self, values=None):
@@ -4250,6 +4318,25 @@ public final class PythonGenerator implements Generator {
                     def list_plus(left, right): return CapyList(list(left) + list(right))
                     def list_remove(value_list, value): return CapyList([item for item in value_list if not equals(item, value)])
                     def list_minus(left, right): return CapyList([item for item in left if not contains(right, item)])
+                    def list_sort(values, compare):
+                        values = CapyList(values)
+                        if len(values) <= 1:
+                            return values
+                        mid = len(values) // 2
+                        return list_sort_merge(list_sort(values[:mid], compare), list_sort(values[mid:], compare), compare)
+                    def list_sort_merge(left, right, compare):
+                        result = []
+                        left_idx = 0
+                        right_idx = 0
+                        while left_idx < len(left) and right_idx < len(right):
+                            ordering = invoke(compare, left[left_idx], right[right_idx])
+                            if getattr(ordering, 'name', None) == 'GREATER':
+                                result.append(right[right_idx])
+                                right_idx += 1
+                            else:
+                                result.append(left[left_idx])
+                                left_idx += 1
+                        return CapyList(result + list(left[left_idx:]) + list(right[right_idx:]))
                     def set_append(value_set, value): return set_(list(value_set) + [value])
                     def set_plus(left, right): return set_(list(left) + list(right))
                     def set_remove(value_set, value): return set_([item for item in value_set if not equals(item, value)])

--- a/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/compiler/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -57,7 +57,7 @@ public class JavaExpressionEvaluator {
                 "capy.collection.List",
                 java.util.List.of("List"),
                 "is_empty", "plus", "minus", "any", "all", "contains", "?", "reduce", "|>",
-                "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*"
+                "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*", "sort"
         );
         registerStandardExtensionMethods(
                 owners,

--- a/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
@@ -1,4 +1,5 @@
 from /capy/lang/Option import { * }
+from /capy/lang/Ordering import { * }
 from /capy/lang/Seq import { * }
 from /capy/collection/CollectionTypes import { * }
 from /capy/meta_prog/Recursive import { Recursive }
@@ -130,8 +131,37 @@ fun List[T].flat_map(map: T => List[Y]): Seq[Y] = to_seq(this.reduce([], (acc, v
 /// Applies `map` to each value and concatenates the resulting lists.
 fun List[T].`|*`(map: T => List[Y]): Seq[Y] = this.flat_map(map)
 
+/// Returns this List sorted with `compare`.
+///
+/// The sort is stable: values that compare as `EQUAL` keep their original order.
+fun List[T].sort(compare: (T, T) => Ordering): List[T] = sort_list(this, compare)
+
 /// Returns the value at idx using the same bounds and negative-index rules as list[idx].
 fun List[T].get(idx: index): Option[T] = <native>
 
 /// Returns the values in the half-open range [from, to) using the same bounds and negative-index rules as list[from:to].
 fun List[T].get(from: int, to: int): List[T] = <native>
+
+private fun sort_list(list: List[T], compare: (T, T) => Ordering): List[T] =
+    if list.size() <= 1
+    then list
+    else merge_sorted(
+        sort_list(list.get(0, list.size().value / 2), compare),
+        0,
+        sort_list(list.get(list.size().value / 2, list.size().value), compare),
+        0,
+        compare,
+        []
+    )
+
+@Recursive
+private fun merge_sorted(left: List[T], left_idx: int, right: List[T], right_idx: int, compare: (T, T) => Ordering, acc: List[T]): List[T] =
+    match left[left_idx] with
+    case None -> acc + right.get(right_idx, right.size().value)
+    case Some { left_value } ->
+        match right[right_idx] with
+        case None -> acc + left.get(left_idx, left.size().value)
+        case Some { right_value } ->
+            match compare(left_value, right_value) with
+            case GREATER -> merge_sorted(left, left_idx, right, right_idx + 1, compare, acc + right_value)
+            case _ -> merge_sorted(left, left_idx + 1, right, right_idx, compare, acc + left_value)

--- a/lib/capybara-lib/src/test/capybara/capy/collection/ListTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/collection/ListTest.cfun
@@ -1,10 +1,13 @@
 from /capy/test/Assert import { * }
 from /capy/collection/CollectionTypes import { * }
 from /capy/lang/Effect import { * }
+from /capy/lang/Ordering import { * }
 from /capy/lang/Result import { * }
 from /capy/lang/Seq import { * }
 from /capy/collection/List import { * }
 from /capy/test/CapyTest import { * }
+
+data SortRecord { name: String, rank: int }
 
 fun tests(): Effect[TestFile] =
     test_file("/capy/collection/List.cfun", [
@@ -17,6 +20,8 @@ fun tests(): Effect[TestFile] =
         test("should map values", () => list_should_map_values()),
         test("should filter and reject values", () => list_should_filter_and_reject_values()),
         test("should flat map values", () => list_should_flat_map_values()),
+        test("should sort values with comparator", () => list_should_sort_values_with_comparator()),
+        test("should sort custom data stably", () => list_should_sort_custom_data_stably()),
         test("should get values by index", () => list_should_get_values_by_index()),
         test("should get values by range", () => list_should_get_values_by_range()),
     ])
@@ -91,6 +96,30 @@ fun list_should_flat_map_values(): Assert =
         assert_that([3].flat_map(value => [value, value * 2]).as_list()).is_equal_to([3, 6]),
     ])
 
+fun list_should_sort_values_with_comparator(): Assert =
+    let empty: List[int] = []
+    assert_all([
+        assert_that([5, 1, 4, 1, 3].sort(:compare_int_ascending)).is_equal_to([1, 1, 3, 4, 5]),
+        assert_that([5, 1, 4, 1, 3].sort(:compare_int_descending)).is_equal_to([5, 4, 3, 1, 1]),
+        assert_that([2, 3, 2, 1, 3].sort(:compare_int_ascending)).is_equal_to([1, 2, 2, 3, 3]),
+        assert_that(empty.sort(:compare_int_ascending)).is_empty(),
+        assert_that([9].sort(:compare_int_ascending)).is_equal_to([9]),
+    ])
+
+fun list_should_sort_custom_data_stably(): Assert =
+    let values = [
+        SortRecord { name: "second", rank: 2 },
+        SortRecord { name: "first-a", rank: 1 },
+        SortRecord { name: "first-b", rank: 1 },
+        SortRecord { name: "third", rank: 3 },
+    ]
+    assert_that(values.sort(:compare_sort_record_rank)).is_equal_to([
+        SortRecord { name: "first-a", rank: 1 },
+        SortRecord { name: "first-b", rank: 1 },
+        SortRecord { name: "second", rank: 2 },
+        SortRecord { name: "third", rank: 3 },
+    ])
+
 fun list_should_get_values_by_index(): Assert =
     let values = [10, 20, 30, 40]
     assert_all([
@@ -113,3 +142,16 @@ private fun list_test_index(value: int): index =
     match index { value } with
     case Success { parsed } -> parsed
     case Error -> FIRST_ELEMENT
+
+private fun compare_int_ascending(left: int, right: int): Ordering =
+    if left < right
+    then LESS
+    else if left > right
+        then GREATER
+        else EQUAL
+
+private fun compare_int_descending(left: int, right: int): Ordering =
+    compare_int_ascending(right, left)
+
+private fun compare_sort_record_rank(left: SortRecord, right: SortRecord): Ordering =
+    compare_int_ascending(left.rank, right.rank)


### PR DESCRIPTION
## Summary
- Add stable `List[T].sort(compare: (T, T) => Ordering)` implemented with merge sort in the Capybara standard library.
- Use the existing `/capy/lang/Ordering` enum instead of introducing a duplicate comparison result type.
- Add standard-library and functional e2e coverage for ascending/descending ints, duplicates, empty/single lists, and stable custom-data sorting.
- Wire Java, JavaScript, and Python generator/runtime support so `List.sort` resolves consistently across backends.

## Impacted modules
- `lib/capybara-lib`
- `capy` e2e functional tests
- JS/Python/Java generator runtime dispatch for standard library list sorting

## Commands run
- `./gradlew :lib:capybara-lib:compileCapybara`
- `./gradlew :capy:e2e-cfun`
- `./gradlew :lib:capybara-lib:testCapybara`
- `./gradlew :compiler:compileJava --no-daemon`
- `./gradlew :capy:e2e-cfun --no-daemon`
- `./gradlew :lib:capybara-lib:testCapybara --no-daemon`
- `./gradlew clean check --no-daemon`