### PR TITLE
fix(#209): decode escaped newlines in string literals

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SimpleFunction.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SimpleFunction.cfun
@@ -19,6 +19,14 @@ fun is_positive(x: int): bool = x > 0
 
 fun greet(name: String): String = "Hello, " + name
 
+fun escaped_newline_concat(): String = "first line\n" + "second line"
+
+fun escaped_newline_interpolation(title: String): String = "title: {title}\n" + "body"
+
+fun multiple_escaped_newline_concat(): String = "header\n" + "\n" + "content\n"
+
+fun escaped_backslash_n_concat(): String = "literal\\n" + "text"
+
 fun double_then_classify(x: int): String =
     if (x * 2 > 0) then "positive" else "non-positive"
 
@@ -106,4 +114,3 @@ fun typed_let_dict(): Dict[int] =
         let v: Dict[int] = {"a": 1, "b": 2}
         v
     }
-

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SimpleFunctionCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SimpleFunctionCapyTest.cfun
@@ -10,6 +10,10 @@ fun tests(): Effect[TestFile] =
         test("arithmetic functions evaluate basic integer operations", () => arithmetic_functions_evaluate_basic_integer_operations()),
         test("is_positive returns true only for positive integers", () => is_positive_returns_true_only_for_positive_integers()),
         test("greet prefixes the provided name", () => greet_prefixes_the_provided_name()),
+        test("escaped newline concatenation produces line breaks", () => escaped_newline_concatenation_produces_line_breaks()),
+        test("escaped newline interpolation produces line breaks", () => escaped_newline_interpolation_produces_line_breaks()),
+        test("multiple escaped newline concatenation preserves each break", () => multiple_escaped_newline_concatenation_preserves_each_break()),
+        test("escaped backslash newline stays literal", () => escaped_backslash_newline_stays_literal()),
         test("double_then_classify classifies the doubled integer", () => double_then_classify_classifies_the_doubled_integer()),
         test("order_of_expression preserves grouped expression evaluation order", () => order_of_expression_preserves_grouped_expression_evaluation_order()),
         test("power evaluates integer exponents", () => power_evaluates_integer_exponents()),
@@ -48,6 +52,18 @@ private fun is_positive_returns_true_only_for_positive_integers(): Assert =
 
 private fun greet_prefixes_the_provided_name(): Assert =
     assert_that(greet("World")).is_equal_to("Hello, World")
