### PR TITLE
fix(#205): preserve effect bind match continuation type

### DIFF
--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -1787,11 +1787,12 @@ public class JavaExpressionEvaluator {
         var restExSc = evaluateExpression(scopeExpression.expression(), scopeExpression.scope()).popExpression();
         var addedStatements = addedStatements(scope, restExSc.scope());
         var statements = String.join("; ", addedStatements);
+        var restExpression = castEffectExpressionForExpectedType(restExSc.expression(), bind.effectType());
         return scope.addExpression(
                 "capy.lang.Effect.delay(() -> { "
                 + statements
                 + "; return (("
-                + restExSc.expression()
+                + restExpression
                 + ").unsafeRun()); })"
         );
     }
@@ -2002,6 +2003,94 @@ public class JavaExpressionEvaluator {
             case dev.capylang.compiler.CompiledGenericTypeParameter genericTypeParameter ->
                     genericTypeParameter.name();
             default -> "java.lang.Object";
+        };
+    }
+
+    private static String castEffectExpressionForExpectedType(
+            String expression,
+            dev.capylang.compiler.CompiledType expectedEffectType
+    ) {
+        if (!(expectedEffectType instanceof dev.capylang.compiler.GenericDataType genericDataType)) {
+            return expression;
+        }
+        var raw = normalizeJavaTypeReference(genericDataType.name());
+        var typed = javaGenericDataTypeReference(genericDataType);
+        if (raw.equals(typed)) {
+            return "((" + raw + ") (" + expression + "))";
+        }
+        return "((" + typed + ") ((" + raw + "<?>) (" + expression + ")))";
+    }
+
+    private static String javaGenericDataTypeReference(dev.capylang.compiler.GenericDataType type) {
+        var raw = normalizeJavaTypeReference(type.name());
+        var typeParameters = switch (type) {
+            case dev.capylang.compiler.CompiledDataType dataType -> dataType.typeParameters();
+            case dev.capylang.compiler.CompiledDataParentType parentType -> parentType.typeParameters();
+            case dev.capylang.compiler.CompiledPrimitiveBackedType ignored -> List.<String>of();
+            case dev.capylang.compiler.CompiledObjectType ignored -> List.<String>of();
+        };
+        if (typeParameters.isEmpty()) {
+            return raw;
+        }
+        var mappedTypeParameters = typeParameters.stream()
+                .map(JavaExpressionEvaluator::javaGenericTypeParameterReference)
+                .toList();
+        return raw + "<" + String.join(", ", mappedTypeParameters) + ">";
+    }
+
+    private static String javaGenericTypeParameterReference(String descriptor) {
+        var normalized = descriptor == null ? "" : descriptor.trim();
+        if (normalized.isEmpty()) {
+            return "java.lang.Object";
+        }
+        var primitiveBackedType = primitiveBackedType(normalized);
+        if (primitiveBackedType.isPresent()) {
+            return javaBoxedPrimitiveType(primitiveBackedType.orElseThrow());
+        }
+        return switch (normalized) {
+            case "byte" -> "java.lang.Byte";
+            case "int" -> "java.lang.Integer";
+            case "long" -> "java.lang.Long";
+            case "float" -> "java.lang.Float";
+            case "double" -> "java.lang.Double";
+            case "String" -> "java.lang.String";
+            case "bool" -> "java.lang.Boolean";
+            case "enum" -> "java.lang.Enum<?>";
+            case "any", "nothing", "data" -> "java.lang.Object";
+            default -> {
+                if ("Error".equals(normalized)
+                    || normalizeQualifiedTypeName(normalized).endsWith("/Result.Error")) {
+                    yield resultErrorJavaTypeReference(normalized);
+                }
+                if (normalized.matches("[A-Z]")) {
+                    yield normalized;
+                }
+                if (normalized.startsWith("List[") && normalized.endsWith("]")) {
+                    var inner = normalized.substring("List[".length(), normalized.length() - 1);
+                    yield "java.util.List<" + javaGenericTypeParameterReference(inner) + ">";
+                }
+                if (normalized.startsWith("Set[") && normalized.endsWith("]")) {
+                    var inner = normalized.substring("Set[".length(), normalized.length() - 1);
+                    yield "java.util.Set<" + javaGenericTypeParameterReference(inner) + ">";
+                }
+                if (normalized.startsWith("Dict[") && normalized.endsWith("]")) {
+                    var inner = normalized.substring("Dict[".length(), normalized.length() - 1);
+                    yield "java.util.Map<java.lang.String, " + javaGenericTypeParameterReference(inner) + ">";
+                }
+                if (normalized.startsWith("Tuple[") && normalized.endsWith("]")) {
+                    yield "java.util.List<?>";
+                }
+                var genericStart = normalized.indexOf('[');
+                if (genericStart > 0 && normalized.endsWith("]")) {
+                    var rawType = normalized.substring(0, genericStart).trim();
+                    var argsDescriptor = normalized.substring(genericStart + 1, normalized.length() - 1);
+                    var javaArgs = splitTopLevelDescriptors(argsDescriptor).stream()
+                            .map(JavaExpressionEvaluator::javaGenericTypeParameterReference)
+                            .toList();
+                    yield normalizeJavaTypeReference(rawType) + "<" + String.join(", ", javaArgs) + ">";
+                }
+                yield normalizeJavaTypeReference(normalized);
+            }
         };
     }
 

