### PR TITLE
fix(#223): qualify release bump branch ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,9 +399,9 @@ jobs:
 
           REMOTE_BUMP_SHA="$(git ls-remote --heads origin "${BUMP_BRANCH}" | awk '{ print $1 }')"
           if [[ -n "${REMOTE_BUMP_SHA}" ]]; then
-            git push --force-with-lease="refs/heads/${BUMP_BRANCH}:${REMOTE_BUMP_SHA}" origin "HEAD:${BUMP_BRANCH}"
+            git push --force-with-lease="refs/heads/${BUMP_BRANCH}:${REMOTE_BUMP_SHA}" origin "HEAD:refs/heads/${BUMP_BRANCH}"
           else
-            git push origin "HEAD:${BUMP_BRANCH}"
+            git push origin "HEAD:refs/heads/${BUMP_BRANCH}"
           fi
 
           PR_NUMBER="$(


### PR DESCRIPTION
## Summary
- Fully qualify the remote ref when the release workflow pushes the post-release bump branch from detached `HEAD`.
- Keeps the existing PR-based protected-branch release flow intact.

## Verification
- Inspected failed Release run 27542304873; release creation succeeded and `Create patch bump pull request` failed because `HEAD:automation/post-release-0.3.2` was not a full refname.
- Parsed `.github/workflows/release.yml` with PyYAML.
- Ran `git diff --check`.
- Ran `./gradlew :capy:classes --no-daemon`.

Refs #223