### PR TITLE
fix(#229): run checks for merge-back pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build-check:
-    if: ${{ !startsWith(github.ref_name, 'merge-back/') && !startsWith(github.head_ref || '', 'merge-back/') }}
+    if: ${{ github.event_name != 'push' || !startsWith(github.ref_name, 'merge-back/') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Keeps the Build & Check workflow disabled for push events on merge-back/* branches while allowing pull_request events from merge-back/* heads to run build-check.

Addresses Codex review feedback on PR #229.

Validation:
- workflow-only change; inspected diff