### PR TITLE
fix(#244): update result and option map helpers

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/GeneratorSemVer.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/GeneratorSemVer.cfun
@@ -19,7 +19,7 @@ fun parse_local_option(value: int): Result[int] =
         case None -> Error { "missing value" }
     ---
     unwrap(Parse { buffer: "", value: Some { value } })
-    | parsed => Success { parsed.value }
+    | parsed => parsed.value
 
 fun parse_local_option_none(): Result[int] =
     data Parse[T] { buffer: String, value: T }
@@ -30,7 +30,7 @@ fun parse_local_option_none(): Result[int] =
     ---
     let none_value: Option[int] = None {}
     unwrap(Parse { buffer: "", value: none_value })
-    | parsed => Success { parsed.value }
+    | parsed => parsed.value
 
 fun parse_local_semver_build(version: String): Result[String] =
     data Parse[T] { buffer: String, value: T }
@@ -42,11 +42,11 @@ fun parse_local_semver_build(version: String): Result[String] =
         value: SemVer { major: 1, build_metadata: None {} }
     }
     parse_build(parse.buffer)
-    | parse_build => Success { Parse {
+    | parse_build => Parse {
         buffer: parse_build.buffer,
         value: parse.value.with(build_metadata: Some { parse_build.value })
-    }}
-    | parse_semver =>
+    }
+    |* parse_semver =>
         match parse_semver.value.build_metadata with
         case Some { value } -> Success { value }
         case None -> Error { "missing metadata" }
@@ -61,11 +61,11 @@ fun parse_local_semver_build_and_increment(version: String): Result[int] =
         value: SemVer { major: 1, build_metadata: None {} }
     }
     parse_build(parse.buffer)
-    | parse_build => Success { Parse {
+    | parse_build => Parse {
         buffer: parse_build.buffer,
         value:
             parse.value
                 .with(build_metadata: Some { parse_build.value })
                 .with(major: parse.value.major + 1)
-    }}
-    | parse_semver => Success { parse_semver.value.major }
+    }
+    | parse_semver => parse_semver.value.major

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/GroupedExpression.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/GroupedExpression.cfun
@@ -3,11 +3,11 @@ from /capy/lang/String import { * }
 
 fun nested_pipe_in_match_branch(value: int): Result[int] =
     Success { value }
