### PR TITLE
fix(#221): skip Build & Check on merge-back branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "**"
+      - "!merge-back/**"
     paths:
       - ".github/workflows/**"
       - "build-tool/**"
@@ -36,6 +37,7 @@ permissions:
 
 jobs:
   build-check:
+    if: ${{ !startsWith(github.ref_name, 'merge-back/') && !startsWith(github.head_ref || '', 'merge-back/') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -141,5 +141,3 @@ jobs:
               --body "Automated merge-back from \`${RELEASE_BRANCH}\` into \`${DEFAULT_BRANCH}\`. The \`${STATE_BRANCH}\` branch preserves merge ancestry, while this PR branch stays linear for \`${DEFAULT_BRANCH}\`.")"
             echo "Created merge-back pull request: ${PR_URL}"
           fi
-
-          gh workflow run check.yml --ref "${BACK_BRANCH}"


### PR DESCRIPTION
## What changed
- Excludes `merge-back/**` branches from the `Build & Check` push trigger.
- Skips the `build-check` job when a workflow dispatch or PR head ref starts with `merge-back/`.
- Removes the explicit `check.yml` dispatch from the merge-back automation.

## Why
Generated merge-back branches should not run the regular `Build & Check` workflow. The merge-back workflow was still dispatching that workflow manually after creating or updating the branch.

## Impact
- Normal branches and release branches continue to run `Build & Check`.
- `merge-back/**` branches no longer spend CI time on `Build & Check`.

Fixes #221.

## Validation
- `git diff --check`
- `python3 -c 'import yaml; [yaml.safe_load(open(path, encoding="utf-8")) for path in (".github/workflows/check.yml", ".github/workflows/merge_back.yml")]'
- Did not run Gradle or `Build & Check`.