+
+private fun escaped_newline_concatenation_produces_line_breaks(): Assert =
+    assert_that(escaped_newline_concat()).is_equal_to('first line' + '\n' + 'second line')
+
+private fun escaped_newline_interpolation_produces_line_breaks(): Assert =
+    assert_that(escaped_newline_interpolation("Capybara")).is_equal_to('title: Capybara' + '\n' + 'body')
+
+private fun multiple_escaped_newline_concatenation_preserves_each_break(): Assert =
+    assert_that(multiple_escaped_newline_concat()).is_equal_to('header' + '\n' + '\n' + 'content' + '\n')
+
+private fun escaped_backslash_newline_stays_literal(): Assert =
+    assert_that(escaped_backslash_n_concat()).is_equal_to('literal' + '\\' + 'n' + 'text')
 
 private fun double_then_classify_classifies_the_doubled_integer(): Assert =
     assert_all([

--- a/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
+++ b/compiler/src/main/java/dev/capylang/compiler/parser/CapybaraParser.java
@@ -3118,9 +3118,21 @@ public class CapybaraParser {
     }
 
     private static String quoteDoubleQuotedSegment(String content) {
-        return "\"" + content
-                .replace("\\", "\\\\")
-                .replace("\"", "\\\"") + "\"";
+        var quoted = new StringBuilder(content.length() + 2);
+        quoted.append('"');
+        for (var i = 0; i < content.length(); i++) {
+            var ch = content.charAt(i);
+            switch (ch) {
+                case '\\' -> quoted.append("\\\\");
+                case '"' -> quoted.append("\\\"");
+                case '\n' -> quoted.append("\\n");
+                case '\r' -> quoted.append("\\r");
+                case '\t' -> quoted.append("\\t");
+                default -> quoted.append(ch);
+            }
+        }
+        quoted.append('"');
+        return quoted.toString();
     }
 
     private static String normalizeDoubleQuotedContent(String content) {
@@ -3129,15 +3141,34 @@ public class CapybaraParser {
             var ch = content.charAt(i);
             if (ch == '\\' && i + 1 < content.length()) {
                 var next = content.charAt(i + 1);
-                if (next == '"' || next == '\\') {
-                    normalized.append(next);
-                    i++;
-                    continue;
-                }
-                if (next == '{') {
-                    normalized.append('\\').append('{');
-                    i++;
-                    continue;
+                switch (next) {
+                    case 'n' -> {
+                        normalized.append('\n');
+                        i++;
+                        continue;
+                    }
+                    case 'r' -> {
+                        normalized.append('\r');
+                        i++;
+                        continue;
+                    }
+                    case 't' -> {
+                        normalized.append('\t');
+                        i++;
+                        continue;
+                    }
+                    case '"', '\\' -> {
+                        normalized.append(next);
+                        i++;
+                        continue;
+                    }
+                    case '{' -> {
+                        normalized.append('\\').append('{');
+                        i++;
+                        continue;
+                    }
+                    default -> {
+                    }
                 }
             }
             normalized.append(ch);
@@ -3157,9 +3188,7 @@ public class CapybaraParser {
         }
         if (raw.charAt(0) == '"' && raw.charAt(raw.length() - 1) == '"') {
             var content = normalizeDoubleQuotedContent(raw.substring(1, raw.length() - 1));
-            return "\"" + content
-                    .replace("\\", "\\\\")
-                    .replace("\"", "\\\"") + "\"";
+            return quoteDoubleQuotedSegment(content);
         }
         if (raw.charAt(0) == '\'' && raw.charAt(raw.length() - 1) == '\'') {
             var content = raw.substring(1, raw.length() - 1)

--- a/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/compiler/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -607,6 +607,23 @@ class CapybaraParserTest {
     }
 
     @Test
+    @DisplayName("should normalize escaped newlines in concatenated double quoted strings")
+    void parseEscapedNewlinesInConcatenatedDoubleQuotedStrings() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                fun joined(): String = "first\\n" + "second"
+                """));
+
+        var function = findFunction("joined", module.functional());
+
+        assertThat(function.expression()).isInstanceOfSatisfying(InfixExpression.class, expression -> {
+            assertThat(expression.left()).isInstanceOfSatisfying(StringValue.class, value ->
+                    assertThat(value.stringValue()).isEqualTo("\"first\\n\""));
+            assertThat(expression.right()).isInstanceOfSatisfying(StringValue.class, value ->
+                    assertThat(value.stringValue()).isEqualTo("\"second\""));
+        });
+    }
+
+    @Test
     @DisplayName("should parse native data declaration")
     void parseNativeDataDeclaration() {
         var module = parseSuccess(new RawModule("String", "/capy/lang", "data String { <native> }"));


### PR DESCRIPTION
## What changed
- Decodes standard double-quoted Capybara string escapes (`\n`, `\r`, `\t`, `\"`, `\\`) during parser normalization.
- Re-quotes normalized string content as backend-safe literal text for the existing Java/Python/JavaScript generator contract.
- Preserves escaped interpolation behavior, including literal `\{` and `\{{expr}}` handling.
- Adds parser and functional e2e regression coverage for concatenated newline strings, interpolation plus newline, repeated newline concatenation, and literal visible `\n` text via `\\n`.

## Why
Double-quoted literals kept `\n` as visible backslash-plus-`n`, so concatenated strings generated runtime text like `first line\nsecond line` instead of a real line break.

## Impacted modules
- `compiler`
- `capy`

## Sample `.cfun` cases
```cfun
"first line\n" + "second line"
"title: {title}\n" + "body"
"header\n" + "\n" + "content\n"
"literal\\n" + "text"
```

## Validation
- `./gradlew :compiler:test --tests dev.capylang.parser.CapybaraParserTest`
- `./gradlew :capy:e2e-cfun`
- `./gradlew clean test`
