### PR TITLE
fix(#207): merge back through pull request

### DIFF
--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: write
   contents: write
+  pull-requests: write
 
 concurrency:
   group: merge-back-${{ github.event.repository.default_branch }}
@@ -38,7 +39,7 @@ jobs:
           git config user.name "CapyAutomata"
           git config user.email "CapyAutomata@capylang.dev"
 
-      - name: Merge release branch into default branch
+      - name: Create merge-back pull request
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -46,39 +47,95 @@ jobs:
           set -euo pipefail
           RELEASE_BRANCH="${GITHUB_REF_NAME}"
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          BACK_BRANCH="merge-back/${RELEASE_BRANCH//\//-}-to-${DEFAULT_BRANCH}"
+          STATE_BRANCH="merge-back-state/${RELEASE_BRANCH//\//-}-to-${DEFAULT_BRANCH}"
           if [[ ! "${RELEASE_BRANCH}" =~ ^release/[0-9]+\.[0-9]+\.x$ ]]; then
             echo "::error::Merge Back requires a release/{major}.{minor}.x branch, got '${RELEASE_BRANCH}'."
             exit 1
           fi
 
-          git fetch origin \
-            "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}" \
-            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
-          git checkout -B "${DEFAULT_BRANCH}" "origin/${DEFAULT_BRANCH}"
+          resolve_conflicts() {
+            local gradle_side="$1"
+            local conflicts
+            conflicts="$(git diff --name-only --diff-filter=U)"
+            if [[ -z "${conflicts}" ]]; then
+              return 0
+            fi
 
-          set +e
-          git merge --no-ff --no-commit "origin/${RELEASE_BRANCH}"
-          MERGE_STATUS=$?
-          set -e
-
-          if [[ "${MERGE_STATUS}" -ne 0 ]]; then
-            CONFLICTS="$(git diff --name-only --diff-filter=U)"
-            if [[ "${CONFLICTS}" == "gradle.properties" ]]; then
-              git checkout --ours gradle.properties
+            if [[ "${conflicts}" == "gradle.properties" ]]; then
+              git checkout "${gradle_side}" gradle.properties
               git add gradle.properties
             else
               echo "::error::Merge conflict outside gradle.properties. Conflicting files:"
-              printf '%s\n' "${CONFLICTS}"
+              printf '%s\n' "${conflicts}"
               exit 1
             fi
+          }
+
+          merge_ref() {
+            local ref="$1"
+            local gradle_side="$2"
+            local message="$3"
+
+            set +e
+            git merge --no-ff --no-commit "${ref}"
+            local merge_status=$?
+            set -e
+
+            if [[ "${merge_status}" -ne 0 ]]; then
+              resolve_conflicts "${gradle_side}"
+            fi
+
+            if [[ -n "$(git diff --name-only --diff-filter=U)" ]]; then
+              echo "::error::Unresolved merge conflicts remain:"
+              git diff --name-only --diff-filter=U
+              exit 1
+            fi
+
+            if git rev-parse -q --verify MERGE_HEAD >/dev/null; then
+              git commit -m "${message}"
+            fi
+          }
+
+          git fetch origin \
+            "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}" \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+
+          if git ls-remote --exit-code --heads origin "${STATE_BRANCH}" >/dev/null; then
+            git fetch origin "+refs/heads/${STATE_BRANCH}:refs/remotes/origin/${STATE_BRANCH}"
+            git checkout -B "${STATE_BRANCH}" "origin/${STATE_BRANCH}"
+            merge_ref "origin/${DEFAULT_BRANCH}" "--theirs" "merge ${DEFAULT_BRANCH} into ${STATE_BRANCH}"
+          else
+            git checkout -B "${STATE_BRANCH}" "origin/${DEFAULT_BRANCH}"
           fi
 
-          if [[ -z "$(git diff --name-only --diff-filter=U)" ]]; then
-            if git rev-parse -q --verify MERGE_HEAD >/dev/null; then
-              git commit -m "merge: ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}"
-              git push origin "HEAD:${DEFAULT_BRANCH}"
-              gh workflow run check.yml --ref "${DEFAULT_BRANCH}"
-            else
-              echo "Default branch already contains ${RELEASE_BRANCH}."
-            fi
+          merge_ref "origin/${RELEASE_BRANCH}" "--ours" "merge ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}"
+          git branch -f "${BACK_BRANCH}" HEAD
+
+          if git diff --quiet "origin/${DEFAULT_BRANCH}" HEAD; then
+            echo "Default branch already contains ${RELEASE_BRANCH}."
+            exit 0
           fi
+
+          git push --force-with-lease origin "HEAD:${STATE_BRANCH}" "HEAD:${BACK_BRANCH}"
+
+          PR_URL="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${BACK_BRANCH}" \
+            --base "${DEFAULT_BRANCH}" \
+            --state open \
+            --json url \
+            --jq '.[0].url // empty')"
+          if [[ -n "${PR_URL}" ]]; then
+            echo "Merge-back pull request already exists: ${PR_URL}"
+          else
+            PR_URL="$(gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base "${DEFAULT_BRANCH}" \
+              --head "${BACK_BRANCH}" \
+              --title "merge back ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}" \
+              --body "Automated merge-back from \`${RELEASE_BRANCH}\` into \`${DEFAULT_BRANCH}\`. This PR branch preserves merge ancestry; use squash merge to keep \`${DEFAULT_BRANCH}\` linear.")"
+            echo "Created merge-back pull request: ${PR_URL}"
+          fi
+
+          gh workflow run check.yml --ref "${BACK_BRANCH}"


### PR DESCRIPTION
## What changed

- Changed the merge-back job to create/update an automation PR branch instead of pushing directly to `master`.
- Preserves merge ancestry on a persistent `merge-back-state/...` branch with real merge commits.
- Mirrors the state branch commit to the PR head branch `merge-back/...`, so the PR can still be squash-merged into `master` to satisfy linear-history rules.
- Keeps the `master` copy of `gradle.properties` when that is the only release merge conflict, matching the existing release-version conflict policy.
- Adds `pull-requests: write` for the workflow token.
- Dispatches `check.yml` for the generated merge-back branch.

## Why

- The previous run reached the push step, but repository rules rejected direct writes to `master`.
- A squash-only automation branch would lose release merge ancestry and could re-merge old release changes on later release pushes.
- The repository deletes merged PR branches, so ancestry must be stored separately from the PR head branch.

Failed run: https://github.com/magx2/Capybara/actions/runs/27511868546/job/81313307070

## Validation

- `git diff --check`
- `shellcheck` on the merge-back bash block, with the GitHub default-branch expression substituted for static analysis
- `cspell` on the workflow file with project/tool tokens normalized
- `actionlint .github/workflows/merge_back.yml` using the temporary official v1.7.7 binary
- Temporary-clone dry run verified initial state-branch creation produces a two-parent merge commit
- Synthetic repeated-run dry run verified a later release edit to a previously touched file merges cleanly from the preserved state branch after a simulated squash merge into `master`