--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -2087,7 +2087,14 @@ public class JavaExpressionEvaluator {
                     var javaArgs = splitTopLevelDescriptors(argsDescriptor).stream()
                             .map(JavaExpressionEvaluator::javaGenericTypeParameterReference)
                             .toList();
+                    if (isOptionSomeTypeName(rawType) || isOptionNoneTypeName(rawType)) {
+                        var optionalElementType = javaArgs.isEmpty() ? "java.lang.Object" : javaArgs.getFirst();
+                        yield "java.util.Optional<" + optionalElementType + ">";
+                    }
                     yield normalizeJavaTypeReference(rawType) + "<" + String.join(", ", javaArgs) + ">";
+                }
+                if (isOptionSomeTypeName(normalized) || isOptionNoneTypeName(normalized)) {
+                    yield "java.util.Optional";
                 }
                 yield normalizeJavaTypeReference(normalized);
             }

--- a/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -1109,6 +1109,25 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldEraseOptionConstructorsInEffectBindContinuationCast() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram("EffectOptionConstructor", "/foo/bar", """
+                from /capy/lang/Effect import { * }
+                from /capy/lang/Option import { Some }
+
+                fun effect_some(): Effect[Some[int]] =
+                    let x <- pure(1)
+                    Some { value: x }
+                """));
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated).contains("capy.lang.Effect<java.util.Optional<java.lang.Integer>>");
+        assertThat(generated).doesNotContain("capy.lang.Effect<Some");
+        assertGeneratedJavaCompiles(generatedProgram);
+    }
+
+    @Test
     void shouldCompileImportedConstructorPatternsNestedInOwnerInterface() {
         var generatedProgram = new JavaGenerator().generate(compileProgram(List.of(
                 new RawModule("EitherLike", "/foo/types", """

--- a/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -1084,6 +1084,31 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldPreserveEffectProgramTypeThroughBindContinuationMatch() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram("EffectProgramMatch", "/foo/bar", """
+                from /capy/lang/Effect import { * }
+                from /capy/lang/Program import { DEFAULT_FAILED_EXIT_CODE }
+                from /capy/lang/Result import { * }
+                from /capy/collection/List import { * }
+
+                fun write_docs(): Effect[Result[String]] =
+                    pure(Success { value: "ok" })
+
+                fun main(args: List[String]): Effect[/capy/lang/Program] =
+                    let result <- write_docs()
+                    match result with
+                    case Success _ -> /capy/lang/Program.Success {}
+                    case Error _ -> /capy/lang/Program.Failed { exit_code: DEFAULT_FAILED_EXIT_CODE }
+                """));
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated).contains("capy.lang.Effect<capy.lang.Program>");
+        assertGeneratedJavaCompiles(generatedProgram);
+    }
+
+    @Test
     void shouldCompileImportedConstructorPatternsNestedInOwnerInterface() {
         var generatedProgram = new JavaGenerator().generate(compileProgram(List.of(
                 new RawModule("EitherLike", "/foo/types", """


### PR DESCRIPTION
## What changed

- Preserve the generic `Effect[...]` continuation type at the effect-bind boundary before generated Java calls `unsafeRun()`.
- Add a generated-Java regression for `let result <- ...` followed by a `match` returning `/capy/lang/Program` values.

## Why

Effect bind continuations that lowered through a `match` could collapse to raw `Effect`, making `unsafeRun()` return `Object` and breaking Java inference for `Effect[/capy/lang/Program]` functions.

Fixes #205.

## Validation

- `./gradlew :capy:test --tests dev.capylang.generator.java.JavaExpressionEvaluatorTest`
- `./gradlew :capy:e2e-cfun`
- `./gradlew :capy:test`