-    | parsed => {
+    |* parsed => {
         match parsed with
         case int v when v > 0 -> {
             Success { v + 1 }
-            | next => Success { next + 1 }
+            | next => next + 1
         }
         case _ -> Error { "invalid" }
     }
@@ -23,23 +23,23 @@ fun grouped_guarded_match_is_exhaustive(input: String): Result[String] =
     match parse_patch.buffer[0] with
     case Some { ch } when ch == '-' -> {
         parse_tail(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_tail => Success { Parse {
+        | parse_tail => Parse {
             buffer: parse_tail.buffer,
             value: "pre:" + parse_tail.value
-        }}
-        | parse => {
+        }
+        |* parse => {
             match parse.buffer[0] with
             case None -> Success { parse.value }
             case Some { ch } when ch == '+' -> {
                 parse_build(parse.buffer[1, parse.buffer.size()])
-                | parse_build => Success { "plus:" + parse.value + ":" + parse_build.value }
+                | parse_build => "plus:" + parse.value + ":" + parse_build.value
             }
             case Some { ch } -> Error { "bad:" + ch }
         }
     }
     case Some { ch } when ch == '+' ->
         parse_build(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_build => Success { "plus:" + parse_build.value }
+        | parse_build => "plus:" + parse_build.value
     case Some { ch } -> Success { "other:" + ch }
     case None -> Success { "none" }
 
@@ -55,23 +55,23 @@ fun semver_style_mixed_case_pipe_bodies(input: String): Result[String] =
     match parse_patch.buffer[0] with
     case Some { next_char } when next_char == '-' -> {
         parse_pre_release(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_pre_release => Success { Parse {
+        | parse_pre_release => Parse {
             buffer: parse_pre_release.buffer,
             value: raw_sem_ver + "-" + parse_pre_release.value
-        }}
-        | parse => {
+        }
+        |* parse => {
             match parse.buffer[0] with
             case None -> Success { parse.value }
             case Some { char } when char == '+' -> {
                 parse_build(parse.buffer[1, parse.buffer.size()])
-                | parse_build => Success { parse.value + "+" + parse_build.value }
+                | parse_build => parse.value + "+" + parse_build.value
             }
             case Some { char } -> Error { "bad:" + char }
         }
     }
     case Some { next_char } when next_char == '+' ->
         parse_build(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_build => Success { raw_sem_ver + "+" + parse_build.value }
+        | parse_build => raw_sem_ver + "+" + parse_build.value
     case Some { next_char } -> Error { "unexpected:" + next_char }
     case None -> Success { raw_sem_ver }
 
@@ -87,22 +87,22 @@ fun inner_ungrouped_pipe_in_match_inside_lambda(input: String): Result[String] =
     match parse_patch.buffer[0] with
     case Some { next_char } when next_char == '-' -> {
         parse_pre_release(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_pre_release => Success { Parse {
+        | parse_pre_release => Parse {
             buffer: parse_pre_release.buffer,
             value: raw_sem_ver + "-" + parse_pre_release.value
-        }}
-        | parse => {
+        }
+        |* parse => {
             match parse.buffer[0] with
             case None -> Success { parse.value }
             case Some { char } when char == '+' ->
                 parse_build(parse.buffer[1, parse.buffer.size()])
-                | parse_build => Success { parse.value + "+" + parse_build.value }
+                | parse_build => parse.value + "+" + parse_build.value
             case Some { char } -> Error { "bad:" + char }
         }
     }
     case Some { next_char } when next_char == '+' -> {
         parse_build(parse_patch.buffer[1, parse_patch.buffer.size()])
-        | parse_build => Success { raw_sem_ver + "+" + parse_build.value }
+        | parse_build => raw_sem_ver + "+" + parse_build.value
     }
     case Some { next_char } -> Error { "unexpected:" + next_char }
     case None -> Success { raw_sem_ver }

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/LocalTypesAndData.cfun
@@ -58,7 +58,7 @@ fun local_generic_data_field_access_followed_by_index(buffer: String): String =
     fun parse(value: String): Result[Parse[int]] =
         Success { Parse { buffer: value, value: 1 } }
     ---
-    match (parse(buffer) | parse =>
+    match (parse(buffer) |* parse =>
         match parse.buffer[0] with
         case Some { value } -> Success { value }
         case None -> Error { "" }) with

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/NamedPipeMethods.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/NamedPipeMethods.cfun
@@ -64,6 +64,8 @@ fun string_reject_named(value: String): Seq[String] = value.reject(ch => ch == "
 
 fun option_map_named(value: Option[String]): Option[String] = value.map(text => text + "!")
 fun option_map_operator(value: Option[String]): Option[String] = value | text => text + "!"
+fun option_map_named_type_change(value: Option[int]): Option[String] = value.map(number => "v=" + number)
+fun option_map_operator_type_change(value: Option[int]): Option[String] = value | number => "v=" + number
 
 fun option_filter_named(value: Option[String]): Option[String] = value.filter(text => text == "drop")
 fun option_filter_operator(value: Option[String]): Option[String] = value |- text => text == "drop"

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/NamedPipeMethods.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/NamedPipeMethods.cfun
@@ -12,7 +12,7 @@ fun is_positive(value: int): bool = value > 0
 fun expand_list(value: int): List[int] = [value, value + 1]
 fun expand_set(value: int): Set[int] = {value, value + 10}
 fun expand_seq(value: int): Seq[int] = to_seq([value, value + 1])
-fun nested_success(value: int): Result[Result[String]] = Success { value: Success { value: "v=" + value } }
+fun nested_success(value: int): Result[String] = Success { value: "v=" + value }
 
 fun list_map_named(values: List[int]): Seq[int] = values.map(x => x * 2)
 fun list_map_operator(values: List[int]): Seq[int] = values | x => x * 2
@@ -77,10 +77,10 @@ fun option_reduce_left_named(value: Option[String]): String =
     value.reduce_left("start:", (acc, inner) => acc + inner)
 
 fun result_map_named(value: Result[int]): Result[String] =
-    value.map(x => Success { value: "v=" + x })
+    value.map(x => "v=" + x)
 
 fun result_map_operator(value: Result[int]): Result[String] =
-    value | x => Success { value: "v=" + x }
+    value | x => "v=" + x
 
 fun result_flat_map_named(value: Result[int]): Result[String] =
     value.flat_map(:nested_success)

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/NamedPipeMethodsCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/NamedPipeMethodsCapyTest.cfun
@@ -82,11 +82,14 @@ private fun string_filter_and_reject_produce_expected_results(): Assert =
 
 private fun option_aliases_match_operators_and_expected_values(): Assert =
     let value = Some { "capy" }
+    let number = Some { 42 }
     let matching = Some { "drop" }
     let empty: Option[String] = None {}
     assert_all([
         assert_that(option_map_named(value)).is_equal_to(option_map_operator(value)),
         assert_that(option_map_named(value)).contains("capy!"),
+        assert_that(option_map_named_type_change(number)).is_equal_to(option_map_operator_type_change(number)),
+        assert_that(option_map_named_type_change(number)).contains("v=42"),
         assert_that(option_filter_named(matching)).is_equal_to(option_filter_operator(matching)),
         assert_that(option_flat_map_named(value)).contains("capy!"),
         assert_that(option_reduce_named(value)).is_equal_to("start:capy"),

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ResultError.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ResultError.cfun
@@ -14,22 +14,22 @@ fun parse_state(input: String): Result[ParseState] =
     Success { value: ParseState { value: input, parsing_string: "xyz" } }
 
 fun parse_and_add_rest_size(input: String): Result[long] =
-    parse_state(input) | parse => (parse.value.to_long() | number => Success { value: number + parse.parsing_string.size().value })
+    parse_state(input) |* parse => (parse.value.to_long() | number => number + parse.parsing_string.size().value)
 
 fun map_untyped_result(): Result[String] =
     let result: Result = Success { "success_value" }
-    result | value => Success { "mapped_" + value }
+    result | value => "mapped_" + value
 
 fun flatmap_untyped_result(): Result[String] =
     let result: Result = Success { "success_value" }
-    result |* value => Success { Success { "mapped_" + value } }
+    result |* value => Success { "mapped_" + value }
 
 private fun append_dict_entry(acc: Result[String], key: String, value: int): Result[String] =
-    acc | text => Success { value: text + key + ":" + value + "," }
+    acc | text => text + key + ":" + value + ","
 
 private fun empty_result(): Result[String] = Success { value: "" }
 
 fun dict_reduce_then_map(d: Dict[int]): Result[String] =
     d
         .reduce(empty_result(), (acc, k, v) => append_dict_entry(acc, k, v))
-        .map(text => Success { value: text + "done" })
+        .map(text => text + "done")

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/ResultErrorCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/ResultErrorCapyTest.cfun
@@ -12,7 +12,7 @@ fun tests(): Effect[TestFile] =
         test("parse_and_add_rest_size adds parsed value and rest size", () => parse_and_add_rest_size_adds_parsed_value_and_rest_size()),
         test("parse_and_add_rest_size propagates parse errors", () => parse_and_add_rest_size_propagates_parse_errors()),
         test("map_untyped_result maps success value", () => map_untyped_result_maps_success_value()),
-        test("flatmap_untyped_result maps nested success value", () => flatmap_untyped_result_maps_nested_success_value()),
+        test("flatmap_untyped_result maps success value", () => flatmap_untyped_result_maps_success_value()),
         test("dict_reduce_then_map keeps entries and final suffix", () => dict_reduce_then_map_keeps_entries_and_final_suffix()),
     ])
 
@@ -31,7 +31,7 @@ private fun parse_and_add_rest_size_propagates_parse_errors(): Assert =
 private fun map_untyped_result_maps_success_value(): Assert =
     assert_that(map_untyped_result()).succeeds("mapped_success_value")
 
-private fun flatmap_untyped_result_maps_nested_success_value(): Assert =
+private fun flatmap_untyped_result_maps_success_value(): Assert =
     assert_that(flatmap_untyped_result()).succeeds("mapped_success_value")
 
 private fun dict_reduce_then_map_keeps_entries_and_final_suffix(): Assert =

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/With.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/With.cfun
@@ -58,15 +58,15 @@ fun chain_sanitized_counter(counter: SanitizedCounter): SanitizedCounter =
 
 fun validated_counter_after_single_with(number: int): String =
     ValidatedCounter { number: number, constructor_runs: 0 }
-        | value => value.with(number: value.number + 1)
+        |* value => value.with(number: value.number + 1)
         |>
             (value => "ok:" + value.number + ":" + value.constructor_runs,
             message => "err:" + message)
 
 fun validated_counter_after_multiple_withs(number: int): String =
     ValidatedCounter { number: number, constructor_runs: 0 }
-        | value => value.with(number: value.number + 1)
-        | updated => updated.with(number: updated.number - 5)
+        |* value => value.with(number: value.number + 1)
+        |* updated => updated.with(number: updated.number - 5)
         |>
             (value => "ok:" + value.number + ":" + value.constructor_runs,
             message => "err:" + message)

--- a/capy/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/capy/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -5663,12 +5663,21 @@ public class CapybaraExpressionCompiler {
         if (!(expression.right() instanceof LambdaExpression lambdaExpression)) {
             if (expression.right() instanceof FunctionReference functionReference) {
                 return resolvePipeFunctionReference(functionReference, elementType)
-                        .map(linked -> (CompiledExpression) new CompiledPipeExpression(
-                                left,
-                                linked.argumentName(),
-                                linked.expression(),
-                                left.type()
-                        ));
+                        .flatMap(linked -> {
+                            var optionType = optionTypeFor(linked.expression().type());
+                            if (optionType == null) {
+                                return withPosition(
+                                        Result.error("Option type is not defined"),
+                                        expression.position()
+                                );
+                            }
+                            return Result.success((CompiledExpression) new CompiledPipeExpression(
+                                    left,
+                                    linked.argumentName(),
+                                    linked.expression(),
+                                    optionType
+                            ));
+                        });
             }
             return withPosition(
                     Result.error("Right side of `|` has to be a lambda expression or function reference"),
@@ -5677,12 +5686,21 @@ public class CapybaraExpressionCompiler {
         }
         return linkPipeLambdaArguments(scope, lambdaExpression, elementType, "|")
                 .flatMap(lambdaBinding -> linkExpression(lambdaExpression.expression(), lambdaBinding.scope())
-                .map(mapper -> (CompiledExpression) new CompiledPipeExpression(
-                        left,
-                        lambdaBinding.argumentName(),
-                        mapper,
-                        left.type()
-                )));
+                .flatMap(mapper -> {
+                    var optionType = optionTypeFor(mapper.type());
+                    if (optionType == null) {
+                        return withPosition(
+                                Result.error("Option type is not defined"),
+                                expression.position()
+                        );
+                    }
+                    return Result.success((CompiledExpression) new CompiledPipeExpression(
+                            left,
+                            lambdaBinding.argumentName(),
+                            mapper,
+                            optionType
+                    ));
+                }));
     }
 
     private Result<CompiledExpression> linkCollectionPipeExpression(

--- a/capy/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/capy/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -4950,6 +4950,9 @@ public class CapybaraExpressionCompiler {
         if (expression.operator() == InfixOperator.PIPE) {
             return linkExpression(expression.left(), scope)
                     .flatMap(left -> {
+                        if (isPipeMapExpression(expression) && resolveSpecializedOptionType(left.type()).isPresent()) {
+                            return linkOptionPipeExpression(expression, scope, left, optionElementType(left));
+                        }
                         var methodCall = resolveMethodInfixCall(
                                 expression.operator().symbol(),
                                 left,
@@ -4969,9 +4972,6 @@ public class CapybaraExpressionCompiler {
                                     .flatMap(right ->
                                             getLinkedInfixExpression(left, expression.operator(), right, expression.position())
                                                     .map(linked -> (CompiledExpression) linked));
-                        }
-                        if (resolveSpecializedOptionType(left.type()).isPresent()) {
-                            return linkOptionPipeExpression(expression, scope, left, optionElementType(left));
                         }
                         return withPosition(
                                 Result.error("`|` operator is not defined for `" + left.type() + "`"),
@@ -5008,6 +5008,14 @@ public class CapybaraExpressionCompiler {
         if (expression.operator() == InfixOperator.PIPE_FLATMAP) {
             return linkExpression(expression.left(), scope)
                     .flatMap(left -> {
+                        if (resolveSpecializedOptionType(left.type()).isPresent()) {
+                            return linkBuiltinOptionFlatMapMethodInvoke(new FunctionCall(
+                                    Optional.empty(),
+                                    "flat_map",
+                                    List.of(expression.left(), expression.right()),
+                                    expression.position()
+                            ), scope);
+                        }
                         var methodCall = resolveMethodInfixCall(
                                 expression.operator().symbol(),
                                 left,

--- a/capy/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -1619,9 +1619,44 @@ public final class JavaGenerator implements Generator {
         var methodTypeParameters = method.typeParameters().isEmpty()
                 ? ""
                 : method.typeParameters().stream().collect(joining(", ", "<", ">")) + " ";
+        if (isCapyLangOptionMethod(method)) {
+            return mapCapyLangOptionInterfaceDefaultMethod(method, prefix, methodTypeParameters);
+        }
         return mapJavaDoc(method.comments())
                + prefix + " " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
                + evaluateMethodBody(method, helperCallOwnerName)
+               + "\n}\n";
+    }
+
+    private boolean isCapyLangOptionMethod(JavaMethod method) {
+        if (!method.sourceName().startsWith(METHOD_DECL_PREFIX + "Option__")) {
+            return false;
+        }
+        return method.parameters().size() == 1
+               && switch (baseMethodName(method.sourceName())) {
+                   case "|", "map", "|*", "flat_map" -> true;
+                   default -> false;
+               };
+    }
+
+    private String mapCapyLangOptionInterfaceDefaultMethod(JavaMethod method, String prefix, String methodTypeParameters) {
+        var mapper = method.parameters().getFirst().generatedName();
+        var body = switch (baseMethodName(method.sourceName())) {
+            case "|", "map" ->
+                    "if (this instanceof capy.lang.Option.Some<?> some) {\n"
+                    + "return java.util.Optional.ofNullable(" + mapper + ".apply((T) some.value()));\n"
+                    + "}\n"
+                    + "return java.util.Optional.empty();";
+            case "|*", "flat_map" ->
+                    "if (this instanceof capy.lang.Option.Some<?> some) {\n"
+                    + "return (java.util.Optional<Y>) " + mapper + ".apply((T) some.value());\n"
+                    + "}\n"
+                    + "return java.util.Optional.empty();";
+            default -> throw new IllegalStateException("Unsupported Option method: " + method.sourceName());
+        };
+        return mapJavaDoc(method.comments())
+               + prefix + " " + methodTypeParameters + method.returnType() + " " + mapMethodName(method.name()) + "(" + mapFunctionParameters(method.parameters()) + ") {\n"
+               + body
                + "\n}\n";
     }
 

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -5828,9 +5828,9 @@ public final class JavaScriptGenerator implements Generator {
                             });
                             return methodAliasProxy(this);
                         }
-                        map(mapper) { return invoke(mapper, this.value); }
-                        pipe(mapper) { return invoke(mapper, this.value); }
-                        flat_map(mapper) { const mapped = invoke(mapper, this.value); return isSuccessLike(mapped) ? mapped.value : mapped; }
+                        map(mapper) { return new Success({ value: invoke(mapper, this.value) }); }
+                        pipe(mapper) { return this.map(mapper); }
+                        flat_map(mapper) { return invoke(mapper, this.value); }
                         flatMap(mapper) { return this.flat_map(mapper); }
                         pipe_star(mapper) { return this.flat_map(mapper); }
                         orElse() { return this.value; }

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -6610,7 +6610,7 @@ public final class JavaScriptGenerator implements Generator {
                     }
 
                     function optionMap(option, mapper) {
-                        return isType(option, 'Some') ? mapper(option.value) : None;
+                        return isType(option, 'Some') ? new Some({ value: mapper(option.value) }) : None;
                     }
 
                     function optionFlatMap(option, mapper) {

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -4464,7 +4464,7 @@ public final class PythonGenerator implements Generator {
                             acc = invoke(reducer, acc, item, index)
                         return Some({'value': acc})
 
-                    def option_map(option, mapper): return mapper(option.value) if is_type(option, 'Some') else None_
+                    def option_map(option, mapper): return Some({'value': mapper(option.value)}) if is_type(option, 'Some') else None_
                     def option_flat_map(option, mapper): return mapper(option.value) if is_type(option, 'Some') else None_
                     def option_filter_out(option, predicate): return None_ if is_type(option, 'Some') and predicate(option.value) else option
 

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -4030,11 +4030,9 @@ public final class PythonGenerator implements Generator {
                             self.__capybaraTypes = ['Success', 'Result']
                             self.value = fields.get('value', fields.get('results'))
                             self.results = fields.get('results', self.value)
-                        def map(self, mapper): return invoke(mapper, self.value)
-                        def pipe(self, mapper): return invoke(mapper, self.value)
-                        def flat_map(self, mapper):
-                            mapped = invoke(mapper, self.value)
-                            return mapped.value if is_success_like(mapped) else mapped
+                        def map(self, mapper): return Success({'value': invoke(mapper, self.value)})
+                        def pipe(self, mapper): return self.map(mapper)
+                        def flat_map(self, mapper): return invoke(mapper, self.value)
                         def flatMap(self, mapper): return self.flat_map(mapper)
                         def pipe_star(self, mapper): return self.flat_map(mapper)
                         def pipeStar(self, mapper): return self.flat_map(mapper)

--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -325,13 +325,8 @@ public class JavaExpressionEvaluator {
                 .anyMatch(pattern ->
                         pattern instanceof CompiledMatchExpression.WildcardPattern
                         || pattern instanceof CompiledMatchExpression.WildcardBindingPattern);
-        if (optionMatch && !hasWildcard) {
-            code.append("case java.lang.Object __capybaraUnexpected -> throw new java.lang.IllegalStateException(\"Unexpected value: \" + ")
-                    .append(switchTarget)
-                    .append(");\n");
-        }
-        if (matchExpression.matchWith().type() == dev.capylang.compiler.PrimitiveLinkedType.BOOL && !hasWildcard) {
-            code.append("default -> throw new java.lang.IllegalStateException(\"Unexpected bool value: \" + ")
+        if (!hasWildcard) {
+            code.append("default -> throw new java.lang.IllegalStateException(\"Unexpected value: \" + ")
                     .append(switchTarget)
                     .append(");\n");
         }
@@ -2245,16 +2240,78 @@ public class JavaExpressionEvaluator {
                         pattern instanceof CompiledMatchExpression.WildcardPattern
                         || pattern instanceof CompiledMatchExpression.WildcardBindingPattern);
         var hasDefaultCase = cases.stream().anyMatch(caseRule -> caseRule.startsWith("default"));
-        if (optionMatch && !hasWildcard && !hasDefaultCase) {
-            cases.add("case java.lang.Object __capybaraUnexpected -> throw new java.lang.IllegalStateException(\"Unexpected value: \" + " + switchTarget + ");");
-        }
-        if (matchExpression.matchWith().type() == dev.capylang.compiler.PrimitiveLinkedType.BOOL
-            && !hasWildcard
-            && !hasDefaultCase) {
-            cases.add("default -> throw new java.lang.IllegalStateException(\"Unexpected bool value: \" + " + switchTarget + ");");
+        var hasUnconditionalCase = matchExpression.cases().stream()
+                .anyMatch(matchCase -> isUnconditionalMatchCase(matchExpression, matchCase));
+        if (!hasWildcard && !hasDefaultCase && !hasUnconditionalCase) {
+            cases.add("default -> throw new java.lang.IllegalStateException(\"Unexpected value: \" + " + switchTarget + ");");
         }
 
         return current.addExpression("switch (" + switchTarget + ") { " + String.join(" ", cases) + " }");
+    }
+
+    private static boolean isUnconditionalMatchCase(
+            CompiledMatchExpression matchExpression,
+            CompiledMatchExpression.MatchCase matchCase
+    ) {
+        return matchCase.guard().isEmpty()
+               && isUnconditionalPattern(matchCase.pattern(), matchExpression.matchWith().type());
+    }
+
+    private static boolean isUnconditionalPattern(
+            CompiledMatchExpression.Pattern pattern,
+            dev.capylang.compiler.CompiledType matchType
+    ) {
+        return switch (pattern) {
+            case CompiledMatchExpression.WildcardPattern ignored -> true;
+            case CompiledMatchExpression.WildcardBindingPattern ignored -> true;
+            case CompiledMatchExpression.TypedPattern typedPattern -> isSameSwitchType(typedPattern.type(), matchType);
+            case CompiledMatchExpression.VariablePattern variablePattern -> isUnconditionalVariablePattern(variablePattern, matchType);
+            case CompiledMatchExpression.ConstructorPattern constructorPattern ->
+                    isUnconditionalConstructorPattern(constructorPattern, matchType);
+            default -> false;
+        };
+    }
+
+    private static boolean isUnconditionalVariablePattern(
+            CompiledMatchExpression.VariablePattern variablePattern,
+            dev.capylang.compiler.CompiledType matchType
+    ) {
+        if (matchType instanceof CompiledDataType dataType) {
+            return typeNameMatches(dataType.name(), variablePattern.name());
+        }
+        if (matchType instanceof CompiledDataParentType parentType && parentType.subTypes().size() == 1) {
+            return typeNameMatches(parentType.subTypes().getFirst().name(), variablePattern.name());
+        }
+        return false;
+    }
+
+    private static boolean isUnconditionalConstructorPattern(
+            CompiledMatchExpression.ConstructorPattern constructorPattern,
+            dev.capylang.compiler.CompiledType matchType
+    ) {
+        if (matchType instanceof CompiledDataType dataType) {
+            return typeNameMatches(dataType.name(), constructorPattern.constructorName());
+        }
+        if (matchType instanceof CompiledDataParentType parentType && parentType.subTypes().size() == 1) {
+            return typeNameMatches(parentType.subTypes().getFirst().name(), constructorPattern.constructorName());
+        }
+        return false;
+    }
+
+    private static boolean isSameSwitchType(
+            dev.capylang.compiler.CompiledType patternType,
+            dev.capylang.compiler.CompiledType matchType
+    ) {
+        if (patternType == matchType || patternType.equals(matchType)) {
+            return true;
+        }
+        if (patternType instanceof CompiledDataType patternDataType && matchType instanceof CompiledDataType matchDataType) {
+            return typeNameMatches(matchDataType.name(), patternDataType.name());
+        }
+        if (patternType instanceof CompiledDataParentType patternParentType && matchType instanceof CompiledDataParentType matchParentType) {
+            return typeNameMatches(matchParentType.name(), patternParentType.name());
+        }
+        return false;
     }
 
     private static PreparedMatchCase prepareMatchCase(
@@ -2269,22 +2326,31 @@ public class JavaExpressionEvaluator {
         var caseBindingNames = new java.util.HashMap<String, String>();
         if (matchCase.pattern() instanceof CompiledMatchExpression.ConstructorPattern constructorPattern) {
             var bindingNames = constructorPatternBindingNames(constructorPattern, caseBindingNames);
+            var constructorValueName = constructorPatternValueName(constructorPattern, caseBindingNames);
+            var fieldExpressions = constructorPatternFieldExpressions(
+                    matchExpression.matchWith().type(),
+                    constructorPattern,
+                    constructorValueName
+            );
             var bindingCastTypes = constructorBindingCastTypes(matchExpression.matchWith().type(), constructorPattern);
             for (int i = 0; i < constructorPattern.fieldPatterns().size(); i++) {
                 var fieldPattern = constructorPattern.fieldPatterns().get(i);
                 var bindingName = bindingNames.get(i);
+                var fieldExpression = fieldExpressions.get(i);
                 if (fieldPattern instanceof CompiledMatchExpression.VariablePattern variablePattern) {
                     branchScope = branchScope.addLocalValue(variablePattern.name());
-                    branchScope = branchScope.addValueOverride(variablePattern.name(), bindingName);
+                    branchScope = branchScope.addValueOverride(bindingName, fieldExpression);
+                    branchScope = branchScope.addValueOverride(variablePattern.name(), fieldExpression);
                     var castType = bindingCastTypes.get(i);
                     if (castType != null && !"java.lang.Object".equals(castType)) {
-                        branchScope = branchScope.addValueOverride(bindingName, "((" + castType + ") " + bindingName + ")");
-                        branchScope = branchScope.addValueOverride(variablePattern.name(), "((" + castType + ") " + bindingName + ")");
+                        var castValue = "((" + castType + ") " + fieldExpression + ")";
+                        branchScope = branchScope.addValueOverride(bindingName, castValue);
+                        branchScope = branchScope.addValueOverride(variablePattern.name(), castValue);
                     }
                 }
                 if (fieldPattern instanceof CompiledMatchExpression.TypedPattern typedPattern) {
                     branchScope = branchScope.addLocalValue(typedPattern.name());
-                    var typedValue = "((" + javaPatternBindingCastType(typedPattern.type()) + ") " + bindingName + ")";
+                    var typedValue = "((" + javaPatternBindingCastType(typedPattern.type()) + ") " + fieldExpression + ")";
                     branchScope = branchScope.addValueOverride(bindingName, typedValue);
                     branchScope = branchScope.addValueOverride(typedPattern.name(), typedValue);
                 }
@@ -2312,13 +2378,6 @@ public class JavaExpressionEvaluator {
                             "((" + castType + ") " + optionSomeBindingExpression(switchTarget + ".orElse(null)") + ")"
                     );
                 }
-            }
-            if (isResultErrorConstructor(matchExpression.matchWith().type(), constructorPattern)
-                && constructorPattern.fieldPatterns().size() == 1
-                && constructorPattern.fieldPatterns().getFirst() instanceof CompiledMatchExpression.VariablePattern variablePattern) {
-                var valueName = variablePattern.name();
-                var generatedName = caseBindingNames.getOrDefault(valueName, valueName);
-                branchScope = branchScope.addValueOverride(valueName, "((" + generatedName + ") == null ? null : " + generatedName + ".getMessage())");
             }
         }
         if (matchCase.pattern() instanceof CompiledMatchExpression.TypedPattern typedPattern) {
@@ -2415,7 +2474,7 @@ public class JavaExpressionEvaluator {
                 .map(field -> {
                     var fieldType = field.type();
                     if (fieldType instanceof dev.capylang.compiler.CompiledFunctionType) {
-                        return null;
+                        return javaConstructorFieldCastType(fieldType, genericCasts);
                     }
                     var resolvedDescriptorCast = sanitizePatternCastType(genericCasts.get(capyTypeDescriptor(fieldType)));
                     if (resolvedDescriptorCast != null) {
@@ -2434,6 +2493,83 @@ public class JavaExpressionEvaluator {
                     return sanitizePatternCastType(javaCastType(fieldType));
                 })
                 .toList();
+    }
+
+    private static String javaConstructorFieldCastType(
+            dev.capylang.compiler.CompiledType type,
+            java.util.Map<String, String> genericCasts
+    ) {
+        return switch (type) {
+            case dev.capylang.compiler.CompiledFunctionType functionType ->
+                    functionType.argumentType() == dev.capylang.compiler.PrimitiveLinkedType.NOTHING
+                            ? "java.util.function.Supplier<"
+                              + javaConstructorFieldCastType(functionType.returnType(), genericCasts)
+                              + ">"
+                            : "java.util.function.Function<"
+                              + javaConstructorFieldCastType(functionType.argumentType(), genericCasts)
+                              + ", "
+                              + javaConstructorFieldCastType(functionType.returnType(), genericCasts)
+                              + ">";
+            case dev.capylang.compiler.CollectionLinkedType.CompiledList listType ->
+                    "java.util.List<" + javaConstructorFieldCastType(listType.elementType(), genericCasts) + ">";
+            case dev.capylang.compiler.CollectionLinkedType.CompiledSet setType ->
+                    "java.util.Set<" + javaConstructorFieldCastType(setType.elementType(), genericCasts) + ">";
+            case dev.capylang.compiler.CollectionLinkedType.CompiledDict dictType ->
+                    "java.util.Map<java.lang.String, "
+                    + javaConstructorFieldCastType(dictType.valueType(), genericCasts)
+                    + ">";
+            case dev.capylang.compiler.CompiledTupleType ignored -> "java.util.List<?>";
+            case dev.capylang.compiler.CompiledGenericTypeParameter genericTypeParameter ->
+                    constructorTypeParameterCast(genericTypeParameter.name(), genericCasts);
+            case dev.capylang.compiler.CompiledDataType dataType when isOptionSomeTypeName(dataType.name()) ||
+                                                               isOptionNoneTypeName(dataType.name()) ->
+                    javaConstructorOptionalCastType(dataType.typeParameters(), genericCasts);
+            case dev.capylang.compiler.CompiledDataParentType parentType when isOptionType(parentType) ->
+                    javaConstructorOptionalCastType(parentType.typeParameters(), genericCasts);
+            case dev.capylang.compiler.CompiledDataType dataType ->
+                    javaConstructorGenericDataTypeCastType(dataType, genericCasts);
+            case dev.capylang.compiler.CompiledDataParentType parentType ->
+                    javaConstructorGenericDataTypeCastType(parentType, genericCasts);
+            default -> javaCastType(type);
+        };
+    }
+
+    private static String javaConstructorGenericDataTypeCastType(
+            dev.capylang.compiler.GenericDataType type,
+            java.util.Map<String, String> genericCasts
+    ) {
+        var raw = normalizeJavaTypeReference(type.name());
+        var typeParameters = switch (type) {
+            case dev.capylang.compiler.CompiledDataType dataType -> dataType.typeParameters();
+            case dev.capylang.compiler.CompiledDataParentType parentType -> parentType.typeParameters();
+            case dev.capylang.compiler.CompiledPrimitiveBackedType ignored -> List.<String>of();
+            case dev.capylang.compiler.CompiledObjectType ignored -> List.<String>of();
+        };
+        if (typeParameters.isEmpty()) {
+            return raw;
+        }
+        var mappedTypeParameters = typeParameters.stream()
+                .map(parameter -> constructorTypeParameterCast(parameter, genericCasts))
+                .toList();
+        return raw + "<" + String.join(", ", mappedTypeParameters) + ">";
+    }
+
+    private static String javaConstructorOptionalCastType(
+            List<String> typeParameters,
+            java.util.Map<String, String> genericCasts
+    ) {
+        if (typeParameters.isEmpty()) {
+            return "java.util.Optional";
+        }
+        return "java.util.Optional<" + constructorTypeParameterCast(typeParameters.getFirst(), genericCasts) + ">";
+    }
+
+    private static String constructorTypeParameterCast(
+            String descriptor,
+            java.util.Map<String, String> genericCasts
+    ) {
+        var resolved = sanitizePatternCastType(genericCasts.get(descriptor));
+        return resolved != null ? resolved : javaGenericTypeParameterReference(descriptor);
     }
 
     private static String capyTypeDescriptor(dev.capylang.compiler.CompiledType type) {
@@ -2826,11 +2962,10 @@ public class JavaExpressionEvaluator {
                     }
                     yield "case " + patternType + " __ignored";
                 }
-                var bindingNames = constructorPatternBindingNames(constructorPattern, caseBindingNames);
-                var constructorCasePattern = "case " + patternType + "("
-                                             + bindingNames.stream().map(name -> "var " + name).reduce((a, b) -> a + ", " + b).orElse("")
-                                             + ")";
-                var guard = constructorPatternGuard(constructorPattern, bindingNames);
+                var constructorValueName = constructorPatternValueName(constructorPattern, caseBindingNames);
+                var constructorCasePattern = "case " + patternType + " " + constructorValueName;
+                var fieldExpressions = constructorPatternFieldExpressions(matchType, constructorPattern, constructorValueName);
+                var guard = constructorPatternGuard(constructorPattern, fieldExpressions);
                 yield guard.map(s -> constructorCasePattern + " when " + s).orElse(constructorCasePattern);
             }
         };
@@ -3186,6 +3321,46 @@ public class JavaExpressionEvaluator {
             }
         }
         return names;
+    }
+
+    private static String constructorPatternValueName(
+            CompiledMatchExpression.ConstructorPattern constructorPattern,
+            java.util.Map<String, String> caseBindingNames
+    ) {
+        var key = "__capybaraConstructorPattern:" + System.identityHashCode(constructorPattern);
+        return caseBindingNames.computeIfAbsent(
+                key,
+                ignored -> "__capybaraMatchBinding" + MATCH_BINDING_COUNTER.incrementAndGet()
+        );
+    }
+
+    private static List<String> constructorPatternFieldExpressions(
+            dev.capylang.compiler.CompiledType matchType,
+            CompiledMatchExpression.ConstructorPattern constructorPattern,
+            String constructorValueName
+    ) {
+        var constructorType = resolveConstructorType(matchType, constructorPattern.constructorName());
+        var expressions = new ArrayList<String>(constructorPattern.fieldPatterns().size());
+        for (int i = 0; i < constructorPattern.fieldPatterns().size(); i++) {
+            if (constructorType == null || i >= constructorType.fields().size()) {
+                expressions.add(constructorValueName);
+                continue;
+            }
+            expressions.add(constructorFieldAccessExpression(constructorType, constructorType.fields().get(i), constructorValueName));
+        }
+        return List.copyOf(expressions);
+    }
+
+    private static String constructorFieldAccessExpression(
+            CompiledDataType constructorType,
+            CompiledDataType.CompiledField field,
+            String constructorValueName
+    ) {
+        if (isResultErrorDataType(constructorType) && "message".equals(field.name())) {
+            return "((" + constructorValueName + ").ex() == null ? null : ("
+                   + constructorValueName + ").ex().getMessage())";
+        }
+        return "(" + constructorValueName + ")." + field.name() + "()";
     }
 
     private static java.util.Optional<String> constructorPatternGuard(

--- a/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -940,7 +940,7 @@ class JavaExpressionEvaluatorTest {
 
         assertThat(generated).contains("case java.lang.Boolean");
         assertThat(generated).contains("java.util.Objects.equals");
-        assertThat(generated).contains("default -> throw new java.lang.IllegalStateException(\"Unexpected bool value:");
+        assertThat(generated).contains("default -> throw new java.lang.IllegalStateException(\"Unexpected value:");
         assertThat(generated).doesNotContain("case true ->");
         assertThat(generated).doesNotContain("case false ->");
     }
@@ -1080,7 +1080,7 @@ class JavaExpressionEvaluatorTest {
                 .map(dev.capylang.generator.GeneratedModule::code)
                 .collect(joining("\n"));
 
-        assertThat(generated).contains("assert_.apply(((T) __capybaraMatchBinding");
+        assertThat(generated).contains("assert_.apply(((T) (__capybaraMatchBinding");
     }
 
     @Test
@@ -1149,8 +1149,8 @@ class JavaExpressionEvaluatorTest {
                 .collect(joining("\n"));
 
         assertThat(generated).contains("import static foo.types.EitherLike.*;");
-        assertThat(generated).contains("case Left(var");
-        assertThat(generated).contains("case Right(var");
+        assertThat(generated).contains("case Left __capybaraMatchBinding");
+        assertThat(generated).contains("case Right __capybaraMatchBinding");
         assertGeneratedJavaCompiles(generatedProgram);
     }
 
@@ -1170,8 +1170,8 @@ class JavaExpressionEvaluatorTest {
                 .map(dev.capylang.generator.GeneratedModule::code)
                 .collect(joining("\n"));
 
-        assertThat(generated).contains("case Passed(var");
-        assertThat(generated).contains("case Failed(var");
+        assertThat(generated).contains("case Passed __capybaraMatchBinding");
+        assertThat(generated).contains("case Failed __capybaraMatchBinding");
         assertThat(generated).doesNotContain("case Outcome.Passed");
         assertThat(generated).doesNotContain("case Outcome.Failed");
         assertGeneratedJavaCompiles(generatedProgram);

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
@@ -1,16 +1,25 @@
+/// Optional value that is either present as Some or absent as None.
 union Option[T] = Some[T] | None
+
+/// Present Option value.
 data Some[T] { value: T }
+
+/// Absent Option value.
 data None {}
 
+/// Transforms a present value using `map`; equivalent to `this.map(map)`.
 fun Option[T].`|`(map: T => Y): Option[Y] = this.map(map)
 
+/// Transforms a present value using `map`, or returns None when empty.
 fun Option[T].map(map: T => Y): Option[Y] =
     match this with
     case None -> None {}
     case Some s -> Some { map(s.value) }
 
+/// Applies `flatmap` to a present value; equivalent to `this.flat_map(flatmap)`.
 fun Option[T].`|*`(flatmap: T => Option[Y]): Option[Y] = this.flat_map(flatmap)
 
+/// Applies `flatmap` to a present value, or returns None when empty.
 fun Option[T].flat_map(flatmap: T => Option[Y]): Option[Y] =
     match this with
     case None -> None {}

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
@@ -1,3 +1,17 @@
 union Option[T] = Some[T] | None
 data Some[T] { value: T }
 data None {}
+
+fun Option[T].`|`(map: T => Y): Option[Y] = this.map(map)
+
+fun Option[T].map(map: T => Y): Option[Y] =
+    match this with
+    case None -> None {}
+    case Some s -> Some { map(s.value) }
+
+fun Option[T].`|*`(flatmap: T => Option[Y]): Option[Y] = this.flat_map(flatmap)
+
+fun Option[T].flat_map(flatmap: T => Option[Y]): Option[Y] =
+    match this with
+    case None -> None {}
+    case Some s -> flatmap(s.value)

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
@@ -2,31 +2,19 @@ union Result[T] = Success[T] | Error
 data Success[T] { value: T }
 data Error { message: String }
 
-fun Result[T].`|`(map: T => Result[Y]): Result[Y] =
-    match this with
-    case Error e -> e
-    case Success s -> map(s.value)
+fun Result[T].`|`(map: T => Y): Result[Y] = this.map(map)
 
-fun Result[T].map(map: T => Result[Y]): Result[Y] =
+fun Result[T].map(map: T => Y): Result[Y] =
     match this with
     case Error e -> e
-    case Success s -> map(s.value)
+    case Success s -> Success { map(s.value) }
 
-fun Result[T].`|*`(flatmap: T => Result[Result[Y]]): Result[Y] =
-    match this with
-    case Error e -> e
-    case Success s ->
-        match flatmap(s.value) with
-        case Error e -> e
-        case Success { top_result } -> top_result
+fun Result[T].`|*`(flatmap: T => Result[Y]): Result[Y] = this.flat_map(flatmap)
 
-fun Result[T].flat_map(flatmap: T => Result[Result[Y]]): Result[Y] =
+fun Result[T].flat_map(flatmap: T => Result[Y]): Result[Y] =
     match this with
     case Error e -> e
-    case Success s ->
-        match flatmap(s.value) with
-        case Error e -> e
-        case Success { top_result } -> top_result
+    case Success s -> flatmap(s.value)
 
 fun Result[T].or_else(v: T): T =
     match this with

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
@@ -1,36 +1,50 @@
+/// Fallible value that is either a Success with a value or an Error with a message.
 union Result[T] = Success[T] | Error
+
+/// Successful Result value.
 data Success[T] { value: T }
+
+/// Failed Result value.
 data Error { message: String }
 
+/// Transforms a successful value using `map`; equivalent to `this.map(map)`.
 fun Result[T].`|`(map: T => Y): Result[Y] = this.map(map)
 
+/// Transforms a successful value using `map`, or propagates an Error unchanged.
 fun Result[T].map(map: T => Y): Result[Y] =
     match this with
     case Error e -> e
     case Success s -> Success { map(s.value) }
 
+/// Applies `flatmap` to a successful value; equivalent to `this.flat_map(flatmap)`.
 fun Result[T].`|*`(flatmap: T => Result[Y]): Result[Y] = this.flat_map(flatmap)
 
+/// Applies `flatmap` to a successful value, or propagates an Error unchanged.
 fun Result[T].flat_map(flatmap: T => Result[Y]): Result[Y] =
     match this with
     case Error e -> e
     case Success s -> flatmap(s.value)
 
+/// Returns the successful value, or `v` when this Result is an Error.
 fun Result[T].or_else(v: T): T =
     match this with
     case Error _ -> v
     case Success { v } -> v
 
+/// Returns this Result when successful, or `r` when this Result is an Error.
 fun Result[T].or(r: Result[T]): Result[T] =
     match this with
     case Error _ -> r
     case Success s -> s
 
+/// Reduces a Result by applying the first function to Success or the second function to Error.
 fun Result[T].`|>`(reduce: Tuple[T => R, String => R]): R =
     match this with
     case Success { v } -> reduce[0](v)
     case Error { msg } -> reduce[1](msg)
 
+/// Reduces a Result by applying `on_success` to Success or `on_error` to Error.
 fun Result[T].reduce(on_success: T => R, on_error: String => R): R = this |> (on_success, on_error)
 
+/// Reduces a Result by applying `on_success` to Success or `on_error` to Error.
 fun Result[T].reduce_left(on_success: T => R, on_error: String => R): R = this.reduce(on_success, on_error)

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -74,9 +74,9 @@ fun to_json(obj: data): Result[JsonObject] =
         }
         case Dict d -> {
             let initial: Result[Dict[Json]] = Success { {:} }
-            d
+            let values <- d
                 |> initial, (acc, key, item) => merge_json_entry(acc, JsonEntry { key, any_to_json(item) })
-                | values => Success { JsonObject { values } }
+            JsonObject { values }
         }
         case Option o -> {
             match o with
@@ -89,7 +89,10 @@ fun to_json(obj: data): Result[JsonObject] =
             case Error { message } -> any_to_json(message)
         }
         case enum e -> Success { JsonString { e.name() } }
-        case data d -> to_json(d) | object => Success { object }
+        case data d -> {
+            let object <- to_json(d)
+            object
+        }
         case _ -> Error { "unsupported value" }
     ---
     let initial: Result[Dict[Json]] = Success { {:} }
@@ -170,11 +173,10 @@ private fun escape_string(value: String): String =
     value |> '', (acc, char) => acc + escape_char(char)
 
 fun deserialize(json: String): Result[JsonObject] =
-    deserialize_json_object(json)
-    | parse =>
-        if parse.parsing_string.size() == 0
-        then Success { value: parse.value }
-        else Error { "Expected string to end, but still got `{parse.parsing_string}`" }
+    let parse <- deserialize_json_object(json)
+    if parse.parsing_string.size() == 0
+    then Success { value: parse.value }
+    else Error { "Expected string to end, but still got `{parse.parsing_string}`" }
 
 private data Parse[T] { value: T, parsing_string: String }
 private fun Parse[T].pop(): Tuple[Option[String], Parse[T]] = (this.parsing_string[0], Parse { this.value, this.parsing_string[1, this.parsing_string.size()] })
@@ -211,12 +213,13 @@ private fun deserialize_json_array(json: String): Result[Parse[JsonArray]] =
     ---
     if json.starts_with('[]')
     then Success { Parse { JsonArray { [] }, json[2, json.size()] } }
-    else
-        deserialize_json(json[1, json.size()])
-            | parse => deserialize_json_array(Parse {
-                value: JsonArray {[parse.value]},
-                parsing_string: parse.parsing_string
-            })
+    else {
+        let parse <- deserialize_json(json[1, json.size()])
+        deserialize_json_array(Parse {
+            value: JsonArray {[parse.value]},
+            parsing_string: parse.parsing_string
+        })
+    }
 
 private fun deserialize_json_null(json: String): Result[Parse[JsonNull]] =
     if json.starts_with('null')
@@ -279,17 +282,16 @@ private fun deserialize_json_number(json: String): Result[Parse[JsonNumber]] =
                     case Some { v2 } -> Error { 'Expected `}`, `]` or `,`, but got `' + v2 + '`!' }
             }
     ---
-    parse_number(Parse {'', drop_white_space(json)})
-    | parse =>
-        if parse.value ? '.'
-        then {
-            let parsed_double <- parse.value.to_double()
-            Parse { JsonNumberDouble { parsed_double }, drop_white_space(parse.parsing_string) }
-        }
-        else {
-            let parsed_long <- parse.value.to_long()
-            Parse { JsonNumberLong { parsed_long }, drop_white_space(parse.parsing_string) }
-        }
+    let parse <- parse_number(Parse {'', drop_white_space(json)})
+    if parse.value ? '.'
+    then {
+        let parsed_double <- parse.value.to_double()
+        Parse { JsonNumberDouble { parsed_double }, drop_white_space(parse.parsing_string) }
+    }
+    else {
+        let parsed_long <- parse.value.to_long()
+        Parse { JsonNumberLong { parsed_long }, drop_white_space(parse.parsing_string) }
+    }
 
 private fun deserialize_json_string(json: String): Result[Parse[JsonString]] =
     let parse <- parse_string(json)
@@ -302,12 +304,11 @@ private fun deserialize_json_object(json: String): Result[Parse[JsonObject]] =
     match json[0] with
     case None -> Error { "message": "Expected JSON object, but got empty string!" }
     case Some { "{" } -> {
-        deserialize_key_values(drop_white_space(json[1, json.size()]))
-        | parse  =>
-            Success { Parse {
-                value: JsonObject { parse.value },
-                parsing_string: parse.parsing_string
-            }}
+        let parse <- deserialize_key_values(drop_white_space(json[1, json.size()]))
+        Parse {
+            value: JsonObject { parse.value },
+            parsing_string: parse.parsing_string
+        }
     }
     case Some { v } -> Error { message: "Expected `{`, but got `" + v + "`."}
 
@@ -340,20 +341,17 @@ private fun deserialize_key_values(json: String): Result[Parse[Dict[Json]]] =
 private data KeyValue { key: String, value: Json }
 
 private fun deserialize_key_value(json: String): Result[Parse[KeyValue]] =
-    parse_string(json)
-    | parse =>
-        match parse.parsing_string[0] with
-        case None -> Error { "Expected `:`, but got end of string!" }
-        case Some { ":" } -> {
-            deserialize_json(drop_white_space(parse.parsing_string[1, parse.parsing_string.size()]))
-            | parse_json => Success {
-                Parse {
-                    KeyValue { parse.value, parse_json.value },
-                    drop_white_space(parse_json.parsing_string)
-                }
-            }
+    let parse <- parse_string(json)
+    match parse.parsing_string[0] with
+    case None -> Error { "Expected `:`, but got end of string!" }
+    case Some { ":" } -> {
+        let parse_json <- deserialize_json(drop_white_space(parse.parsing_string[1, parse.parsing_string.size()]))
+        Parse {
+            KeyValue { parse.value, parse_json.value },
+            drop_white_space(parse_json.parsing_string)
         }
-        case Some { v } ->  Error { "Expected `:`, but got `" + v + "`!" }
+    }
+    case Some { v } ->  Error { "Expected `:`, but got `" + v + "`!" }
 
 private fun parse_string(json: String): Result[Parse[String]] =
     const escape_chars: Set[String] = { '"', '\\', '/', 'b', 'f', 'n', 'r', 't', 'u' }
@@ -436,6 +434,6 @@ fun deserialize(dict: Dict[any]): Result[JsonObject] =
         parsed_dict + { key : json }
     ---
     let initial_result: Result[Dict[Json]] = initial_result()
-    dict
+    let d <- dict
         |> initial_result, (acc, k, v) => merge(acc, k, v)
-        | d => Success { JsonObject { d } }
+    JsonObject { d }

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -208,8 +208,8 @@ fun parse_semver(version: String): Result[SemVer] =
             case Some ->
                 parse_alphanumeric_identifier(version)
                     .or(parse_numeric_identifier(version)
-                        | parse => Success { Parse { buffer: parse.buffer, value: "" + parse.value } })
-                    | parse => Success { parse }
+                        | parse => Parse { buffer: parse.buffer, value: "" + parse.value })
+                    | parse => parse
         /// ```
         /// <build> ::= <dot-separated build identifiers>
         /// ```
@@ -237,7 +237,7 @@ fun parse_semver(version: String): Result[SemVer] =
         fun parse_dot_separated_build_identifier(version: String): Result[Parse[String]] =
             parse_alphanumeric_identifier(version)
                 .or(parse_digits_as_string(version)
-                    | parse => Success { Parse { buffer: parse.buffer, value: "" + parse.value } })
+                    | parse => Parse { buffer: parse.buffer, value: "" + parse.value })
 
         /// ```
         /// <alphanumeric identifier> ::= <non-digit>
@@ -252,20 +252,19 @@ fun parse_semver(version: String): Result[SemVer] =
                 parse_non_digit(version)
                 | (parse_non_digit => {
                     match parse_identifier_characters(parse_non_digit.buffer) with
-                    case Error -> Success { parse_non_digit }
-                    case Success { parse_identifier_characters } -> Success { Parse {
+                    case Error -> parse_non_digit
+                    case Success { parse_identifier_characters } -> Parse {
                         buffer: parse_identifier_characters.buffer,
                         value: parse_non_digit.value + parse_identifier_characters.value
-                    }}})
-                .or(
-                    parse_identifier_characters(version)
-                    | pic => { parse_non_digit(pic.buffer) | pnd => Success { Parse { buffer: pnd.buffer, pic.value + pnd.value }} }
-                    | parse_non_digit => {
-                        match parse_identifier_characters(parse_non_digit.buffer) with
-                        case Error -> Success { parse_non_digit }
-                        case Success { parse_identifier_characters } -> Success { Parse {
-                            buffer: parse_identifier_characters.buffer,
-                            value: pic.value + parse_non_digit.value + parse_identifier_characters.value }}
+                    }})
+                .or({
+                    let pic <- parse_identifier_characters(version)
+                    let parsed_non_digit <- parse_non_digit(pic.buffer)
+                    match parse_identifier_characters(parsed_non_digit.buffer) with
+                    case Error -> Success { Parse { buffer: parsed_non_digit.buffer, value: pic.value + parsed_non_digit.value } }
+                    case Success { parse_identifier_characters } -> Success { Parse {
+                        buffer: parse_identifier_characters.buffer,
+                        value: pic.value + parsed_non_digit.value + parse_identifier_characters.value }}
                     })
         /// ```
         // <identifier characters> ::= <identifier character>
@@ -285,7 +284,7 @@ fun parse_semver(version: String): Result[SemVer] =
         /// ```
         fun parse_identifier_character(version: String): Result[Parse[String]] =
             (parse_digit(version)
-                | parse => Success { Parse { buffer: parse.buffer, value: "" + parse.value } })
+                | parse => Parse { buffer: parse.buffer, value: "" + parse.value })
                 .or(parse_non_digit(version))
         /// ```
         /// <non-digit> ::= <letter>
@@ -338,7 +337,7 @@ fun parse_semver(version: String): Result[SemVer] =
                 match value with
                 case '0' -> Success { Parse { tail(version), '0' } }
                 case _ -> parse_positive_digit(version)
-                    | parse => Success { Parse { buffer: parse.buffer, value: parse.value + '' } }
+                    | parse => Parse { buffer: parse.buffer, value: parse.value + '' }
         /// ```
         /// <positive digit> ::= "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
         /// ```
@@ -379,7 +378,7 @@ fun parse_semver(version: String): Result[SemVer] =
                 case _ -> Error { "Expected A-Z or a-z, but got `" + value + "`!" }
     ---
     parse_version_core(version)
-    | version_parse =>
+    |* version_parse =>
         if !version_parse.buffer.is_empty()
         then Error { 'Unexpected characters after patch version: `' + version_parse.buffer + '`!' }
         else Success { version_parse.value }

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTest.cfun
@@ -96,8 +96,8 @@ private fun test_month(): List[TestCase] =
     ]
 
 private fun test_leap_year(): List[TestCase] =
-    let leap_year = Date { day: 1, month: JANUARY, year: 2020 } | d => Success { d.leap_year() }
-    let not_leap_year = Date { day: 1, month: JANUARY, year: 2019 } | d => Success { d.leap_year() }
+    let leap_year = Date { day: 1, month: JANUARY, year: 2020 } | d => d.leap_year()
+    let not_leap_year = Date { day: 1, month: JANUARY, year: 2019 } | d => d.leap_year()
     [
         test('1/1/2020 should be a leap year', () => assert_that(leap_year).succeeds(true)),
         test('1/1/2019 should not be a leap year', () => assert_that(not_leap_year).succeeds(false)) ]
@@ -109,7 +109,7 @@ private fun date_test_to_iso_8601(): List[TestCase] =
         (7, JANUARY, 10000, "+10000-01-07"),
     ] | (day, month, year, expected) => test(
         "Date.to_iso_8601() should format {day}/{month}/{year}",
-        () => assert_that(Date { day, month, year } | d => Success { d.to_iso_8601() }).succeeds(expected))).as_list()
+        () => assert_that(Date { day, month, year } | d => d.to_iso_8601()).succeeds(expected))).as_list()
 
 private fun date_test_from_iso_8601_success(): List[TestCase] =
     ([

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/TimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/TimeTest.cfun
@@ -126,7 +126,7 @@ private fun test_to_seconds(): List[TestCase] =
         (3, 0, 0, 10800),
     ] | (hour, minute, second, expected) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.to_seconds() should return the {expected} seconds",
-        () => assert_that(local_time(hour, minute, second) | t => Success { t.to_seconds() }).succeeds(expected))).as_list()
+        () => assert_that(local_time(hour, minute, second) | t => t.to_seconds()).succeeds(expected))).as_list()
 
 private fun test_to_minutes(): List[TestCase] =
     ([
@@ -135,7 +135,7 @@ private fun test_to_minutes(): List[TestCase] =
         (3, 0, 0, 180),
     ] | (hour, minute, second, expected) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.to_minutes() should return the {expected} minutes",
-        () => assert_that(local_time(hour, minute, second) | t => Success { t.to_minutes() }).succeeds(expected))).as_list()
+        () => assert_that(local_time(hour, minute, second) | t => t.to_minutes()).succeeds(expected))).as_list()
 
 private fun test_to_hours(): List[TestCase] =
     ([
@@ -144,7 +144,7 @@ private fun test_to_hours(): List[TestCase] =
         (3, 0, 0, 3),
     ] | (hour, minute, second, expected) => test(
         "Time \{ hour: {hour}, minute: {minute}, second: {second} }.to_hours() should return the {expected} hours",
-        () => assert_that(local_time(hour, minute, second) | t => Success { t.to_hours() }).succeeds(expected))).as_list()
+        () => assert_that(local_time(hour, minute, second) | t => t.to_hours()).succeeds(expected))).as_list()
 
 private fun test_round_to_minutes(): TestCase =
     test(

--- a/lib/capybara-lib/src/test/capybara/capy/lang/OptionTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/OptionTest.cfun
@@ -1,0 +1,40 @@
+from /capy/test/Assert import { * }
+from /capy/lang/Effect import { * }
+from /capy/lang/Option import { * }
+from /capy/test/CapyTest import { * }
+
+fun tests(): Effect[TestFile] =
+    test_file("/capy/lang/OptionTest.cfun", [
+        test("should map some", () => should_map_some()),
+        test("should map none", () => should_map_none()),
+        test("should flatmap some", () => should_flatmap_some()),
+        test("should flatmap none", () => should_flatmap_none()),
+    ])
+
+fun should_map_some(): Assert =
+    let option: Option[String] = Some { "value" }
+    assert_all([
+        assert_that(option.map(value => "mapped_" + value)).contains("mapped_value"),
+        assert_that(option | value => "mapped_" + value).contains("mapped_value"),
+    ])
+
+fun should_map_none(): Assert =
+    let option: Option[String] = None {}
+    assert_all([
+        assert_that(option.map(value => "mapped_" + value)).is_empty(),
+        assert_that(option | value => "mapped_" + value).is_empty(),
+    ])
+
+fun should_flatmap_some(): Assert =
+    let option: Option[String] = Some { "value" }
+    assert_all([
+        assert_that(option.flat_map(value => Some { "mapped_" + value })).contains("mapped_value"),
+        assert_that(option |* value => Some { "mapped_" + value }).contains("mapped_value"),
+    ])
+
+fun should_flatmap_none(): Assert =
+    let option: Option[String] = None {}
+    assert_all([
+        assert_that(option.flat_map(value => Some { "mapped_" + value })).is_empty(),
+        assert_that(option |* value => Some { "mapped_" + value }).is_empty(),
+    ])

--- a/lib/capybara-lib/src/test/capybara/capy/lang/ResultTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/ResultTest.cfun
@@ -24,12 +24,12 @@ fun tests(): Effect[TestFile] =
 
 fun should_map_success(): Assert =
     let result: Result = Success { "success_value" }
-    let mapped = result | value => Success { "mapped_" + value }
+    let mapped = result | value => "mapped_" + value
     assert_that(mapped).succeeds("mapped_success_value")
 
 fun should_map_error(): Assert =
     let result: Result = Error { "error message" }
-    let mapped = result | value => Success { "mapped_" + value }
+    let mapped = result | value => "mapped_" + value
     assert_that(mapped).fails("error message")
 
 private fun positive(x: int): Result[String] =
@@ -37,29 +37,29 @@ private fun positive(x: int): Result[String] =
     then Success { x + " is positive" }
     else Error { x + " is NOT positive" }
 
-private fun positive_not_zero(x: int): Result[Result[String]] =
+private fun positive_not_zero(x: int): Result[String] =
     if x != 0
-    then Success { positive(x) }
+    then positive(x)
     else Error { "I don't like zero" }
 
 fun should_map_positive(): Assert =
     let result = Success { 420 }
-    let mapped = result | :positive
+    let mapped = result | x => x + " is positive"
     assert_that(mapped).succeeds("420 is positive")
 
 fun should_map_negative(): Assert =
     let result = Success { -1337 }
-    let mapped = result | :positive
-    assert_that(mapped).fails("-1337 is NOT positive")
+    let mapped = result | x => x + " is negative"
+    assert_that(mapped).succeeds("-1337 is negative")
 
 fun should_flatmap_success(): Assert =
     let result: Result = Success { "success_value" }
-    let mapped = result |* value => Success { Success { "mapped_" + value } }
+    let mapped = result |* value => Success { "mapped_" + value }
     assert_that(mapped).succeeds("mapped_success_value")
 
 fun should_flatmap_error(): Assert =
     let result: Result = Error { "error message" }
-    let mapped = result |* value => Success { Success { "mapped_" + value } }
+    let mapped = result |* value => Success { "mapped_" + value }
     assert_that(mapped).fails("error message")
 
 fun should_flatmap_positive(): Assert =
@@ -106,4 +106,3 @@ fun should_reduce_error_result(): Assert =
     let result: Result[int] = Error { "Unknown" }
     let reduced: String = result |> (x=>x+"", msg=>msg)
     assert_that(reduced).is_equal_to("Unknown")
-


### PR DESCRIPTION
## What changed

- Reworked `Result.|` and `Result.|*` so the operators delegate to `map` and `flat_map`.
- Made `Result.map` wrap plain mapped values in `Success`, while `Result.flat_map` returns the mapper result directly.
- Added non-native `Option.map`, `Option.flat_map`, `Option.|`, and `Option.|*` helpers with matching tests.
- Updated library and e2e code that was using `|` for fallible Result-returning chains to use `|*` or `let <-`.
- Adjusted Java/JS/Python generated runtime behavior and Java match code so the changed library compiles across backends.

## Impacted modules

- `lib/capybara-lib` standard library and generated Capybara tests.
- `capy` compiler/generator code and functional/object-oriented e2e suites.

## Sample

```cfun
fun Result[T].`|`(map: T => Y): Result[Y] = this.map(map)
fun Result[T].`|*`(flatmap: T => Result[Y]): Result[Y] = this.flat_map(flatmap)
```

## Commands run

- `./gradlew :lib:capybara-lib:compileJava`
- `./gradlew :lib:capybara-lib:testCapybara`
- `./gradlew :capy:test --console=plain`
- `./gradlew --no-daemon --max-workers=1 --console=plain :capy:e2e-cfun --rerun-tasks`
- `./gradlew --no-daemon --max-workers=1 --console=plain :capy:e2eTests`
