### PR TITLE
fix(#223): set up MSVC in Windows release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,6 @@ jobs:
           github-token: ${{ github.token }}
           native-image-job-reports: "false"
 
-      - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
@@ -205,6 +200,11 @@ jobs:
           java-version: "21"
           github-token: ${{ github.token }}
           native-image-job-reports: "false"
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
## Summary
- Move the MSVC developer command setup from `build-linux` to `build-windows`.
- Keep the Windows native-image build running after GraalVM and MSVC are both configured.

## Verification
- Inspected failed Release run 27539226869; `build-windows` still lacked the MSVC setup and failed finding `vcvarsall.bat`.
- Parsed `.github/workflows/release.yml` with PyYAML.
- Ran `git diff --check`.
- Ran `./gradlew :capy:classes --no-daemon`.

Refs #223