### PR TITLE
fix(#202): allow trailing comma in data construction

### DIFF
--- a/capy/src/main/antlr/Functional.g4
+++ b/capy/src/main/antlr/Functional.g4
@@ -322,7 +322,7 @@ new_list: (LBRACK | LINE_START_LBRACK) (expression (',' expression)* ','?)? RBRA
 new_set: '{' (expression (',' expression)* ','?)? '}';
 new_dict: '{' (dict_entry (',' dict_entry)* ','? | COLON) '}';
 dict_entry: expression ':' expression;
-fieldAssignmentList: fieldAssignment (',' fieldAssignment)*;
+fieldAssignmentList: fieldAssignment (',' fieldAssignment)* ','?;
 fieldAssignment: namedFieldAssignment
                | spreadFieldAssignment
                | positionalFieldAssignment;

--- a/capy/src/main/antlr/ObjectOriented.g4
+++ b/capy/src/main/antlr/ObjectOriented.g4
@@ -297,7 +297,7 @@ new_list: LBRACK (expression (COMMA expression)* COMMA?)? RBRACK;
 new_set: LBRACE (expression (COMMA expression)* COMMA?)? RBRACE;
 new_dict: LBRACE (dict_entry (COMMA dict_entry)* COMMA? | COLON) RBRACE;
 dict_entry: expression COLON expression;
-fieldAssignmentList: fieldAssignment (COMMA fieldAssignment)*;
+fieldAssignmentList: fieldAssignment (COMMA fieldAssignment)* COMMA?;
 fieldAssignment
     : namedFieldAssignment
     | spreadFieldAssignment

--- a/capy/src/test/java/dev/capylang/parser/CapybaraParserTest.java
+++ b/capy/src/test/java/dev/capylang/parser/CapybaraParserTest.java
@@ -339,6 +339,39 @@ class CapybaraParserTest {
     }
 
     @Test
+    @DisplayName("should parse trailing comma in data constructor field assignments")
+    void parseTrailingCommaInDataConstructorFieldAssignments() {
+        var module = parseSuccess(new RawModule("Test", "/parser", """
+                data Inner { value: int }
+                data Outer { inner: Inner, label: String } with constructor {
+                    * { inner: inner, label: label, }
+                }
+
+                fun direct(): Outer =
+                    Outer { inner: Inner { value: 1, }, label: "ok", }
+                """));
+
+        var direct = findFunction("direct", module.functional());
+        assertThat(direct.expression()).isInstanceOf(NewData.class);
+        var outer = (NewData) direct.expression();
+        assertThat(outer.assignments()).extracting(NewData.FieldAssignment::name)
+                .containsExactly("inner", "label");
+        assertThat(outer.assignments().getFirst().value()).isInstanceOf(NewData.class);
+        var inner = (NewData) outer.assignments().getFirst().value();
+        assertThat(inner.assignments()).singleElement()
+                .extracting(NewData.FieldAssignment::name)
+                .isEqualTo("value");
+
+        var data = findDefinition(DataDeclaration.class, "Outer", module.functional());
+        assertThat(data.constructor()).hasValueSatisfying(constructor -> {
+            assertThat(constructor).isInstanceOf(ConstructorData.class);
+            var constructorData = (ConstructorData) constructor;
+            assertThat(constructorData.assignments()).extracting(NewData.FieldAssignment::name)
+                    .containsExactly("inner", "label");
+        });
+    }
+
+    @Test
     @DisplayName("should parse primitive-backed type declarations")
     void parsePrimitiveBackedTypeDeclaration() {
         var module = parseSuccess(new RawModule("Test", "/parser", """

--- a/capy/src/test/java/dev/capylang/parser/ObjectOrientedParserTest.java
+++ b/capy/src/test/java/dev/capylang/parser/ObjectOrientedParserTest.java
@@ -109,6 +109,24 @@ class ObjectOrientedParserTest {
     }
 
     @Test
+    @DisplayName("should parse trailing comma in data constructor field assignments from .coo")
+    void parseTrailingCommaInDataConstructorFieldAssignments() {
+        var result = ObjectOrientedParser.INSTANCE.parseModule(new RawModule(
+                "Builder",
+                "/parser",
+                """
+                        class Builder {
+                            def direct(): Outer =
+                                Outer { inner: Inner { value: 1, }, label: "ok", }
+                        }
+                        """,
+                SourceKind.OBJECT_ORIENTED
+        ));
+
+        assertThat(result).isInstanceOf(Result.Success.class);
+    }
+
+    @Test
     @DisplayName("should parse class trait and interface declarations from .coo source")
     void parseObjectOrientedModule() {
         var result = ObjectOrientedParser.INSTANCE.parseModule(new RawModule(


### PR DESCRIPTION
## Summary
- Allow optional trailing commas in data construction field assignment lists.
- Apply the grammar update to both functional and object-oriented parser grammars.
- Add parser coverage for normal, nested, and constructor-local data construction with trailing commas.

## Validation
- ./gradlew :capy:test
- ./gradlew :capy:e2eTests

Closes #202