### PR TITLE
feat(#254): add typed JSON metadata support

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -37,11 +37,28 @@ fun JsonValueArray.get(idx: index): Option[Json] = this.value.get(idx)
 data JsonBool { value: bool }
 data JsonNull {}
 
+/// Typed JSON representation that preserves Capy metadata.
+///
+/// Unlike plain `Json`, this representation is opt-in and records data
+/// constructor names, package metadata, collection kind, and primitive numeric
+/// kind. Use it when structurally identical union variants must remain
+/// distinguishable after serialization.
 union TypedJson = TypedJsonData | TypedJsonObject | TypedJsonArray | TypedJsonValue
+/// Package metadata for a typed Capy data constructor.
 data TypedJsonPackage { name: String, path: String }
+/// Typed Capy data value with constructor name, package metadata, and typed fields.
 data TypedJsonData { name: String, pkg: TypedJsonPackage, fields: Dict[TypedJson] }
+/// Typed object node used for dictionary-like values.
 data TypedJsonObject { value: Dict[TypedJson] }
+/// Typed array node used for collection values.
+///
+/// The `kind` field records the source collection family, such as `List` or
+/// `Set`, because both are represented as JSON arrays.
 data TypedJsonArray { kind: String, value: List[TypedJson] }
+/// Typed primitive value.
+///
+/// Numeric variants are separate so `int`, `long`, `float`, `double`, and
+/// `byte` values can be distinguished after a typed JSON round trip.
 union TypedJsonValue =
     TypedJsonString
     | TypedJsonByte
@@ -51,13 +68,24 @@ union TypedJsonValue =
     | TypedJsonDouble
     | TypedJsonBool
     | TypedJsonNull
+/// Typed string value.
 data TypedJsonString { value: String }
+/// Typed byte value.
+///
+/// The byte payload is stored as `int` while the `TypedJsonByte` constructor
+/// preserves the original numeric kind.
 data TypedJsonByte { value: int }
+/// Typed int value.
 data TypedJsonInt { value: int }
+/// Typed long value.
 data TypedJsonLong { value: long }
+/// Typed float value.
 data TypedJsonFloat { value: float }
+/// Typed double value.
 data TypedJsonDouble { value: double }
+/// Typed bool value.
 data TypedJsonBool { value: bool }
+/// Typed null value.
 data TypedJsonNull {}
 
 deriver Jsonable {
@@ -156,6 +184,12 @@ fun stringify(json: Json): String =
 
 fun serialize(obj: JsonObject): String = stringify(obj)
 
+/// Converts a Capy data value into typed JSON metadata.
+///
+/// The result keeps the concrete constructor name from reflection, package
+/// metadata, and typed field values. `Option` and `Result` fields keep their
+/// concrete variants (`Some`, `None`, `Success`, `Error`) instead of collapsing
+/// to their plain JSON payload representation.
 fun to_typed_json(obj: data): Result[TypedJsonData] =
     match any_to_typed_json(obj) with
     case Success { typed } -> {
@@ -165,10 +199,19 @@ fun to_typed_json(obj: data): Result[TypedJsonData] =
     }
     case Error e -> e
 
+/// Converts typed JSON to a JSON string using the reserved typed envelope.
+///
+/// The envelope field is `$capybaraTypedJson`, which separates typed data,
+/// object, array, and primitive value nodes from ordinary user JSON objects.
 fun stringify_typed(json: TypedJson): String = stringify(typed_json_to_json(json))
 
+/// Serializes a typed data value to a JSON string.
 fun serialize_typed(obj: TypedJsonData): String = stringify_typed(obj)
 
+/// Parses a JSON string produced by `serialize_typed` into typed JSON metadata.
+///
+/// This does not reconstruct the original runtime Capy data value. It returns a
+/// typed AST that callers can inspect without Java reflection.
 fun deserialize_typed(json: String): Result[TypedJsonData] =
     let parsed <- deserialize(json)
     let typed <- json_to_typed_json(parsed)

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -9,6 +9,8 @@ from /capy/lang/String import { * }
 from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
 from /capy/meta_prog/Recursive import { Recursive }
 
+private const TYPED_JSON_ENVELOPE_FIELD: String = "$capybaraTypedJson"
+
 union Json = JsonObject | JsonArray | JsonValue
 data JsonObject { value: Dict[Json] }
 fun JsonObject.`+`(other: JsonObject): JsonObject = JsonObject { value: this.value + other.value }
@@ -34,6 +36,30 @@ data JsonValueArray { value: JsonArray }
 fun JsonValueArray.get(idx: index): Option[Json] = this.value.get(idx)
 data JsonBool { value: bool }
 data JsonNull {}
+
+union TypedJson = TypedJsonData | TypedJsonObject | TypedJsonArray | TypedJsonValue
+data TypedJsonPackage { name: String, path: String }
+data TypedJsonData { name: String, pkg: TypedJsonPackage, fields: Dict[TypedJson] }
+data TypedJsonObject { value: Dict[TypedJson] }
+data TypedJsonArray { kind: String, value: List[TypedJson] }
+union TypedJsonValue =
+    TypedJsonString
+    | TypedJsonByte
+    | TypedJsonInt
+    | TypedJsonLong
+    | TypedJsonFloat
+    | TypedJsonDouble
+    | TypedJsonBool
+    | TypedJsonNull
+data TypedJsonString { value: String }
+data TypedJsonByte { value: int }
+data TypedJsonInt { value: int }
+data TypedJsonLong { value: long }
+data TypedJsonFloat { value: float }
+data TypedJsonDouble { value: double }
+data TypedJsonBool { value: bool }
+data TypedJsonNull {}
+
 deriver Jsonable {
     fun to_json(): Result[JsonObject] = to_json(receiver)
 }
@@ -129,6 +155,376 @@ fun stringify(json: Json): String =
     case JsonNull -> "null"
 
 fun serialize(obj: JsonObject): String = stringify(obj)
+
+fun to_typed_json(obj: data): Result[TypedJsonData] =
+    match any_to_typed_json(obj) with
+    case Success { typed } -> {
+        match typed with
+        case TypedJsonData typed_data -> Success { typed_data }
+        case _ -> Error { "Expected data value" }
+    }
+    case Error e -> e
+
+fun stringify_typed(json: TypedJson): String = stringify(typed_json_to_json(json))
+
+fun serialize_typed(obj: TypedJsonData): String = stringify_typed(obj)
+
+fun deserialize_typed(json: String): Result[TypedJsonData] =
+    let parsed <- deserialize(json)
+    let typed <- json_to_typed_json(parsed)
+    match typed with
+    case TypedJsonData typed_data -> Success { typed_data }
+    case _ -> Error { "Expected typed JSON data" }
+
+private fun any_to_typed_json(value: any): Result[TypedJson] =
+    match value with
+    case TypedJson typed -> Success { typed }
+    case String s -> Success { TypedJsonString { s } }
+    case int i -> Success { TypedJsonInt { i } }
+    case long l -> Success { TypedJsonLong { l } }
+    case double d -> Success { TypedJsonDouble { d } }
+    case float f -> Success { TypedJsonFloat { f } }
+    case byte b -> Success { TypedJsonByte { b + 0 } }
+    case bool b -> Success { TypedJsonBool { b } }
+    case List l -> {
+        let initial: Result[List[TypedJson]] = Success { [] }
+        let values <- l |> initial, (acc_result, item) => {
+            let acc <- acc_result
+            let encoded <- any_to_typed_json(item)
+            Success { acc + encoded }
+        }
+        TypedJsonArray { kind: "List", value: values }
+    }
+    case Set s -> {
+        let initial: Result[List[TypedJson]] = Success { [] }
+        let values <- s |> initial, (acc_result, item) => {
+            let acc <- acc_result
+            let encoded <- any_to_typed_json(item)
+            Success { acc + encoded }
+        }
+        TypedJsonArray { kind: "Set", value: values }
+    }
+    case Dict d -> {
+        let initial: Result[Dict[TypedJson]] = Success { {:} }
+        let values <- d |> initial, (acc_result, key, item) => {
+            let acc <- acc_result
+            let encoded <- any_to_typed_json(item)
+            Success { acc + { key : encoded } }
+        }
+        TypedJsonObject { value: values }
+    }
+    case Option o -> typed_option_to_json(o)
+    case Result r -> typed_result_to_json(r)
+    case data d -> typed_data_to_json(d)
+    case _ -> Error { "unsupported value" }
+
+private fun typed_option_to_json(option: Option[any]): Result[TypedJsonData] =
+    match option with
+    case Some { value } -> {
+        let encoded <- any_to_typed_json(value)
+        TypedJsonData {
+            name: "Some",
+            pkg: TypedJsonPackage { name: "capy.lang", path: "capy/lang/Option" },
+            fields: { "value": encoded }
+        }
+    }
+    case None -> Success {
+        TypedJsonData {
+            name: "None",
+            pkg: TypedJsonPackage { name: "capy.lang", path: "capy/lang/Option" },
+            fields: {:}
+        }
+    }
+
+private fun typed_result_to_json(result: Result[any]): Result[TypedJsonData] =
+    match result with
+    case Success { value } -> {
+        let encoded <- any_to_typed_json(value)
+        TypedJsonData {
+            name: "Success",
+            pkg: TypedJsonPackage { name: "capy.lang", path: "capy/lang/Result" },
+            fields: { "value": encoded }
+        }
+    }
+    case Error { message } -> Success {
+        TypedJsonData {
+            name: "Error",
+            pkg: TypedJsonPackage { name: "capy.lang", path: "capy/lang/Result" },
+            fields: { "message": TypedJsonString { message } }
+        }
+    }
+
+private fun typed_data_to_json(obj: data): Result[TypedJsonData] =
+    let info = reflection(obj)
+    let initial: Result[Dict[TypedJson]] = Success { {:} }
+    let fields <- info.fields
+        |> initial, (acc_result, field) => {
+            let acc <- acc_result
+            match any_to_typed_json_by_type(field.type.name, field.value) with
+            case Success { encoded } -> Success { acc + { field.name : encoded } }
+            case Error { message } -> Error { "Cannot convert field `" + field.name + "` to typed JSON: " + message }
+        }
+    TypedJsonData {
+        name: info.name,
+        pkg: TypedJsonPackage { name: info.pkg.name, path: info.pkg.path },
+        fields: fields
+    }
+
+private fun typed_json_to_json(json: TypedJson): JsonObject =
+    match json with
+    case TypedJsonData { name, pkg, fields } -> JsonObject {
+        value: {
+            TYPED_JSON_ENVELOPE_FIELD: JsonString { value: "data" },
+            "name": JsonString { value: name },
+            "pkg": typed_package_to_json(pkg),
+            "fields": typed_fields_to_json(fields),
+        }
+    }
+    case TypedJsonObject { value } -> JsonObject {
+        value: {
+            TYPED_JSON_ENVELOPE_FIELD: JsonString { value: "object" },
+            "value": typed_fields_to_json(value),
+        }
+    }
+    case TypedJsonArray { kind, value } -> {
+        let initial: List[Json] = []
+        let encoded: List[Json] = value |> initial, (acc, item) => acc + typed_json_to_json(item)
+        JsonObject {
+            value: {
+                TYPED_JSON_ENVELOPE_FIELD: JsonString { value: "array" },
+                "kind": JsonString { value: kind },
+                "value": JsonArray { value: encoded },
+            }
+        }
+    }
+    case TypedJsonString { value } -> typed_value_to_json("String", JsonString { value })
+    case TypedJsonByte { value } -> typed_value_to_json("byte", JsonNumberLong { value })
+    case TypedJsonInt { value } -> typed_value_to_json("int", JsonNumberLong { value })
+    case TypedJsonLong { value } -> typed_value_to_json("long", JsonNumberLong { value })
+    case TypedJsonFloat { value } -> typed_value_to_json("float", JsonNumberDouble { value })
+    case TypedJsonDouble { value } -> typed_value_to_json("double", JsonNumberDouble { value })
+    case TypedJsonBool { value } -> typed_value_to_json("bool", JsonBool { value })
+    case TypedJsonNull -> JsonObject {
+        value: {
+            TYPED_JSON_ENVELOPE_FIELD: JsonString { value: "value" },
+            "kind": JsonString { value: "null" },
+            "value": JsonNull {},
+        }
+    }
+
+private fun typed_package_to_json(pkg: TypedJsonPackage): JsonObject =
+    JsonObject {
+        value: {
+            "name": JsonString { value: pkg.name },
+            "path": JsonString { value: pkg.path },
+        }
+    }
+
+private fun typed_fields_to_json(fields: Dict[TypedJson]): JsonObject =
+    JsonObject {
+        value: fields | (_, value) => typed_json_to_json(value)
+    }
+
+private fun typed_value_to_json(kind: String, value: Json): JsonObject =
+    JsonObject {
+        value: {
+            TYPED_JSON_ENVELOPE_FIELD: JsonString { value: "value" },
+            "kind": JsonString { value: kind },
+            "value": value,
+        }
+    }
+
+private fun json_to_typed_json(json: Json): Result[TypedJson] =
+    match json with
+    case JsonObject object -> {
+        let marker <- json_string_field(object, TYPED_JSON_ENVELOPE_FIELD)
+        match marker with
+        case "data" -> parse_typed_data(object)
+        case "object" -> parse_typed_object(object)
+        case "array" -> parse_typed_array(object)
+        case "value" -> parse_typed_value(object)
+        case _ -> Error { "Unknown typed JSON marker `" + marker + "`" }
+    }
+    case _ -> Error { "Expected typed JSON envelope object" }
+
+private fun parse_typed_data(object: JsonObject): Result[TypedJsonData] =
+    let name <- json_string_field(object, "name")
+    let pkg_json <- json_field(object, "pkg")
+    let pkg <- parse_typed_package(pkg_json)
+    let fields_json <- json_field(object, "fields")
+    let fields <- parse_typed_fields(fields_json)
+    TypedJsonData { name: name, pkg: pkg, fields: fields }
+
+private fun parse_typed_object(object: JsonObject): Result[TypedJsonObject] =
+    let value_json <- json_field(object, "value")
+    let value <- parse_typed_fields(value_json)
+    TypedJsonObject { value: value }
+
+private fun parse_typed_array(object: JsonObject): Result[TypedJsonArray] =
+    let kind <- json_string_field(object, "kind")
+    let value_json <- json_field(object, "value")
+    match value_json with
+    case JsonArray { value } -> {
+        let initial: Result[List[TypedJson]] = Success { [] }
+        let values <- value |> initial, (acc_result, item) => {
+            let acc <- acc_result
+            let parsed <- json_to_typed_json(item)
+            Success { acc + parsed }
+        }
+        TypedJsonArray { kind: kind, value: values }
+    }
+    case _ -> Error { "Expected typed JSON array value to be a JSON array" }
+
+private fun parse_typed_value(object: JsonObject): Result[TypedJsonValue] =
+    let kind <- json_string_field(object, "kind")
+    let value <- json_field(object, "value")
+    match kind with
+    case "String" -> {
+        let parsed <- json_string_value(value)
+        TypedJsonString { parsed }
+    }
+    case "byte" -> {
+        let parsed <- json_long_value(value)
+        TypedJsonByte { typed_json_long_to_int(parsed) }
+    }
+    case "int" -> {
+        let parsed <- json_long_value(value)
+        TypedJsonInt { typed_json_long_to_int(parsed) }
+    }
+    case "long" -> {
+        let parsed <- json_long_value(value)
+        TypedJsonLong { parsed }
+    }
+    case "float" -> {
+        let parsed <- json_double_value(value)
+        let float_value <- typed_json_double_to_float(parsed)
+        TypedJsonFloat { float_value }
+    }
+    case "double" -> {
+        let parsed <- json_double_value(value)
+        TypedJsonDouble { parsed }
+    }
+    case "bool" -> {
+        let parsed <- json_bool_value(value)
+        TypedJsonBool { parsed }
+    }
+    case "null" -> Success { TypedJsonNull {} }
+    case _ -> Error { "Unknown typed JSON value kind `" + kind + "`" }
+
+private fun parse_typed_package(json: Json): Result[TypedJsonPackage] =
+    match json with
+    case JsonObject object -> {
+        let name <- json_string_field(object, "name")
+        let path <- json_string_field(object, "path")
+        TypedJsonPackage { name: name, path: path }
+    }
+    case _ -> Error { "Expected typed JSON package to be an object" }
+
+private fun parse_typed_fields(json: Json): Result[Dict[TypedJson]] =
+    match json with
+    case JsonObject { value } -> {
+        let initial: Result[Dict[TypedJson]] = Success { {:} }
+        value |> initial, (acc_result, key, item) => {
+            let acc <- acc_result
+            let parsed <- json_to_typed_json(item)
+            Success { acc + { key : parsed } }
+        }
+    }
+    case _ -> Error { "Expected typed JSON fields to be an object" }
+
+private fun json_field(object: JsonObject, name: String): Result[Json] =
+    match object.get(name) with
+    case Some { value } -> Success { value }
+    case None -> Error { "Expected JSON object field `" + name + "`" }
+
+private fun json_string_field(object: JsonObject, name: String): Result[String] =
+    let value <- json_field(object, name)
+    json_string_value(value)
+
+private fun json_string_value(json: Json): Result[String] =
+    match json with
+    case JsonString { value } -> Success { value }
+    case _ -> Error { "Expected JSON string" }
+
+private fun json_long_value(json: Json): Result[long] =
+    match json with
+    case JsonNumberLong { value } -> Success { value }
+    case _ -> Error { "Expected JSON long number" }
+
+private fun json_double_value(json: Json): Result[double] =
+    match json with
+    case JsonNumberDouble { value } -> Success { value }
+    case JsonNumberLong { value } -> Success { value }
+    case _ -> Error { "Expected JSON double number" }
+
+private fun json_bool_value(json: Json): Result[bool] =
+    match json with
+    case JsonBool { value } -> Success { value }
+    case _ -> Error { "Expected JSON bool" }
+
+private fun any_to_typed_json_by_type(type_name: String, value: any): Result[TypedJson] =
+    match type_name with
+    case "byte" -> typed_byte_value(value)
+    case "int" -> typed_int_value(value)
+    case "long" -> typed_long_value(value)
+    case "float" -> typed_float_value(value)
+    case "double" -> typed_double_value(value)
+    case _ -> any_to_typed_json(value)
+
+private fun typed_byte_value(value: any): Result[TypedJsonByte] =
+    match value with
+    case byte b -> Success { TypedJsonByte { b + 0 } }
+    case int i -> Success { TypedJsonByte { i } }
+    case long l -> Success { TypedJsonByte { typed_json_long_to_int(l) } }
+    case _ -> Error { "expected byte value" }
+
+private fun typed_int_value(value: any): Result[TypedJsonInt] =
+    match value with
+    case int i -> Success { TypedJsonInt { i } }
+    case byte b -> Success { TypedJsonInt { b + 0 } }
+    case long l -> Success { TypedJsonInt { typed_json_long_to_int(l) } }
+    case _ -> Error { "expected int value" }
+
+private fun typed_long_value(value: any): Result[TypedJsonLong] =
+    match value with
+    case long l -> Success { TypedJsonLong { l } }
+    case int i -> Success { TypedJsonLong { i } }
+    case byte b -> Success { TypedJsonLong { b + 0L } }
+    case _ -> Error { "expected long value" }
+
+private fun typed_float_value(value: any): Result[TypedJsonFloat] =
+    match value with
+    case float f -> Success { TypedJsonFloat { f } }
+    case double d -> {
+        let f <- typed_json_double_to_float(d)
+        TypedJsonFloat { f }
+    }
+    case int i -> {
+        let f <- typed_json_double_to_float(i)
+        TypedJsonFloat { f }
+    }
+    case long l -> {
+        let f <- typed_json_double_to_float(l)
+        TypedJsonFloat { f }
+    }
+    case byte b -> {
+        let f <- typed_json_double_to_float(b + 0L)
+        TypedJsonFloat { f }
+    }
+    case _ -> Error { "expected float value" }
+
+private fun typed_double_value(value: any): Result[TypedJsonDouble] =
+    match value with
+    case double d -> Success { TypedJsonDouble { d } }
+    case float f -> Success { TypedJsonDouble { f } }
+    case long l -> Success { TypedJsonDouble { l } }
+    case int i -> Success { TypedJsonDouble { i } }
+    case byte b -> Success { TypedJsonDouble { b + 0L } }
+    case _ -> Error { "expected double value" }
+
+private fun typed_json_long_to_int(value: long): int = value.to_int()
+
+private fun typed_json_double_to_float(value: double): Result[float] = ("" + value).to_float()
 
 private fun escape_string(value: String): String =
     fun unicode_control(hex: String): String = '\\' + 'u00' + hex

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -4,6 +4,7 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 from /capy/lang/Result import { * }
+from /capy/lang/Primitives import { safe_long_to_int }
 from /capy/collection/Seq import { * }
 from /capy/lang/String import { * }
 from /capy/meta_prog/Reflection import { DataValueInfo, reflection }
@@ -428,11 +429,13 @@ private fun parse_typed_value(object: JsonObject): Result[TypedJsonValue] =
     }
     case "byte" -> {
         let parsed <- json_long_value(value)
-        TypedJsonByte { typed_json_long_to_int(parsed) }
+        let int_value <- typed_json_long_to_int(parsed)
+        TypedJsonByte { int_value }
     }
     case "int" -> {
         let parsed <- json_long_value(value)
-        TypedJsonInt { typed_json_long_to_int(parsed) }
+        let int_value <- typed_json_long_to_int(parsed)
+        TypedJsonInt { int_value }
     }
     case "long" -> {
         let parsed <- json_long_value(value)
@@ -518,14 +521,20 @@ private fun typed_byte_value(value: any): Result[TypedJsonByte] =
     match value with
     case byte b -> Success { TypedJsonByte { b + 0 } }
     case int i -> Success { TypedJsonByte { i } }
-    case long l -> Success { TypedJsonByte { typed_json_long_to_int(l) } }
+    case long l -> {
+        let int_value <- typed_json_long_to_int(l)
+        TypedJsonByte { int_value }
+    }
     case _ -> Error { "expected byte value" }
 
 private fun typed_int_value(value: any): Result[TypedJsonInt] =
     match value with
     case int i -> Success { TypedJsonInt { i } }
     case byte b -> Success { TypedJsonInt { b + 0 } }
-    case long l -> Success { TypedJsonInt { typed_json_long_to_int(l) } }
+    case long l -> {
+        let int_value <- typed_json_long_to_int(l)
+        TypedJsonInt { int_value }
+    }
     case _ -> Error { "expected int value" }
 
 private fun typed_long_value(value: any): Result[TypedJsonLong] =
@@ -565,7 +574,7 @@ private fun typed_double_value(value: any): Result[TypedJsonDouble] =
     case byte b -> Success { TypedJsonDouble { b + 0L } }
     case _ -> Error { "expected double value" }
 
-private fun typed_json_long_to_int(value: long): int = value.to_int()
+private fun typed_json_long_to_int(value: long): Result[int] = safe_long_to_int(value)
 
 private fun typed_json_double_to_float(value: double): Result[float] = ("" + value).to_float()
 

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -38,6 +38,31 @@ data JsonableNestedSample {
     metadata: Dict[int],
     raw: Json
 } derive Jsonable
+union TypedJsonShapeSample { name: String } =
+    TypedJsonListShape
+    | TypedJsonSetShape
+    | TypedJsonTupleShape
+data TypedJsonListShape {}
+data TypedJsonSetShape {}
+data TypedJsonTupleShape {}
+union TypedJsonReferenceSample { name: String } =
+    TypedJsonVariableReference
+    | TypedJsonFunctionReference
+data TypedJsonVariableReference {}
+data TypedJsonFunctionReference {}
+data TypedJsonNumberSample {
+    int_value: int,
+    long_value: long,
+    float_value: float,
+    double_value: double,
+    byte_value: byte
+}
+data TypedJsonWrapperVariants {
+    present: Option[String],
+    absent: Option[String],
+    success: Result[int],
+    error: Result[int]
+}
 
 fun tests(): Effect[TestFile] =
     test_file("/capy/lang/Json.cfun", [
@@ -70,6 +95,11 @@ fun tests(): Effect[TestFile] =
         test("should deserialize array with objects", () => should_deserialize_array_with_objects()),
         test("should deserialize array with arrays", () => should_deserialize_array_with_arrays()),
         test("should deserialize JSON with whitespaces", () => should_deserialize_json_with_white_spaces()),
+        test("should round-trip typed data constructors with identical shapes", () => should_round_trip_typed_data_constructors_with_identical_shapes()),
+        test("should round-trip typed references with identical name fields", () => should_round_trip_typed_references_with_identical_name_fields()),
+        test("should preserve typed numeric value kinds", () => should_preserve_typed_numeric_value_kinds()),
+        test("should preserve typed option and result constructors", () => should_preserve_typed_option_and_result_constructors()),
+        test("should stringify typed json with reserved envelope", () => should_stringify_typed_json_with_reserved_envelope()),
     ])
 
 fun should_convert_data_with_primitive_fields_to_json_object(): Assert =
@@ -485,3 +515,83 @@ fun should_deserialize_json_with_white_spaces(): Assert =
                 }
             }
         })
