### PR TITLE
fix(#207): run merge back for all release pushes

### DIFF
--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "release/*"
-    paths:
-      - "gradle.properties"
 
 permissions:
   actions: write


### PR DESCRIPTION
## What changed

- Removed the `paths` filter from `Merge Back` so every push to `release/*` runs the merge-back job, not only pushes touching `gradle.properties`.

## Why

- Release branches can receive non-version changes that still need to merge back to the default branch.
- The workflow already validates the `release/{major}.{minor}.x` branch shape inside the job.

## Validation

- `git diff --check`
- `shellcheck` on the merge-back bash block, with the GitHub default-branch expression substituted for static analysis
- `cspell` on the workflow file with project/tool tokens normalized
- `actionlint .github/workflows/merge_back.yml` using the temporary official v1.7.7 binary
