### PR TITLE
fix(#207): keep merge-back PR branch linear

### DIFF
--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -110,14 +110,18 @@ jobs:
           fi
 
           merge_ref "origin/${RELEASE_BRANCH}" "--ours" "merge ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}"
-          git branch -f "${BACK_BRANCH}" HEAD
+          STATE_HEAD="$(git rev-parse HEAD)"
 
-          if git diff --quiet "origin/${DEFAULT_BRANCH}" HEAD; then
+          if git diff --quiet "origin/${DEFAULT_BRANCH}" "${STATE_HEAD}"; then
             echo "Default branch already contains ${RELEASE_BRANCH}."
             exit 0
           fi
 
-          git push --force-with-lease origin "HEAD:${STATE_BRANCH}" "HEAD:${BACK_BRANCH}"
+          git checkout -B "${BACK_BRANCH}" "origin/${DEFAULT_BRANCH}"
+          git diff --binary "origin/${DEFAULT_BRANCH}" "${STATE_HEAD}" | git apply --index
+          git commit -m "merge back ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}"
+
+          git push --force-with-lease origin "${STATE_HEAD}:refs/heads/${STATE_BRANCH}" "HEAD:${BACK_BRANCH}"
 
           PR_URL="$(gh pr list \
             --repo "${GITHUB_REPOSITORY}" \
@@ -134,7 +138,7 @@ jobs:
               --base "${DEFAULT_BRANCH}" \
               --head "${BACK_BRANCH}" \
               --title "merge back ${RELEASE_BRANCH} into ${DEFAULT_BRANCH}" \
-              --body "Automated merge-back from \`${RELEASE_BRANCH}\` into \`${DEFAULT_BRANCH}\`. This PR branch preserves merge ancestry; use squash merge to keep \`${DEFAULT_BRANCH}\` linear.")"
+              --body "Automated merge-back from \`${RELEASE_BRANCH}\` into \`${DEFAULT_BRANCH}\`. The \`${STATE_BRANCH}\` branch preserves merge ancestry, while this PR branch stays linear for \`${DEFAULT_BRANCH}\`.")"
             echo "Created merge-back pull request: ${PR_URL}"
           fi
 


### PR DESCRIPTION
## What changed

- Keep merge-back ancestry on the persistent `merge-back-state/...` branch.
- Rebuild the visible `merge-back/...` PR branch from `origin/${DEFAULT_BRANCH}` and apply the state-branch diff as a normal one-parent commit.
- Update the generated PR body to explain that ancestry is preserved on the state branch while the PR branch stays linear.

## Why

- PR #213 was mergeable and green, but GitHub reported that it could not be rebased because the visible PR branch contained a merge commit.
- The state branch needs merge ancestry for future release pushes, but the visible PR branch does not.

## Validation

- `git diff --check`
- `shellcheck` on the merge-back bash block, with the GitHub default-branch expression substituted for static analysis
- `cspell` on the workflow file with project/tool tokens normalized
- `actionlint .github/workflows/merge_back.yml` using the temporary official v1.7.7 binary
- Temporary-clone dry run against the real `merge-back-state/release-0.3.x-to-master` verified state branch has 2 parents and generated PR branch has 1 parent