+
+fun should_round_trip_typed_data_constructors_with_identical_shapes(): Assert =
+    assert_all([
+        assert_that(round_trip_typed_name(TypedJsonListShape { name: "items" })).succeeds("TypedJsonListShape"),
+        assert_that(round_trip_typed_name(TypedJsonSetShape { name: "items" })).succeeds("TypedJsonSetShape"),
+        assert_that(round_trip_typed_name(TypedJsonTupleShape { name: "items" })).succeeds("TypedJsonTupleShape"),
+    ])
+
+fun should_round_trip_typed_references_with_identical_name_fields(): Assert =
+    assert_all([
+        assert_that(round_trip_typed_name(TypedJsonVariableReference { name: "value" })).succeeds("TypedJsonVariableReference"),
+        assert_that(round_trip_typed_name(TypedJsonFunctionReference { name: "value" })).succeeds("TypedJsonFunctionReference"),
+    ])
+
+fun should_preserve_typed_numeric_value_kinds(): Assert =
+    let sample = TypedJsonNumberSample {
+        int_value: 7,
+        long_value: 9876543210L,
+        float_value: 1.5f,
+        double_value: 2.5,
+        byte_value: 0x0A
+    }
+    assert_all([
+        assert_that(round_trip_typed_field(sample, "int_value")).succeeds(TypedJsonInt { 7 }),
+        assert_that(round_trip_typed_field(sample, "long_value")).succeeds(TypedJsonLong { 9876543210L }),
+        assert_that(round_trip_typed_field(sample, "float_value")).succeeds(TypedJsonFloat { 1.5f }),
+        assert_that(round_trip_typed_field(sample, "double_value")).succeeds(TypedJsonDouble { 2.5 }),
+        assert_that(round_trip_typed_field(sample, "byte_value")).succeeds(TypedJsonByte { 10 }),
+    ])
+
+fun should_preserve_typed_option_and_result_constructors(): Assert =
+    let sample = TypedJsonWrapperVariants {
+        present: Some { value: "available" },
+        absent: None {},
+        success: Success { value: 42 },
+        error: Error { message: "not found" }
+    }
+    assert_all([
+        assert_that(round_trip_typed_field_data_name(sample, "present")).succeeds("Some"),
+        assert_that(round_trip_typed_field_data_name(sample, "absent")).succeeds("None"),
+        assert_that(round_trip_typed_field_data_name(sample, "success")).succeeds("Success"),
+        assert_that(round_trip_typed_field_data_name(sample, "error")).succeeds("Error"),
+    ])
+
+fun should_stringify_typed_json_with_reserved_envelope(): Assert =
+    assert_that(to_typed_json(TypedJsonNumberSample {
+        int_value: 7,
+        long_value: 8L,
+        float_value: 1.5f,
+        double_value: 2.5,
+        byte_value: 0x0A
+    }))
+        .succeeds(typed =>
+            assert_that(serialize_typed(typed))
+                .contains('"$capybaraTypedJson":"data"')
+                .contains('"name":"TypedJsonNumberSample"')
+                .contains('"int_value":{"$capybaraTypedJson":"value"'))
+
+private fun round_trip_typed_data(obj: data): Result[TypedJsonData] =
+    let typed <- to_typed_json(obj)
+    deserialize_typed(serialize_typed(typed))
+
+private fun round_trip_typed_name(obj: data): Result[String] =
+    let typed <- round_trip_typed_data(obj)
+    typed.name
+
+private fun round_trip_typed_field(obj: data, field_name: String): Result[TypedJson] =
+    let typed <- round_trip_typed_data(obj)
+    typed_field(typed, field_name)
+
+private fun round_trip_typed_field_data_name(obj: data, field_name: String): Result[String] =
+    let field <- round_trip_typed_field(obj, field_name)
+    match field with
+    case TypedJsonData typed_data -> Success { typed_data.name }
+    case _ -> Error { "Expected typed data field `" + field_name + "`" }
+
+private fun typed_field(typed: TypedJsonData, field_name: String): Result[TypedJson] =
+    match typed.fields.get(field_name) with
+    case Some { value } -> Success { value }
+    case None -> Error { "Expected typed field `" + field_name + "`" }

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -98,6 +98,7 @@ fun tests(): Effect[TestFile] =
         test("should round-trip typed data constructors with identical shapes", () => should_round_trip_typed_data_constructors_with_identical_shapes()),
         test("should round-trip typed references with identical name fields", () => should_round_trip_typed_references_with_identical_name_fields()),
         test("should preserve typed numeric value kinds", () => should_preserve_typed_numeric_value_kinds()),
