### PR TITLE
test(#206): cover string-backed compare dispatch

### DIFF
--- a/compiler/src/test/java/dev/capylang/generator/PrimitiveBackedTypeGeneratorTest.java
+++ b/compiler/src/test/java/dev/capylang/generator/PrimitiveBackedTypeGeneratorTest.java
@@ -132,6 +132,28 @@ class PrimitiveBackedTypeGeneratorTest {
     }
 
     @Test
+    void shouldDispatchStringBackedCompareMethodsInJavaScriptAndPython() {
+        var program = compileProgram(List.of(new RawModule("Tokens", "/foo", """
+                type token -> String
+
+                fun token.compare(other: token): bool = this.value == other.value
+                fun tokens_match(left: token, right: token): bool = left.compare(right)
+                """)));
+
+        var js = generatedCode(new JavaScriptGenerator(), program, Path.of("foo", "Tokens.js"));
+        var python = generatedCode(new PythonGenerator(), program, Path.of("foo", "Tokens.py"));
+
+        assertThat(js)
+                .contains("function compare__name_compare__token__token(this_, other)")
+                .contains("return compare__name_compare__token__token(left, right);")
+                .doesNotContain("__module_capy_lang_String.compare(left, right)");
+        assertThat(python)
+                .contains("def compare__name_compare__token__token(this_, other):")
+                .contains("return compare__name_compare__token__token(left, right)")
+                .doesNotContain("capy_module_capy_lang_String.compare(left, right)");
+    }
+
+    @Test
     void shouldNotShadowPythonRuntimeWithPrimitiveBackedConstructorAliases() {
         var program = compileProgram(List.of(new RawModule("Numbers", "/foo", """
                 from /capy/lang/Result import { * }


### PR DESCRIPTION
## What changed

- Added a focused generator regression test for custom `String`-backed primitive `compare` methods.
- The test verifies JavaScript and Python dispatch `token.compare(token)` through the generated primitive-backed method instead of the `capy.lang.String.compare` runtime helper.

## Why

- Follows up on the unresolved Codex review comments from #212.
- `release/0.3.x` already contains the narrowed built-in `String.compare` guard; this locks the behavior in so custom string-backed methods stay protected.

## Impacted modules

- `compiler` tests only.

## Checks

- `./gradlew :compiler:test --tests dev.capylang.generator.PrimitiveBackedTypeGeneratorTest`
- `./gradlew :compiler:test`
