### PR TITLE
merge back release/0.3.x into master

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "**"
+      - "!merge-back/**"
     paths:
       - ".github/workflows/**"
       - "build-tool/**"
@@ -34,6 +35,7 @@ permissions:
 
 jobs:
   build-check:
+    if: ${{ !startsWith(github.ref_name, 'merge-back/') && !startsWith(github.head_ref || '', 'merge-back/') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -141,5 +141,3 @@ jobs:
               --body "Automated merge-back from \`${RELEASE_BRANCH}\` into \`${DEFAULT_BRANCH}\`. The \`${STATE_BRANCH}\` branch preserves merge ancestry, while this PR branch stays linear for \`${DEFAULT_BRANCH}\`.")"
             echo "Created merge-back pull request: ${PR_URL}"
           fi
-
-          gh workflow run check.yml --ref "${BACK_BRANCH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,11 @@ jobs:
           github-token: ${{ github.token }}
           native-image-job-reports: "false"
 
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:

--- a/capy/src/test/java/dev/capylang/generator/PrimitiveBackedTypeGeneratorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/PrimitiveBackedTypeGeneratorTest.java
@@ -132,6 +132,28 @@ class PrimitiveBackedTypeGeneratorTest {
     }
 
     @Test
+    void shouldDispatchStringBackedCompareMethodsInJavaScriptAndPython() {
+        var program = compileProgram(List.of(new RawModule("Tokens", "/foo", """
+                type token -> String
+
+                fun token.compare(other: token): bool = this.value == other.value
+                fun tokens_match(left: token, right: token): bool = left.compare(right)
+                """)));
+
+        var js = generatedCode(new JavaScriptGenerator(), program, Path.of("foo", "Tokens.js"));
+        var python = generatedCode(new PythonGenerator(), program, Path.of("foo", "Tokens.py"));
+
+        assertThat(js)
+                .contains("function compare__name_compare__token__token(this_, other)")
+                .contains("return compare__name_compare__token__token(left, right);")
+                .doesNotContain("__module_capy_lang_String.compare(left, right)");
+        assertThat(python)
+                .contains("def compare__name_compare__token__token(this_, other):")
+                .contains("return compare__name_compare__token__token(left, right)")
+                .doesNotContain("capy_module_capy_lang_String.compare(left, right)");
+    }
+
+    @Test
     void shouldNotShadowPythonRuntimeWithPrimitiveBackedConstructorAliases() {
         var program = compileProgram(List.of(new RawModule("Numbers", "/foo", """
                 from /capy/lang/Result import { * }


### PR DESCRIPTION
Automated merge-back from `release/0.3.x` into `master`. The `merge-back-state/release-0.3.x-to-master` branch preserves merge ancestry, while this PR branch stays linear for `master`.

CLOSE #223