### PR TITLE
fix(#223): set up MSVC for Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,11 @@ jobs:
           github-token: ${{ github.token }}
           native-image-job-reports: "false"
 
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:


### PR DESCRIPTION
## Summary
- Set up the MSVC developer environment before the Windows native-image release build.
- Keeps the existing GraalVM and Gradle release steps unchanged.

## Verification
- Inspected failed Release run 27529584077 with `gh run view --log-failed`; Windows native-image failed because `vcvarsall.bat` was not found.
- Parsed `.github/workflows/release.yml` with PyYAML.
- Ran `git diff --check`.
- Ran `./gradlew :capy:classes --no-daemon`.

CLOSE #223