+        test("should reject typed int and byte values outside int range", () => should_reject_typed_int_and_byte_values_outside_int_range()),
         test("should preserve typed option and result constructors", () => should_preserve_typed_option_and_result_constructors()),
         test("should stringify typed json with reserved envelope", () => should_stringify_typed_json_with_reserved_envelope()),
     ])
@@ -543,6 +544,14 @@ fun should_preserve_typed_numeric_value_kinds(): Assert =
         assert_that(round_trip_typed_field(sample, "float_value")).succeeds(TypedJsonFloat { 1.5f }),
         assert_that(round_trip_typed_field(sample, "double_value")).succeeds(TypedJsonDouble { 2.5 }),
         assert_that(round_trip_typed_field(sample, "byte_value")).succeeds(TypedJsonByte { 10 }),
+    ])
+
+fun should_reject_typed_int_and_byte_values_outside_int_range(): Assert =
+    assert_all([
+        assert_that(deserialize_typed('{"$capybaraTypedJson":"data","name":"TypedJsonNumberSample","pkg":{"name":"capy.serialization","path":"capy/serialization/JsonTest"},"fields":{"int_value":{"$capybaraTypedJson":"value","kind":"int","value":2147483648}}}'))
+            .fails("long value `2147483648` is greater than max int value"),
+        assert_that(deserialize_typed('{"$capybaraTypedJson":"data","name":"TypedJsonNumberSample","pkg":{"name":"capy.serialization","path":"capy/serialization/JsonTest"},"fields":{"byte_value":{"$capybaraTypedJson":"value","kind":"byte","value":-2147483649}}}'))
+            .fails("long value `-2147483649` is smaller than min int value"),
     ])
 
 fun should_preserve_typed_option_and_result_constructors(): Assert =


### PR DESCRIPTION
## What changed
- Added an opt-in typed JSON AST and serialization API in `/capy/serialization/Json.cfun`.
- Typed JSON output uses a reserved `$capybaraTypedJson` envelope to preserve constructor names, package metadata, collection kind, and primitive numeric kind.
- Added typed round-trip coverage for ambiguous data variants, reference-like variants, numeric kinds, and `Option`/`Result` constructors while leaving plain JSON behavior unchanged.

## Impacted modules
- `lib/capybara-lib`

## Sample
```cfun
let typed <- to_typed_json(TypedJsonNumberSample { int_value: 7, long_value: 8L, float_value: 1.5f, double_value: 2.5, byte_value: 0x0A })
let json = serialize_typed(typed)
let round_tripped <- deserialize_typed(json)
```

## Commands run
- `./gradlew :lib:capybara-lib:testCapybara`
- `./gradlew :capy:test`
- `./gradlew :capy:e2e-cfun`
- `./gradlew clean test`
