### PR TITLE
fix(#258): avoid recursive signature keys

### DIFF
--- a/capy/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
+++ b/capy/src/main/java/dev/capylang/compiler/CapybaraCompiler.java
@@ -1736,8 +1736,10 @@ public class CapybaraCompiler {
     private SortedSet<CompiledFunction> deduplicateFunctions(List<CompiledFunction> linkedFunctions) {
         var byKey = new LinkedHashMap<String, CompiledFunction>();
         for (var function : linkedFunctions) {
-            var parameters = function.parameters().stream().map(parameter -> String.valueOf(parameter.type())).toList();
-            byKey.put(function.name() + "#" + parameters, function);
+            var parameterTypes = function.parameters().stream()
+                    .map(CompiledFunctionParameter::type)
+                    .toList();
+            byKey.put(CompiledTypeSignature.signatureKey(function.name(), parameterTypes), function);
         }
         return unmodifiableSortedSet(new TreeSet<>(byKey.values()));
     }
@@ -1924,8 +1926,7 @@ public class CapybaraCompiler {
     }
 
     private String signatureKey(CapybaraExpressionCompiler.FunctionSignature signature) {
-        var parameters = signature.parameterTypes().stream().map(String::valueOf).toList();
-        return signature.name() + "#" + parameters;
+        return CompiledTypeSignature.signatureKey(signature.name(), signature.parameterTypes());
     }
 
     private List<Function> findFunctions(Set<Definition> definitions) {

--- a/capy/src/main/java/dev/capylang/compiler/CompiledFunction.java
+++ b/capy/src/main/java/dev/capylang/compiler/CompiledFunction.java
@@ -73,7 +73,8 @@ public record CompiledFunction(String name,
                     var leftParameter = left.get(i);
                     var rightParameter = right.get(i);
 
-                    var typeCompare = leftParameter.type().toString().compareTo(rightParameter.type().toString());
+                    var typeCompare = CompiledTypeSignature.typeKey(leftParameter.type())
+                            .compareTo(CompiledTypeSignature.typeKey(rightParameter.type()));
                     if (typeCompare != 0) {
                         return typeCompare;
                     }

--- a/capy/src/main/java/dev/capylang/compiler/CompiledTypeSignature.java
+++ b/capy/src/main/java/dev/capylang/compiler/CompiledTypeSignature.java
@@ -1,0 +1,53 @@
+package dev.capylang.compiler;
+
+import dev.capylang.compiler.CollectionLinkedType.CompiledDict;
+import dev.capylang.compiler.CollectionLinkedType.CompiledList;
+import dev.capylang.compiler.CollectionLinkedType.CompiledSet;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
+public final class CompiledTypeSignature {
+    private CompiledTypeSignature() {
+    }
+
+    public static String signatureKey(String name, List<CompiledType> parameterTypes) {
+        return name + "|" + parameterSignature(parameterTypes);
+    }
+
+    public static String parameterSignature(List<CompiledType> parameterTypes) {
+        return parameterTypes.stream()
+                .map(CompiledTypeSignature::typeKey)
+                .collect(joining(","));
+    }
+
+    public static String typeKey(CompiledType type) {
+        return switch (type) {
+            case PrimitiveLinkedType primitive -> primitive.name();
+            case CompiledList list -> "CompiledList[elementType=" + typeKey(list.elementType()) + "]";
+            case CompiledSet set -> "CompiledSet[elementType=" + typeKey(set.elementType()) + "]";
+            case CompiledDict dict -> "CompiledDict[valueType=" + typeKey(dict.valueType()) + "]";
+            case CompiledTupleType tuple -> "CompiledTupleType[elementTypes=[" + tuple.elementTypes().stream()
+                    .map(CompiledTypeSignature::typeKey)
+                    .collect(joining(", ")) + "]]";
+            case CompiledFunctionType function -> "CompiledFunctionType[argumentType="
+                                                  + typeKey(function.argumentType())
+                                                  + ", returnType="
+                                                  + typeKey(function.returnType())
+                                                  + "]";
+            case CompiledGenericTypeParameter genericTypeParameter -> genericTypeParameter.name();
+            case CompiledDataType dataType -> namedTypeKey(dataType.name(), dataType.typeParameters());
+            case CompiledDataParentType parentType -> namedTypeKey(parentType.name(), parentType.typeParameters());
+            case CompiledObjectType objectType -> objectType.name();
+            case CompiledPrimitiveBackedType primitiveBackedType -> primitiveBackedType.name();
+        };
+    }
+
+    private static String namedTypeKey(String name, List<String> typeParameters) {
+        if (typeParameters.isEmpty()) {
+            return name;
+        }
+        return name + "[" + String.join(", ", typeParameters) + "]";
+    }
+}

--- a/capy/src/main/java/dev/capylang/compiler/CompiledTypeSignature.java
+++ b/capy/src/main/java/dev/capylang/compiler/CompiledTypeSignature.java
@@ -39,7 +39,7 @@ public final class CompiledTypeSignature {
             case CompiledGenericTypeParameter genericTypeParameter -> genericTypeParameter.name();
             case CompiledDataType dataType -> namedTypeKey(dataType.name(), dataType.typeParameters());
             case CompiledDataParentType parentType -> namedTypeKey(parentType.name(), parentType.typeParameters());
-            case CompiledObjectType objectType -> objectType.name();
+            case CompiledObjectType objectType -> objectType.name() + "[backendClassName=" + objectType.backendClassName() + "]";
             case CompiledPrimitiveBackedType primitiveBackedType -> primitiveBackedType.name();
         };
     }

--- a/capy/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
+++ b/capy/src/main/java/dev/capylang/compiler/expression/CapybaraExpressionCompiler.java
@@ -3925,7 +3925,7 @@ public class CapybaraExpressionCompiler {
 
     private String overloadedJavaFunctionName(FunctionSignature signature) {
         return signature.name() + "__" + signature.parameterTypes().stream()
-                .map(type -> sanitizeOverloadSuffix(String.valueOf(type)))
+                .map(type -> sanitizeOverloadSuffix(CompiledTypeSignature.typeKey(type)))
                 .collect(java.util.stream.Collectors.joining("__"));
     }
 

--- a/capy/src/main/java/dev/capylang/generator/JavaGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaGenerator.java
@@ -7,6 +7,7 @@ import dev.capylang.compiler.CompiledModule;
 import dev.capylang.compiler.CompiledObjectKind;
 import dev.capylang.compiler.CompiledObjectType;
 import dev.capylang.compiler.CompiledProgram;
+import dev.capylang.compiler.CompiledTypeSignature;
 import dev.capylang.compiler.NativeProviderBackendBinding;
 import dev.capylang.compiler.PrimitiveLinkedType;
 import dev.capylang.compiler.expression.CompiledFunctionCall;
@@ -895,7 +896,7 @@ public final class JavaGenerator implements Generator {
     }
 
     private static String signatureKey(String name, java.util.List<dev.capylang.compiler.CompiledType> parameterTypes) {
-        return name + "|" + parameterTypes.stream().map(type -> String.valueOf(type)).collect(joining(","));
+        return CompiledTypeSignature.signatureKey(name, parameterTypes);
     }
 
     private static String baseMethodName(String name) {
@@ -1089,10 +1090,7 @@ public final class JavaGenerator implements Generator {
     }
 
     private static String overloadTypeName(dev.capylang.compiler.CompiledType type) {
-        if (type instanceof dev.capylang.compiler.CompiledPrimitiveBackedType primitiveBackedType) {
-            return primitiveBackedType.name();
-        }
-        return String.valueOf(type);
+        return CompiledTypeSignature.typeKey(type);
     }
 
     private <T> T time(java.util.function.LongConsumer recorder, Supplier<T> action) {

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -5531,7 +5531,8 @@ public final class JavaScriptGenerator implements Generator {
                             if (typeof property === 'string'
                                 && (property.startsWith('testFile__string__compiledlist_elementtype_')
                                     || property.startsWith('test_file__string__compiledlist_elementtype_'))
-                                && (property.includes('compileddatatype_name_testcase')
+                                && (property.endsWith('_testcase')
+                                    || property.includes('compileddatatype_name_testcase')
                                     || property.includes('compileddataparenttype_name_effect'))) {
                                 return testFile;
                             }

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -18,6 +18,7 @@ import dev.capylang.compiler.CompiledPrimitiveBackedType;
 import dev.capylang.compiler.CompiledProgram;
 import dev.capylang.compiler.CompiledTupleType;
 import dev.capylang.compiler.CompiledType;
+import dev.capylang.compiler.CompiledTypeSignature;
 import dev.capylang.compiler.GenericDataType;
 import dev.capylang.compiler.NativeProviderBackendBinding;
 import dev.capylang.compiler.NativeProviderCatalog;
@@ -2825,7 +2826,7 @@ public final class JavaScriptGenerator implements Generator {
             if (functionNameOverrides.containsKey(key)) {
                 return functionNameOverrides.get(key);
             }
-            var parameterSignature = parameterTypes.stream().map(String::valueOf).collect(joining(","));
+            var parameterSignature = CompiledTypeSignature.parameterSignature(parameterTypes);
             if (simple.contains("__local_const_")) {
                 return normalizeJsIdentifier(simple);
             }
@@ -7111,7 +7112,7 @@ public final class JavaScriptGenerator implements Generator {
     }
 
     private static String signatureKey(String name, List<CompiledType> parameterTypes) {
-        return name + "|" + parameterTypes.stream().map(type -> String.valueOf(type)).collect(joining(","));
+        return CompiledTypeSignature.signatureKey(name, parameterTypes);
     }
 
     private static String baseMethodName(String name) {
@@ -7140,10 +7141,7 @@ public final class JavaScriptGenerator implements Generator {
     }
 
     private static String overloadTypeName(CompiledType type) {
-        if (type instanceof CompiledPrimitiveBackedType primitiveBackedType) {
-            return primitiveBackedType.name();
-        }
-        return String.valueOf(type);
+        return CompiledTypeSignature.typeKey(type);
     }
 
     private static String methodVariantSuffix(String rawBaseName) {

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -18,6 +18,7 @@ import dev.capylang.compiler.CompiledPrimitiveBackedType;
 import dev.capylang.compiler.CompiledProgram;
 import dev.capylang.compiler.CompiledTupleType;
 import dev.capylang.compiler.CompiledType;
+import dev.capylang.compiler.CompiledTypeSignature;
 import dev.capylang.compiler.GenericDataType;
 import dev.capylang.compiler.NativeProviderBackendBinding;
 import dev.capylang.compiler.NativeProviderCatalog;
@@ -2729,7 +2730,7 @@ public final class PythonGenerator implements Generator {
             if (functionNameOverrides.containsKey(key)) {
                 return functionNameOverrides.get(key);
             }
-            var parameterSignature = parameterTypes.stream().map(String::valueOf).collect(joining(","));
+            var parameterSignature = CompiledTypeSignature.parameterSignature(parameterTypes);
             if (simple.contains("__local_const_")) {
                 return pyIdentifier(simple);
             }
@@ -5538,7 +5539,7 @@ public final class PythonGenerator implements Generator {
     }
 
     private static String signatureKey(String name, List<CompiledType> parameterTypes) {
-        return name + "|" + parameterTypes.stream().map(String::valueOf).collect(joining(","));
+        return CompiledTypeSignature.signatureKey(name, parameterTypes);
     }
 
     private static String baseMethodName(String name) {
@@ -5567,10 +5568,7 @@ public final class PythonGenerator implements Generator {
     }
 
     private static String overloadTypeName(CompiledType type) {
-        if (type instanceof CompiledPrimitiveBackedType primitiveBackedType) {
-            return primitiveBackedType.name();
-        }
-        return String.valueOf(type);
+        return CompiledTypeSignature.typeKey(type);
     }
 
     private static String methodVariantSuffix(String rawBaseName) {

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -3706,7 +3706,8 @@ public final class PythonGenerator implements Generator {
                         if (
                             name.startswith('testFileStringCompiledlistElementtype')
                             and (
-                                'CompileddatatypeNameTestcase' in name
+                                name.endswith('Testcase')
+                                or 'CompileddatatypeNameTestcase' in name
                                 or 'CompileddataparenttypeNameEffect' in name
                             )
                         ):

--- a/capy/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaAstBuilder.java
@@ -587,7 +587,7 @@ public class JavaAstBuilder {
     }
 
     private static String signatureKey(String name, List<CompiledType> parameterTypes) {
-        return name + "|" + parameterTypes.stream().map(type -> String.valueOf(type)).collect(joining(","));
+        return CompiledTypeSignature.signatureKey(name, parameterTypes);
     }
 
     private String normalizeJavaMethodIdentifier(String rawName) {

--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -2,6 +2,7 @@ package dev.capylang.generator.java;
 
 import dev.capylang.compiler.CompiledDataParentType;
 import dev.capylang.compiler.CompiledDataType;
+import dev.capylang.compiler.CompiledTypeSignature;
 import dev.capylang.compiler.CompiledType;
 import dev.capylang.compiler.expression.*;
 import dev.capylang.compiler.parser.InfixOperator;
@@ -3878,9 +3879,7 @@ public class JavaExpressionEvaluator {
         if (standardMethodName.isPresent()) {
             return standardMethodName.orElseThrow();
         }
-        var parameterSignature = parameterTypes.stream()
-                .map(type -> String.valueOf(type))
-                .collect(java.util.stream.Collectors.joining(","));
+        var parameterSignature = CompiledTypeSignature.parameterSignature(parameterTypes);
         var overrideBySimpleName = findOverrideBySimpleName(functionCall.name(), parameterSignature);
         if (overrideBySimpleName.isPresent()) {
             return overrideBySimpleName.get();
@@ -3976,10 +3975,7 @@ public class JavaExpressionEvaluator {
     }
 
     private static String overloadTypeName(dev.capylang.compiler.CompiledType type) {
-        if (type instanceof dev.capylang.compiler.CompiledPrimitiveBackedType primitiveBackedType) {
-            return primitiveBackedType.name();
-        }
-        return String.valueOf(type);
+        return CompiledTypeSignature.typeKey(type);
     }
 
     private static String methodVariantSuffix(String rawBaseName) {
@@ -4076,7 +4072,7 @@ public class JavaExpressionEvaluator {
     }
 
     private static String signatureKey(String name, java.util.List<dev.capylang.compiler.CompiledType> parameterTypes) {
-        return name + "|" + parameterTypes.stream().map(type -> String.valueOf(type)).collect(java.util.stream.Collectors.joining(","));
+        return CompiledTypeSignature.signatureKey(name, parameterTypes);
     }
 
     private static String normalizeJavaQualifier(String qualifier) {

--- a/capy/src/test/java/dev/capylang/compiler/CompiledTypeSignatureTest.java
+++ b/capy/src/test/java/dev/capylang/compiler/CompiledTypeSignatureTest.java
@@ -30,4 +30,14 @@ class CompiledTypeSignatureTest {
         assertThat(CompiledTypeSignature.typeKey(new CompiledList(PrimitiveLinkedType.INT)))
                 .isNotEqualTo(CompiledTypeSignature.typeKey(new CompiledList(PrimitiveLinkedType.LONG)));
     }
+
+    @Test
+    void shouldIncludeObjectBackendIdentity() {
+        var left = new CompiledObjectType("User", "pkg.a.Model.User", List.of(), null);
+        var right = new CompiledObjectType("User", "pkg.b.Model.User", List.of(), null);
+
+        assertThat(CompiledTypeSignature.typeKey(left))
+                .isEqualTo("User[backendClassName=pkg.a.Model.User]")
+                .isNotEqualTo(CompiledTypeSignature.typeKey(right));
+    }
 }

--- a/capy/src/test/java/dev/capylang/compiler/CompiledTypeSignatureTest.java
+++ b/capy/src/test/java/dev/capylang/compiler/CompiledTypeSignatureTest.java
@@ -1,0 +1,33 @@
+package dev.capylang.compiler;
+
+import dev.capylang.compiler.CollectionLinkedType.CompiledList;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CompiledTypeSignatureTest {
+    @Test
+    void shouldUseShallowKeysForRecursiveNamedTypes() {
+        var fields = new ArrayList<CompiledDataType.CompiledField>();
+        var tree = new CompiledDataParentType("Tree", fields, List.of(), List.of());
+        fields.add(new CompiledDataType.CompiledField("children", new CompiledList(tree)));
+
+        var treeKey = CompiledTypeSignature.typeKey(tree);
+        var listTreeKey = CompiledTypeSignature.typeKey(new CompiledList(tree));
+
+        assertThat(treeKey).isEqualTo("Tree");
+        assertThat(listTreeKey).isEqualTo("CompiledList[elementType=Tree]");
+        assertThat(treeKey).isNotEqualTo(listTreeKey);
+        assertThat(treeKey).doesNotContain("children");
+        assertThat(listTreeKey).doesNotContain("children");
+    }
+
+    @Test
+    void shouldKeepCollectionElementTypesDistinct() {
+        assertThat(CompiledTypeSignature.typeKey(new CompiledList(PrimitiveLinkedType.INT)))
+                .isNotEqualTo(CompiledTypeSignature.typeKey(new CompiledList(PrimitiveLinkedType.LONG)));
+    }
+}

--- a/capy/src/test/java/dev/capylang/compiler/ObjectOrientedCompilerTest.java
+++ b/capy/src/test/java/dev/capylang/compiler/ObjectOrientedCompilerTest.java
@@ -447,6 +447,30 @@ class ObjectOrientedCompilerTest {
     }
 
     @Test
+    void shouldAllowOverloadsForObjectTypesWithSameNameFromDifferentModules() {
+        var result = CapybaraCompiler.INSTANCE.compile(List.of(
+                new RawModule("Model", "/pkg/a", """
+                        class User {
+                        }
+                        """, SourceKind.OBJECT_ORIENTED),
+                new RawModule("Model", "/pkg/b", """
+                        class User {
+                        }
+                        """, SourceKind.OBJECT_ORIENTED),
+                new RawModule("Use", "/pkg/app", """
+                        fun describe(user: /pkg/a/Model.User): int = 1
+                        fun describe(user: /pkg/b/Model.User): int = 2
+                        """)
+        ), new TreeSet<>());
+
+        assertThat(result).isInstanceOf(Result.Success.class);
+        var program = ((Result.Success<CompiledProgram>) result).value();
+        assertThat(program.modules().first().functions())
+                .filteredOn(function -> function.name().equals("describe"))
+                .hasSize(2);
+    }
+
+    @Test
     void shouldLinkImportedObjectOrientedMethodsFromFunctionalCode() {
         var result = CapybaraCompiler.INSTANCE.compile(List.of(
                 effectModule(),

--- a/capy/src/test/java/dev/capylang/compiler/RecursionCompilerTest.java
+++ b/capy/src/test/java/dev/capylang/compiler/RecursionCompilerTest.java
@@ -3,10 +3,12 @@ package dev.capylang.compiler;
 import dev.capylang.compiler.parser.RawModule;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class RecursionCompilerTest {
     @Test
@@ -104,8 +106,39 @@ class RecursionCompilerTest {
                 });
     }
 
+    @Test
+    void shouldCompileRecursiveDataSignaturesWithoutWalkingFields() {
+        var program = assertTimeoutPreemptively(
+                Duration.ofSeconds(10),
+                () -> compileProgram(recursiveSignatureSource())
+        );
+
+        assertThat(program.modules().first().functions())
+                .extracting(CompiledFunction::name)
+                .contains("wrap_tree", "wrap_trees", "describe");
+    }
+
     private static CompiledProgram compileProgram(String source) {
         return compileProgram(List.of(new RawModule("Recursion", "/foo/bar", source)));
+    }
+
+    private static String recursiveSignatureSource() {
+        return """
+                from /capy/collection/List import { * }
+
+                union Tree = Leaf | Branch
+                data Leaf { value: int }
+                data Branch { children: List[Tree] }
+
+                union Result[T] = Success[T] | Error
+                data Success[T] { value: T }
+                data Error { message: String }
+
+                fun wrap_tree(tree: Tree): Result[Tree] = Success { value: tree }
+                fun wrap_trees(trees: List[Tree]): Result[List[Tree]] = Success { value: trees }
+                fun describe(result: Result[Tree]): int = 1
+                fun describe(result: Result[List[Tree]]): int = 2
+                """;
     }
 
     private static RawModule recursiveAnnotationModule() {

--- a/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/java/JavaExpressionEvaluatorTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -38,6 +39,7 @@ import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static dev.capylang.compiler.CompiledExpressionPrinter.printExpression;
 import static dev.capylang.compiler.PrimitiveLinkedType.ANY;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 class JavaExpressionEvaluatorTest {
     private static final Object STANDARD_LIBRARY_LOCK = new Object();
@@ -109,6 +111,25 @@ class JavaExpressionEvaluatorTest {
                 """);
     }
 
+    private static String recursiveSignatureSource() {
+        return """
+                from /capy/collection/List import { * }
+
+                union Tree = Leaf | Branch
+                data Leaf { value: int }
+                data Branch { children: List[Tree] }
+
+                union Result[T] = Success[T] | Error
+                data Success[T] { value: T }
+                data Error { message: String }
+
+                fun wrap_tree(tree: Tree): Result[Tree] = Success { value: tree }
+                fun wrap_trees(trees: List[Tree]): Result[List[Tree]] = Success { value: trees }
+                fun describe(result: Result[Tree]): int = 1
+                fun describe(result: Result[List[Tree]]): int = 2
+                """;
+    }
+
     private static CompiledProgram compileProgram(List<RawModule> modules) {
         var programResult = CapybaraCompiler.INSTANCE.compile(modules, new java.util.TreeSet<>());
         if (programResult instanceof Result.Error<CompiledProgram> er) {
@@ -155,6 +176,23 @@ class JavaExpressionEvaluatorTest {
                 "CompiledList[elementType=INT]");
 
         assertThat(resolved).contains("choose_target");
+    }
+
+    @Test
+    void shouldGenerateRecursiveSignatureOverloadNamesWithoutWalkingFields() {
+        var generated = assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            var program = compileProgram("RecursiveSignature", "/foo/bar", recursiveSignatureSource());
+            return new JavaGenerator().generate(program).modules().stream()
+                    .filter(module -> module.relativePath().equals(Path.of("foo", "bar", "RecursiveSignature.java")))
+                    .map(dev.capylang.generator.GeneratedModule::code)
+                    .findFirst()
+                    .orElseThrow();
+        });
+
+        assertThat(generated)
+                .contains("describe__result_tree")
+                .contains("describe__result_list_tree")
+                .doesNotContainPattern("describe__[A-Za-z0-9_]*children");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a shared shallow compiled type signature key helper
- replace recursive `CompiledType.toString()` signature and overload-name keys in compiler and generators
- add regression tests for recursive `Tree`/`Result[List[Tree]]` signatures and generated Java overload names

## Root Cause
Signature maps and overload suffixes used record `toString()` for linked types. Recursive data and union types can include fields or subtypes that point back to themselves, so formatting them for a key could recurse through the type graph.

## Impact
Compiler and generator signature keys now use stable shallow type identity. Named data, union, object, and primitive-backed types key by name plus type parameters, while collection, tuple, and function types recurse only into contained type arguments.

## Validation
- `./gradlew :capy:test`
- `./gradlew :capy:e2e-cfun`
