### PR TITLE
fix(#229): grant release workflow PR permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ permissions:
   actions: write
   contents: write
   packages: write
+  pull-requests: write
 
 concurrency:
   group: release-${{ github.ref_name }}


### PR DESCRIPTION
Adds pull-requests: write to the release workflow permissions so the post-release patch bump PR can be created with the workflow GITHUB_TOKEN.

Addresses Codex review feedback on PR #229.

Validation:
- workflow-only change; inspected diff