### PR TITLE
fix(#249): emit Java strings as java.lang.String

### DIFF
--- a/capy/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -32,6 +32,7 @@ import static dev.capylang.generator.java.JavaExpressionEvaluator.evaluateTailRe
 
 public final class JavaGenerator implements Generator {
     private static final Logger log = Logger.getLogger(JavaGenerator.class.getName());
+    private static final String CAPY_LANG_STRING_CLASS = "capy.lang.String";
     private static final String METHOD_DECL_PREFIX = "__method__";
     private static final String PRIMITIVE_BACKED_TYPE_CONSTRUCTOR_FUNCTION_PREFIX = "__constructor__primitive__";
     private static final Set<String> JAVA_KEYWORDS = Set.of(
@@ -1325,7 +1326,9 @@ public final class JavaGenerator implements Generator {
                         classImports.add(companionImport);
                     }
                 });
-        classImports.forEach(classImport -> code.append("import ").append(classImport).append(";\n"));
+        classImports.stream()
+                .filter(classImport -> !CAPY_LANG_STRING_CLASS.equals(classImport))
+                .forEach(classImport -> code.append("import ").append(classImport).append(";\n"));
         staticImports.stream()
                 .sorted()
                 .filter(staticImport -> !isTypeImport(staticImport))
@@ -1915,7 +1918,7 @@ public final class JavaGenerator implements Generator {
         var failedType = programType + ".Failed";
         return capybaraMainMethod
                + "\n"
-               + "public static final void main(String... args) {\n"
+               + "public static final void main(java.lang.String... args) {\n"
                + "var __capybaraArgsList = java.util.List.of(args);\n"
                + programType + " __capybaraProgram = " + mapMethodName(method.name()) + "(__capybaraArgsList).unsafeRun();\n"
                + "if (__capybaraProgram instanceof " + failedType + " __capybaraFailed) {\n"

--- a/capy/src/test/java/dev/capylang/generator/ProgramMainSourceGeneratorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/ProgramMainSourceGeneratorTest.java
@@ -22,7 +22,7 @@ class ProgramMainSourceGeneratorTest {
         assertThat(main)
                 .contains("public static capy.lang.Effect<Program> main(java.util.List<java.lang.String> args)")
                 .containsSubsequence(
-                        "public static final void main(String... args)",
+                        "public static final void main(java.lang.String... args)",
                         "var __capybaraArgsList = java.util.List.of(args);",
                         "Program __capybaraProgram = main(__capybaraArgsList).unsafeRun();",
                         "if (__capybaraProgram instanceof Program.Failed __capybaraFailed)",
@@ -35,7 +35,7 @@ class ProgramMainSourceGeneratorTest {
         var directProgramMain = generatedCode(generated, Path.of("foo", "SecondaryMain.java"));
         assertThat(directProgramMain)
                 .contains("public static capy.lang.Program main(java.util.List<java.lang.String> args)")
-                .doesNotContain("public static final void main(String... args)")
+                .doesNotContain("public static final void main(java.lang.String... args)")
                 .doesNotContain("unsafeRun()")
                 .doesNotContain("System.exit(");
     }

--- a/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -553,6 +553,29 @@ class JavaExpressionEvaluatorTest {
     }
 
     @Test
+    void shouldNotImportCapyLangStringAsClassWhenStringModuleIsImported() {
+        var generatedProgram = new JavaGenerator().generate(compileProgram(List.of(
+                new RawModule("String", "/capy/lang", """
+                        data String { <native> }
+                        fun String.trim(): String = <native>
+                        """),
+                new RawModule("Consumer", "/foo/app", """
+                        from /capy/lang/String import { * }
+
+                        fun normalized(value: String): String = value.trim()
+                        """)
+        )));
+        var generated = generatedProgram.modules().stream()
+                .map(dev.capylang.generator.GeneratedModule::code)
+                .collect(joining("\n"));
+
+        assertThat(generated)
+                .contains("import static capy.lang.String.*;")
+                .doesNotContain("import capy.lang.String;")
+                .contains("public static java.lang.String normalized(java.lang.String value)");
+    }
+
+    @Test
     void shouldStillRequireBracesForSingleValues() {
         var programResult = CapybaraCompiler.INSTANCE.compile(List.of(new RawModule("test", "/foo/boo", """
                 data Done {}
@@ -1104,7 +1127,11 @@ class JavaExpressionEvaluatorTest {
                 .map(dev.capylang.generator.GeneratedModule::code)
                 .collect(joining("\n"));
 
-        assertThat(generated).contains("capy.lang.Effect<capy.lang.Program>");
+        assertThat(generated)
+                .contains("capy.lang.Effect<capy.lang.Program>")
+                .contains("public static capy.lang.Effect<capy.lang.Program> main(java.util.List<java.lang.String> args)")
+                .contains("public static final void main(java.lang.String... args)")
+                .doesNotContain("public static final void main(String... args)");
         assertGeneratedJavaCompiles(generatedProgram);
     }
 


### PR DESCRIPTION
## What changed
- Skip the derived class import for `capy.lang.String` while preserving `import static capy.lang.String.*;` for extension calls.
- Emit generated executable launchers as `main(java.lang.String... args)`.
- Added regression coverage for `/capy/lang/String` imports, launcher signatures, and generated Java compilation for `main(args: List[String])`.

## Why
Generated Java could import `capy.lang.String` as a class, shadowing `java.lang.String` and breaking generated launcher/code signatures that should use the Java runtime string type.

## Validation
- `./gradlew :capy:test --tests dev.capylang.generator.java.JavaExpressionEvaluatorTest --tests dev.capylang.generator.ProgramMainSourceGeneratorTest`
- `./gradlew :lib:capybara-lib:compileCapybara`
- `./gradlew :capy:test`
- `./gradlew :lib:capybara-lib:compileCapybara --rerun-tasks`