### PR TITLE
fix(#207): fetch release merge-back refs safely

### DIFF
--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -51,11 +51,13 @@ jobs:
             exit 1
           fi
 
-          git fetch origin "${RELEASE_BRANCH}:${RELEASE_BRANCH}" "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
-          git checkout "${DEFAULT_BRANCH}"
+          git fetch origin \
+            "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}" \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
 
           set +e
-          git merge --no-ff --no-commit "${RELEASE_BRANCH}"
+          git merge --no-ff --no-commit "origin/${RELEASE_BRANCH}"
           MERGE_STATUS=$?
           set -e
 


### PR DESCRIPTION
## What changed

- Fetch merge-back inputs into `refs/remotes/origin/*` instead of local branch refs.
- Check out the default branch from `origin/${DEFAULT_BRANCH}` before merging.
- Merge `origin/${RELEASE_BRANCH}` so the job does not depend on the checked-out release branch name.

## Why

- The merged workflow failed on https://github.com/magx2/Capybara/actions/runs/27511552308/job/81312424931 because Actions checked out `release/0.3.x`, then the script tried to fetch into the checked-out local `release/0.3.x` branch.
- Git rejected that with: `fatal: refusing to fetch into branch ... checked out`.

## Validation

- `git diff --check`
- `shellcheck` on the merge-back bash block, with the GitHub default-branch expression substituted for static analysis
- `cspell` on the workflow file with project/tool tokens normalized
- `actionlint .github/workflows/merge_back.yml` using the temporary official v1.7.7 binary
- Temporary-clone dry run from `origin/release/0.3.x` verified the updated fetch/checkout/merge path reaches the merge commit point; push and workflow dispatch were replaced by echo
