### PR TITLE
feat(#260): add string and char case methods

### DIFF
--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -874,6 +874,19 @@ public final class JavaScriptGenerator implements Generator {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".compare(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
+            if (("to_upper_case".equals(methodName) || "toUpperCase".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".to_upper_case(" + receiver + ")";
+            }
+            if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName)
+                 || "tol_lower_case".equals(methodName) || "tolLowerCase".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".to_lower_case(" + receiver + ")";
+            }
             if (("starts_with".equals(methodName) || "startsWith".equals(methodName))
                 && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.size() == 1) {
@@ -2861,6 +2874,10 @@ public final class JavaScriptGenerator implements Generator {
             exports.put("capy.lang.String", Set.of(
                     "size", "get", "replace", "is_empty", "plus", "contains", "starts_with", "end_with", "trim", "compare",
                     "chars", "__constructor__primitive__char", "char_at", "charAt", "get_char", "getChar",
+                    "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                    "toUpperCase__name_to_upper_case__char",
+                    "toLowerCase__name_to_lower_case__char",
+                    "tolLowerCase__name_tol_lower_case__char",
                     "to_string", "toString", "toString__name_to_string__char",
                     "op3d_op3d__op_op3d_op3d__char__char", "compare__name_compare__char__char", "__capybaraPrimitiveTypes"
             ));
@@ -3243,6 +3260,16 @@ public final class JavaScriptGenerator implements Generator {
                    + "    const next = idx => idx >= text.length ? Seq.End : new Seq.Cons({ value: text.charAt(idx), rest: () => next(idx + 1) });\n"
                    + "    return next(0);\n"
                    + "};\n"
+                   + "const LOWER_CASE_ASCII_LETTERS = 'abcdefghijklmnopqrstuvwxyz';\n"
+                   + "const UPPER_CASE_ASCII_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';\n"
+                   + "function convertAsciiCase(value, source, target) {\n"
+                   + "    return Array.from(String(value), char => {\n"
+                   + "        const index = source.indexOf(char);\n"
+                   + "        return index >= 0 ? target.charAt(index) : char;\n"
+                   + "    }).join('');\n"
+                   + "}\n"
+                   + "const toUpperCase = value => convertAsciiCase(value, LOWER_CASE_ASCII_LETTERS, UPPER_CASE_ASCII_LETTERS);\n"
+                   + "const toLowerCase = value => convertAsciiCase(value, UPPER_CASE_ASCII_LETTERS, LOWER_CASE_ASCII_LETTERS);\n"
                    + "const toStringChar = value => String(value);\n"
                    + "const equalsChar = (left, right) => String(left) === String(right);\n"
                    + "const __capybaraPrimitiveTypes = Object.freeze({ char: Object.freeze({ cfunType: '/capy/lang/String.char', backingType: 'String' }) });\n"
@@ -3256,6 +3283,12 @@ public final class JavaScriptGenerator implements Generator {
                    + "    starts_with: (value, part) => String(value).startsWith(part),\n"
                    + "    end_with: (value, part) => String(value).endsWith(part),\n"
                    + "    trim: value => String(value).trim(),\n"
+                   + "    to_upper_case: toUpperCase,\n"
+                   + "    toUpperCase,\n"
+                   + "    to_lower_case: toLowerCase,\n"
+                   + "    toLowerCase,\n"
+                   + "    tol_lower_case: toLowerCase,\n"
+                   + "    tolLowerCase: toLowerCase,\n"
                    + "    compare,\n"
                    + "    chars,\n"
                    + "    __constructor__primitive__char,\n"
@@ -3266,6 +3299,9 @@ public final class JavaScriptGenerator implements Generator {
                    + "    to_string: toStringChar,\n"
                    + "    toString: toStringChar,\n"
                    + "    toString__name_to_string__char: toStringChar,\n"
+                   + "    toUpperCase__name_to_upper_case__char: toUpperCase,\n"
+                   + "    toLowerCase__name_to_lower_case__char: toLowerCase,\n"
+                   + "    tolLowerCase__name_tol_lower_case__char: toLowerCase,\n"
                    + "    op3d_op3d__op_op3d_op3d__char__char: equalsChar,\n"
                    + "    compare__name_compare__char__char: compare,\n"
                    + "    __capybaraPrimitiveTypes,\n"

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -875,13 +875,13 @@ public final class JavaScriptGenerator implements Generator {
                 return moduleVar("capy.lang.String") + ".compare(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (("to_upper_case".equals(methodName) || "toUpperCase".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".to_upper_case(" + receiver + ")";
             }
             if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".to_lower_case(" + receiver + ")";
@@ -896,40 +896,40 @@ public final class JavaScriptGenerator implements Generator {
                 && tailArgs.size() == 1) {
                 return "String(" + receiver + ").endsWith(" + tailArgs.getFirst() + ")";
             }
-            if ("trim".equals(methodName) && isStringLike(receiverType) && tailArgs.isEmpty()) {
+            if ("trim".equals(methodName) && receiverType == PrimitiveLinkedType.STRING && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".trim(" + receiver + ")";
             }
             if (("is_blank".equals(methodName) || "isBlank".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".is_blank(" + receiver + ")";
             }
             if (("trim_start".equals(methodName) || "trimStart".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".trim_start(" + receiver + ")";
             }
             if (("trim_end".equals(methodName) || "trimEnd".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".trim_end(" + receiver + ")";
             }
-            if ("repeat".equals(methodName) && isStringLike(receiverType) && tailArgs.size() == 1) {
+            if ("repeat".equals(methodName) && receiverType == PrimitiveLinkedType.STRING && tailArgs.size() == 1) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".repeat(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (("index_of".equals(methodName) || "indexOf".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.size() == 1) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".index_of(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (("last_index_of".equals(methodName) || "lastIndexOf".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.size() == 1) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".last_index_of(" + receiver + ", " + tailArgs.getFirst() + ")";

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -880,8 +880,7 @@ public final class JavaScriptGenerator implements Generator {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".to_upper_case(" + receiver + ")";
             }
-            if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName)
-                 || "tol_lower_case".equals(methodName) || "tolLowerCase".equals(methodName))
+            if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName))
                 && isStringLike(receiverType)
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
@@ -2912,12 +2911,11 @@ public final class JavaScriptGenerator implements Generator {
             exports.put("capy.lang.String", Set.of(
                     "size", "get", "replace", "is_empty", "plus", "contains", "starts_with", "end_with", "trim", "compare",
                     "chars", "__constructor__primitive__char", "char_at", "charAt", "get_char", "getChar",
-                    "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                    "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase",
                     "is_blank", "isBlank", "trim_start", "trimStart", "trim_end", "trimEnd",
                     "repeat", "index_of", "indexOf", "last_index_of", "lastIndexOf",
                     "toUpperCase__name_to_upper_case__char",
                     "toLowerCase__name_to_lower_case__char",
-                    "tolLowerCase__name_tol_lower_case__char",
                     "to_string", "toString", "toString__name_to_string__char",
                     "op3d_op3d__op_op3d_op3d__char__char", "compare__name_compare__char__char", "__capybaraPrimitiveTypes"
             ));
@@ -3366,8 +3364,6 @@ public final class JavaScriptGenerator implements Generator {
                    + "    toUpperCase,\n"
                    + "    to_lower_case: toLowerCase,\n"
                    + "    toLowerCase,\n"
-                   + "    tol_lower_case: toLowerCase,\n"
-                   + "    tolLowerCase: toLowerCase,\n"
                    + "    compare,\n"
                    + "    chars,\n"
                    + "    __constructor__primitive__char,\n"
@@ -3380,7 +3376,6 @@ public final class JavaScriptGenerator implements Generator {
                    + "    toString__name_to_string__char: toStringChar,\n"
                    + "    toUpperCase__name_to_upper_case__char: toUpperCase,\n"
                    + "    toLowerCase__name_to_lower_case__char: toLowerCase,\n"
-                   + "    tolLowerCase__name_tol_lower_case__char: toLowerCase,\n"
                    + "    op3d_op3d__op_op3d_op3d__char__char: equalsChar,\n"
                    + "    compare__name_compare__char__char: compare,\n"
                    + "    __capybaraPrimitiveTypes,\n"

--- a/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/JavaScriptGenerator.java
@@ -897,6 +897,44 @@ public final class JavaScriptGenerator implements Generator {
                 && tailArgs.size() == 1) {
                 return "String(" + receiver + ").endsWith(" + tailArgs.getFirst() + ")";
             }
+            if ("trim".equals(methodName) && isStringLike(receiverType) && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".trim(" + receiver + ")";
+            }
+            if (("is_blank".equals(methodName) || "isBlank".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".is_blank(" + receiver + ")";
+            }
+            if (("trim_start".equals(methodName) || "trimStart".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".trim_start(" + receiver + ")";
+            }
+            if (("trim_end".equals(methodName) || "trimEnd".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".trim_end(" + receiver + ")";
+            }
+            if ("repeat".equals(methodName) && isStringLike(receiverType) && tailArgs.size() == 1) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".repeat(" + receiver + ", " + tailArgs.getFirst() + ")";
+            }
+            if (("index_of".equals(methodName) || "indexOf".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.size() == 1) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".index_of(" + receiver + ", " + tailArgs.getFirst() + ")";
+            }
+            if (("last_index_of".equals(methodName) || "lastIndexOf".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.size() == 1) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".last_index_of(" + receiver + ", " + tailArgs.getFirst() + ")";
+            }
             if ("size".equals(methodName) && isCollectionType(receiverType)) {
                 if (receiverType instanceof CollectionLinkedType.CompiledDict
                     || receiverType instanceof CollectionLinkedType.CompiledSet) {
@@ -2875,6 +2913,8 @@ public final class JavaScriptGenerator implements Generator {
                     "size", "get", "replace", "is_empty", "plus", "contains", "starts_with", "end_with", "trim", "compare",
                     "chars", "__constructor__primitive__char", "char_at", "charAt", "get_char", "getChar",
                     "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                    "is_blank", "isBlank", "trim_start", "trimStart", "trim_end", "trimEnd",
+                    "repeat", "index_of", "indexOf", "last_index_of", "lastIndexOf",
                     "toUpperCase__name_to_upper_case__char",
                     "toLowerCase__name_to_lower_case__char",
                     "tolLowerCase__name_tol_lower_case__char",
@@ -3262,6 +3302,34 @@ public final class JavaScriptGenerator implements Generator {
                    + "};\n"
                    + "const LOWER_CASE_ASCII_LETTERS = 'abcdefghijklmnopqrstuvwxyz';\n"
                    + "const UPPER_CASE_ASCII_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';\n"
+                   + "const TRIM_WHITESPACE = new Set([' ', '\\t', '\\n', '\\r', '\\f']);\n"
+                   + "function trimStartValue(value) {\n"
+                   + "    const text = String(value);\n"
+                   + "    let idx = 0;\n"
+                   + "    while (idx < text.length && TRIM_WHITESPACE.has(text.charAt(idx))) {\n"
+                   + "        idx += 1;\n"
+                   + "    }\n"
+                   + "    return text.slice(idx);\n"
+                   + "}\n"
+                   + "function trimEndValue(value) {\n"
+                   + "    const text = String(value);\n"
+                   + "    let idx = text.length;\n"
+                   + "    while (idx > 0 && TRIM_WHITESPACE.has(text.charAt(idx - 1))) {\n"
+                   + "        idx -= 1;\n"
+                   + "    }\n"
+                   + "    return text.slice(0, idx);\n"
+                   + "}\n"
+                   + "const trimValue = value => trimEndValue(trimStartValue(value));\n"
+                   + "const isBlank = value => trimValue(value).length === 0;\n"
+                   + "const repeat = (value, times) => times <= 0 ? '' : String(value).repeat(times);\n"
+                   + "function indexOf(value, part) {\n"
+                   + "    const idx = String(value).indexOf(String(part));\n"
+                   + "    return idx < 0 ? capy.None : new capy.Some({ value: idx });\n"
+                   + "}\n"
+                   + "function lastIndexOf(value, part) {\n"
+                   + "    const idx = String(value).lastIndexOf(String(part));\n"
+                   + "    return idx < 0 ? capy.None : new capy.Some({ value: idx });\n"
+                   + "}\n"
                    + "function convertAsciiCase(value, source, target) {\n"
                    + "    return Array.from(String(value), char => {\n"
                    + "        const index = source.indexOf(char);\n"
@@ -3282,7 +3350,18 @@ public final class JavaScriptGenerator implements Generator {
                    + "    contains: (value, part) => String(value).includes(part),\n"
                    + "    starts_with: (value, part) => String(value).startsWith(part),\n"
                    + "    end_with: (value, part) => String(value).endsWith(part),\n"
-                   + "    trim: value => String(value).trim(),\n"
+                   + "    trim: trimValue,\n"
+                   + "    is_blank: isBlank,\n"
+                   + "    isBlank,\n"
+                   + "    trim_start: trimStartValue,\n"
+                   + "    trimStart: trimStartValue,\n"
+                   + "    trim_end: trimEndValue,\n"
+                   + "    trimEnd: trimEndValue,\n"
+                   + "    repeat,\n"
+                   + "    index_of: indexOf,\n"
+                   + "    indexOf,\n"
+                   + "    last_index_of: lastIndexOf,\n"
+                   + "    lastIndexOf,\n"
                    + "    to_upper_case: toUpperCase,\n"
                    + "    toUpperCase,\n"
                    + "    to_lower_case: toLowerCase,\n"

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -865,13 +865,13 @@ public final class PythonGenerator implements Generator {
                 return moduleVar("capy.lang.String") + ".compare(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (("to_upper_case".equals(methodName) || "toUpperCase".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".to_upper_case(" + receiver + ")";
             }
             if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".to_lower_case(" + receiver + ")";
@@ -886,40 +886,40 @@ public final class PythonGenerator implements Generator {
                 && tailArgs.size() == 1) {
                 return "str(" + receiver + ").endswith(" + tailArgs.getFirst() + ")";
             }
-            if ("trim".equals(methodName) && isStringLike(receiverType) && tailArgs.isEmpty()) {
+            if ("trim".equals(methodName) && receiverType == PrimitiveLinkedType.STRING && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".trim(" + receiver + ")";
             }
             if (("is_blank".equals(methodName) || "isBlank".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".is_blank(" + receiver + ")";
             }
             if (("trim_start".equals(methodName) || "trimStart".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".trim_start(" + receiver + ")";
             }
             if (("trim_end".equals(methodName) || "trimEnd".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".trim_end(" + receiver + ")";
             }
-            if ("repeat".equals(methodName) && isStringLike(receiverType) && tailArgs.size() == 1) {
+            if ("repeat".equals(methodName) && receiverType == PrimitiveLinkedType.STRING && tailArgs.size() == 1) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".repeat(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (("index_of".equals(methodName) || "indexOf".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.size() == 1) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".index_of(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if (("last_index_of".equals(methodName) || "lastIndexOf".equals(methodName))
-                && isStringLike(receiverType)
+                && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.size() == 1) {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".last_index_of(" + receiver + ", " + tailArgs.getFirst() + ")";

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -887,8 +887,43 @@ public final class PythonGenerator implements Generator {
                 && tailArgs.size() == 1) {
                 return "str(" + receiver + ").endswith(" + tailArgs.getFirst() + ")";
             }
-            if ("trim".equals(methodName) && receiverType == PrimitiveLinkedType.STRING && tailArgs.isEmpty()) {
-                return "str(" + receiver + ").strip()";
+            if ("trim".equals(methodName) && isStringLike(receiverType) && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".trim(" + receiver + ")";
+            }
+            if (("is_blank".equals(methodName) || "isBlank".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".is_blank(" + receiver + ")";
+            }
+            if (("trim_start".equals(methodName) || "trimStart".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".trim_start(" + receiver + ")";
+            }
+            if (("trim_end".equals(methodName) || "trimEnd".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".trim_end(" + receiver + ")";
+            }
+            if ("repeat".equals(methodName) && isStringLike(receiverType) && tailArgs.size() == 1) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".repeat(" + receiver + ", " + tailArgs.getFirst() + ")";
+            }
+            if (("index_of".equals(methodName) || "indexOf".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.size() == 1) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".index_of(" + receiver + ", " + tailArgs.getFirst() + ")";
+            }
+            if (("last_index_of".equals(methodName) || "lastIndexOf".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.size() == 1) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".last_index_of(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
             if ("size".equals(methodName) && isCollectionType(receiverType)) {
                 return "capy.size(" + receiver + ")";
@@ -2780,6 +2815,8 @@ public final class PythonGenerator implements Generator {
                     "__constructor__primitive__char", "capy__constructorPrimitiveChar",
                     "chars", "char_at", "charAt", "get_char", "getChar",
                     "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                    "is_blank", "isBlank", "trim_start", "trimStart", "trim_end", "trimEnd",
+                    "repeat", "index_of", "indexOf", "last_index_of", "lastIndexOf",
                     "toUpperCase__name_to_upper_case__char",
                     "toLowerCase__name_to_lower_case__char",
                     "tolLowerCase__name_tol_lower_case__char",
@@ -3097,7 +3134,33 @@ public final class PythonGenerator implements Generator {
                     contains = lambda value, part: part in str(value)
                     starts_with = lambda value, part: str(value).startswith(part)
                     end_with = lambda value, part: str(value).endswith(part)
-                    trim = lambda value: str(value).strip()
+                    TRIM_WHITESPACE = " \\t\\n\\r\\f"
+                    def trim_start(value):
+                        text = str(value)
+                        idx = 0
+                        while idx < len(text) and text[idx] in TRIM_WHITESPACE:
+                            idx += 1
+                        return text[idx:]
+                    trimStart = trim_start
+                    def trim_end(value):
+                        text = str(value)
+                        idx = len(text)
+                        while idx > 0 and text[idx - 1] in TRIM_WHITESPACE:
+                            idx -= 1
+                        return text[:idx]
+                    trimEnd = trim_end
+                    trim = lambda value: trim_end(trim_start(value))
+                    is_blank = lambda value: len(trim(value)) == 0
+                    isBlank = is_blank
+                    repeat = lambda value, times: str(value) * max(0, times)
+                    def index_of(value, part):
+                        idx = str(value).find(str(part))
+                        return capy.None_ if idx < 0 else capy.Some({'value': idx})
+                    indexOf = index_of
+                    def last_index_of(value, part):
+                        idx = str(value).rfind(str(part))
+                        return capy.None_ if idx < 0 else capy.Some({'value': idx})
+                    lastIndexOf = last_index_of
                     LOWER_CASE_ASCII_LETTERS = "abcdefghijklmnopqrstuvwxyz"
                     UPPER_CASE_ASCII_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     def _convert_ascii_case(value, source, target):

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -870,8 +870,7 @@ public final class PythonGenerator implements Generator {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".to_upper_case(" + receiver + ")";
             }
-            if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName)
-                 || "tol_lower_case".equals(methodName) || "tolLowerCase".equals(methodName))
+            if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName))
                 && isStringLike(receiverType)
                 && tailArgs.isEmpty()) {
                 require("capy.lang.String");
@@ -2814,12 +2813,11 @@ public final class PythonGenerator implements Generator {
                     "size", "get", "replace", "is_empty", "plus", "contains", "starts_with", "end_with", "trim", "compare",
                     "__constructor__primitive__char", "capy__constructorPrimitiveChar",
                     "chars", "char_at", "charAt", "get_char", "getChar",
-                    "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                    "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase",
                     "is_blank", "isBlank", "trim_start", "trimStart", "trim_end", "trimEnd",
                     "repeat", "index_of", "indexOf", "last_index_of", "lastIndexOf",
                     "toUpperCase__name_to_upper_case__char",
                     "toLowerCase__name_to_lower_case__char",
-                    "tolLowerCase__name_tol_lower_case__char",
                     "to_string", "toString", "toString__name_to_string__char",
                     "op3d_op3d__op_op3d_op3d__char__char", "compare__name_compare__char__char", "__capybaraPrimitiveTypes"
             ));
@@ -3169,8 +3167,6 @@ public final class PythonGenerator implements Generator {
                     toUpperCase = to_upper_case
                     to_lower_case = lambda value: _convert_ascii_case(value, UPPER_CASE_ASCII_LETTERS, LOWER_CASE_ASCII_LETTERS)
                     toLowerCase = to_lower_case
-                    tol_lower_case = to_lower_case
-                    tolLowerCase = to_lower_case
                     def compare(left, right):
                         left_text = str(left)
                         right_text = str(right)
@@ -3195,7 +3191,6 @@ public final class PythonGenerator implements Generator {
                     compare__name_compare__char__char = compare
                     toUpperCase__name_to_upper_case__char = to_upper_case
                     toLowerCase__name_to_lower_case__char = to_lower_case
-                    tolLowerCase__name_tol_lower_case__char = to_lower_case
                     __capybaraPrimitiveTypes = {'char': {"cfunType": '/capy/lang/String.char', "backingType": 'String'}}
                     """;
         }

--- a/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
+++ b/capy/src/main/java/dev/capylang/generator/PythonGenerator.java
@@ -864,6 +864,19 @@ public final class PythonGenerator implements Generator {
                 require("capy.lang.String");
                 return moduleVar("capy.lang.String") + ".compare(" + receiver + ", " + tailArgs.getFirst() + ")";
             }
+            if (("to_upper_case".equals(methodName) || "toUpperCase".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".to_upper_case(" + receiver + ")";
+            }
+            if (("to_lower_case".equals(methodName) || "toLowerCase".equals(methodName)
+                 || "tol_lower_case".equals(methodName) || "tolLowerCase".equals(methodName))
+                && isStringLike(receiverType)
+                && tailArgs.isEmpty()) {
+                require("capy.lang.String");
+                return moduleVar("capy.lang.String") + ".to_lower_case(" + receiver + ")";
+            }
             if (("starts_with".equals(methodName) || "startsWith".equals(methodName))
                 && receiverType == PrimitiveLinkedType.STRING
                 && tailArgs.size() == 1) {
@@ -2766,6 +2779,10 @@ public final class PythonGenerator implements Generator {
                     "size", "get", "replace", "is_empty", "plus", "contains", "starts_with", "end_with", "trim", "compare",
                     "__constructor__primitive__char", "capy__constructorPrimitiveChar",
                     "chars", "char_at", "charAt", "get_char", "getChar",
+                    "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                    "toUpperCase__name_to_upper_case__char",
+                    "toLowerCase__name_to_lower_case__char",
+                    "tolLowerCase__name_tol_lower_case__char",
                     "to_string", "toString", "toString__name_to_string__char",
                     "op3d_op3d__op_op3d_op3d__char__char", "compare__name_compare__char__char", "__capybaraPrimitiveTypes"
             ));
@@ -3081,6 +3098,16 @@ public final class PythonGenerator implements Generator {
                     starts_with = lambda value, part: str(value).startswith(part)
                     end_with = lambda value, part: str(value).endswith(part)
                     trim = lambda value: str(value).strip()
+                    LOWER_CASE_ASCII_LETTERS = "abcdefghijklmnopqrstuvwxyz"
+                    UPPER_CASE_ASCII_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    def _convert_ascii_case(value, source, target):
+                        return ''.join(target[source.index(char)] if char in source else char for char in str(value))
+                    to_upper_case = lambda value: _convert_ascii_case(value, LOWER_CASE_ASCII_LETTERS, UPPER_CASE_ASCII_LETTERS)
+                    toUpperCase = to_upper_case
+                    to_lower_case = lambda value: _convert_ascii_case(value, UPPER_CASE_ASCII_LETTERS, LOWER_CASE_ASCII_LETTERS)
+                    toLowerCase = to_lower_case
+                    tol_lower_case = to_lower_case
+                    tolLowerCase = to_lower_case
                     def compare(left, right):
                         left_text = str(left)
                         right_text = str(right)
@@ -3103,6 +3130,9 @@ public final class PythonGenerator implements Generator {
                     toString__name_to_string__char = lambda value: str(value)
                     op3d_op3d__op_op3d_op3d__char__char = lambda left, right: str(left) == str(right)
                     compare__name_compare__char__char = compare
+                    toUpperCase__name_to_upper_case__char = to_upper_case
+                    toLowerCase__name_to_lower_case__char = to_lower_case
+                    tolLowerCase__name_tol_lower_case__char = to_lower_case
                     __capybaraPrimitiveTypes = {'char': {"cfunType": '/capy/lang/String.char', "backingType": 'String'}}
                     """;
         }

--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -86,7 +86,8 @@ public class JavaExpressionEvaluator {
                 java.util.List.of("String"),
                 "is_empty", "plus", "any", "all", "contains", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*",
-                "starts_with", "end_with", "trim", "compare", "chars", "char_at", "charAt", "get_char", "getChar"
+                "starts_with", "end_with", "trim", "compare", "chars", "char_at", "charAt", "get_char", "getChar",
+                "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase"
         );
         return java.util.Map.copyOf(owners);
     }

--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -87,7 +87,7 @@ public class JavaExpressionEvaluator {
                 "is_empty", "plus", "any", "all", "contains", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*",
                 "starts_with", "end_with", "trim", "compare", "chars", "char_at", "charAt", "get_char", "getChar",
-                "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase",
                 "is_blank", "isBlank", "trim_start", "trimStart", "trim_end", "trimEnd",
                 "repeat", "index_of", "indexOf", "last_index_of", "lastIndexOf"
         );

--- a/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
+++ b/capy/src/main/java/dev/capylang/generator/java/JavaExpressionEvaluator.java
@@ -87,7 +87,9 @@ public class JavaExpressionEvaluator {
                 "is_empty", "plus", "any", "all", "contains", "?", "reduce", "|>",
                 "reduce_left", "|l>", "map", "|", "filter", "reject", "|-", "flat_map", "flatMap", "|*",
                 "starts_with", "end_with", "trim", "compare", "chars", "char_at", "charAt", "get_char", "getChar",
-                "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase"
+                "to_upper_case", "toUpperCase", "to_lower_case", "toLowerCase", "tol_lower_case", "tolLowerCase",
+                "is_blank", "isBlank", "trim_start", "trimStart", "trim_end", "trimEnd",
+                "repeat", "index_of", "indexOf", "last_index_of", "lastIndexOf"
         );
         return java.util.Map.copyOf(owners);
     }

--- a/capy/src/test/java/dev/capylang/generator/PrimitiveBackedTypeGeneratorTest.java
+++ b/capy/src/test/java/dev/capylang/generator/PrimitiveBackedTypeGeneratorTest.java
@@ -154,6 +154,28 @@ class PrimitiveBackedTypeGeneratorTest {
     }
 
     @Test
+    void shouldDispatchStringBackedPrimitiveMethodsBeforeStandardStringShortcutsInJavaScriptAndPython() {
+        var program = compileProgram(List.of(new RawModule("Tokens", "/foo", """
+                type token -> String
+
+                fun token.to_upper_case(): token = token { "token:" + this.value }
+                fun uppercase_token(value: token): token = value.to_upper_case()
+                """)));
+
+        var js = generatedCode(new JavaScriptGenerator(), program, Path.of("foo", "Tokens.js"));
+        var python = generatedCode(new PythonGenerator(), program, Path.of("foo", "Tokens.py"));
+
+        assertThat(js)
+                .contains("function toUpperCase__name_to_upper_case__token(this_)")
+                .contains("return toUpperCase__name_to_upper_case__token(value);")
+                .doesNotContain("__module_capy_lang_String.to_upper_case(value)");
+        assertThat(python)
+                .contains("def toUpperCase__name_to_upper_case__token(this_):")
+                .contains("return toUpperCase__name_to_upper_case__token(value)")
+                .doesNotContain("capy_module_capy_lang_String.to_upper_case(value)");
+    }
+
+    @Test
     void shouldNotShadowPythonRuntimeWithPrimitiveBackedConstructorAliases() {
         var program = compileProgram(List.of(new RawModule("Numbers", "/foo", """
                 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -41,9 +41,6 @@ fun String.to_upper_case(): String = string_convert_ascii_case(this, LOWER_CASE_
 /// Characters outside `A` through `Z` are unchanged.
 fun String.to_lower_case(): String = string_convert_ascii_case(this, UPPER_CASE_ASCII_LETTERS, LOWER_CASE_ASCII_LETTERS)
 
-/// Compatibility alias for `to_lower_case`.
-fun String.tol_lower_case(): String = this.to_lower_case()
-
 /// Returns this char converted to uppercase when it is an ASCII lowercase letter.
 ///
 /// Characters outside `a` through `z` are unchanged.
@@ -53,9 +50,6 @@ fun char.to_upper_case(): char = char! { this.value.to_upper_case() }
 ///
 /// Characters outside `A` through `Z` are unchanged.
 fun char.to_lower_case(): char = char! { this.value.to_lower_case() }
-
-/// Compatibility alias for `to_lower_case`.
-fun char.tol_lower_case(): char = this.to_lower_case()
 
 private fun string_convert_ascii_case(value: String, from: String, to: String): String =
     @Recursive

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -78,6 +78,9 @@ private fun string_ascii_case_pair(char: String, from: String, to: String): Stri
     ---
     find(char, from, to, 0)
 
+private fun string_is_trim_whitespace(char: String): bool =
+    char == " " | char == '\t' | char == '\n' | char == '\r' | char == '\f'
+
 /// Returns the character at idx as a String using the same bounds and negative-index rules as string[idx].
 fun String.get(idx: index): Option[char] = <native>
 
@@ -251,26 +254,92 @@ fun String.end_with(part: String): bool =
     then false
     else this[this.size().value - part.size().value, this.size()] == part
 
-/// Returns this String without leading and trailing whitespace.
-fun String.trim(): String =
-    fun is_trim_whitespace(char: String): bool =
-        char == " " | char == '\t' | char == '\n' | char == '\r' | char == '\f'
+/// Returns true when this String is empty or contains only trim whitespace.
+///
+/// Trim whitespace is space, tab, newline, carriage return, or form feed.
+fun String.is_blank(): bool = this.trim().is_empty()
+
+/// Returns this String without leading trim whitespace.
+///
+/// Trim whitespace is space, tab, newline, carriage return, or form feed.
+fun String.trim_start(): String =
     @Recursive
     fun trim_left(value: String): String =
         if value.size() == EMPTY
         then ""
-        else if is_trim_whitespace(value[0, 1])
+        else if string_is_trim_whitespace(value[0, 1])
             then trim_left(value[1, value.size()])
             else value
+    ---
+    trim_left(this)
+
+/// Returns this String without trailing trim whitespace.
+///
+/// Trim whitespace is space, tab, newline, carriage return, or form feed.
+fun String.trim_end(): String =
     @Recursive
     fun trim_right(value: String): String =
         if value.size() == EMPTY
         then ""
-        else if is_trim_whitespace(value[value.size().value - 1, value.size()])
+        else if string_is_trim_whitespace(value[value.size().value - 1, value.size()])
             then trim_right(value[0, value.size().value - 1])
             else value
     ---
-    trim_right(trim_left(this))
+    trim_right(this)
+
+/// Returns this String without leading and trailing whitespace.
+///
+/// Trim whitespace is space, tab, newline, carriage return, or form feed.
+fun String.trim(): String = this.trim_start().trim_end()
+
+/// Returns this String repeated `times` times.
+///
+/// Values less than or equal to zero return an empty String.
+fun String.repeat(times: int): String =
+    @Recursive
+    fun repeat_text(value: String, remaining: int, acc: String): String =
+        if remaining <= 0
+        then acc
+        else repeat_text(value, remaining - 1, acc + value)
+    ---
+    repeat_text(this, times, "")
+
+/// Returns the first zero-based index where `part` occurs.
+///
+/// Empty `part` matches at the first index. Missing `part` returns None.
+fun String.index_of(part: String): Option[index] =
+    if part.is_empty()
+    then Some { FIRST_ELEMENT }
+    else string_index_of(this, part, 0)
+
+/// Returns the last zero-based index where `part` occurs.
+///
+/// Empty `part` matches at this String's size. Missing `part` returns None.
+fun String.last_index_of(part: String): Option[index] =
+    if part.is_empty()
+    then string_index_option(this.size().value)
+    else string_last_index_of(this, part, this.size().value - part.size().value)
 
 /// Replaces every occurrence of old with new.
 fun String.replace(old: String, new: String): String = <native>
+
+@Recursive
+private fun string_index_of(value: String, part: String, idx: int): Option[index] =
+    if idx + part.size().value > value.size().value
+    then None {}
+    else if value[idx, idx + part.size().value] == part
+    then string_index_option(idx)
+    else string_index_of(value, part, idx + 1)
+
+@Recursive
+private fun string_last_index_of(value: String, part: String, idx: int): Option[index] =
+    if idx < 0
+    then None {}
+    else if value[idx, idx + part.size().value] == part
+    then string_index_option(idx)
+    else string_last_index_of(value, part, idx - 1)
+
+private fun string_index_option(value: int): Option[index] =
+    match index { value } with
+    case Success { parsed } -> Some { parsed }
+    case Error -> None {}

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -28,6 +28,56 @@ fun char.`==`(other: char): bool = this.value == other.value
 /// Compares this char with `other` using case-sensitive lexicographic ordering.
 fun char.compare(other: char): Ordering = this.value.compare(other.value)
 
+private const LOWER_CASE_ASCII_LETTERS: String = "abcdefghijklmnopqrstuvwxyz"
+private const UPPER_CASE_ASCII_LETTERS: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+/// Returns this String with ASCII lowercase letters converted to uppercase.
+///
+/// Characters outside `a` through `z` are unchanged.
+fun String.to_upper_case(): String = string_convert_ascii_case(this, LOWER_CASE_ASCII_LETTERS, UPPER_CASE_ASCII_LETTERS)
+
+/// Returns this String with ASCII uppercase letters converted to lowercase.
+///
+/// Characters outside `A` through `Z` are unchanged.
+fun String.to_lower_case(): String = string_convert_ascii_case(this, UPPER_CASE_ASCII_LETTERS, LOWER_CASE_ASCII_LETTERS)
+
+/// Compatibility alias for `to_lower_case`.
+fun String.tol_lower_case(): String = this.to_lower_case()
+
+/// Returns this char converted to uppercase when it is an ASCII lowercase letter.
+///
+/// Characters outside `a` through `z` are unchanged.
+fun char.to_upper_case(): char = char! { this.value.to_upper_case() }
+
+/// Returns this char converted to lowercase when it is an ASCII uppercase letter.
+///
+/// Characters outside `A` through `Z` are unchanged.
+fun char.to_lower_case(): char = char! { this.value.to_lower_case() }
+
+/// Compatibility alias for `to_lower_case`.
+fun char.tol_lower_case(): char = this.to_lower_case()
+
+private fun string_convert_ascii_case(value: String, from: String, to: String): String =
+    @Recursive
+    fun convert(value: String, idx: int, from: String, to: String, acc: String): String =
+        match value[idx] with
+        case None -> acc
+        case Some { char } -> convert(value, idx + 1, from, to, acc + string_ascii_case_pair(char, from, to))
+    ---
+    convert(value, 0, from, to, "")
+
+private fun string_ascii_case_pair(char: String, from: String, to: String): String =
+    @Recursive
+    fun find(char: String, from: String, to: String, idx: int): String =
+        match from[idx] with
+        case None -> char
+        case Some { from_char } ->
+            if from_char == char
+            then to[idx, idx + 1]
+            else find(char, from, to, idx + 1)
+    ---
+    find(char, from, to, 0)
+
 /// Returns the character at idx as a String using the same bounds and negative-index rules as string[idx].
 fun String.get(idx: index): Option[char] = <native>
 

--- a/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
@@ -16,6 +16,7 @@ fun tests(): Effect[TestFile] =
         test("should get substrings by range", () => should_get_substrings_by_range()),
         test("should concatenate values", () => should_concatenate_values()),
         test("should compare strings and chars", () => should_compare_strings_and_chars()),
+        test("should change ASCII case", () => should_change_ascii_case()),
         test("should test any and all characters", () => should_test_any_and_all_characters()),
         test("should test any and all characters with index", () => should_test_any_and_all_characters_with_index()),
         test("should detect contained substrings", () => should_detect_contained_substrings()),
@@ -101,6 +102,21 @@ fun should_compare_strings_and_chars(): Assert =
         assert_that(char { "b" }).succeeds(left =>
             assert_that(char { "a" }).succeeds(right =>
                 assert_that(left.compare(right)).is_equal_to(GREATER))),
+    ])
+
+fun should_change_ascii_case(): Assert =
+    assert_all([
+        assert_that("Capy BARA 123!?".to_upper_case()).is_equal_to("CAPY BARA 123!?"),
+        assert_that("Capy BARA 123!?".to_lower_case()).is_equal_to("capy bara 123!?"),
+        assert_that("ABC".tol_lower_case()).is_equal_to("abc"),
+        assert_that(char { "a" }).succeeds(value =>
+            assert_that(value.to_upper_case().to_string()).is_equal_to("A")),
+        assert_that(char { "Z" }).succeeds(value =>
+            assert_that(value.to_lower_case().to_string()).is_equal_to("z")),
+        assert_that(char { "B" }).succeeds(value =>
+            assert_that(value.tol_lower_case().to_string()).is_equal_to("b")),
+        assert_that(char { "!" }).succeeds(value =>
+            assert_that(value.to_upper_case().to_string()).is_equal_to("!")),
     ])
 
 fun should_test_any_and_all_characters(): Assert =

--- a/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
@@ -26,6 +26,10 @@ fun tests(): Effect[TestFile] =
         test("should flat map characters", () => should_flat_map_characters()),
         test("should detect prefixes and suffixes", () => should_detect_prefixes_and_suffixes()),
         test("should trim whitespace", () => should_trim_whitespace()),
+        test("should detect blank strings", () => should_detect_blank_strings()),
+        test("should trim one side", () => should_trim_one_side()),
+        test("should repeat strings", () => should_repeat_strings()),
+        test("should find substring indexes", () => should_find_substring_indexes()),
         test("should replace all occurrences", () => should_replace_all_occurrences()),
     ])
 
@@ -182,6 +186,43 @@ fun should_trim_whitespace(): Assert =
         assert_that((" " + '\t' + "capybara" + '\n' + " ").trim()).is_equal_to("capybara"),
         assert_that("     ".trim()).is_equal_to(""),
         assert_that("capy".trim()).is_equal_to("capy"),
+    ])
+
+fun should_detect_blank_strings(): Assert =
+    assert_all([
+        assert_that("".is_blank()).is_equal_to(true),
+        assert_that((" " + '\t' + '\n').is_blank()).is_equal_to(true),
+        assert_that(" capy ".is_blank()).is_equal_to(false),
+    ])
+
+fun should_trim_one_side(): Assert =
+    assert_all([
+        assert_that((" " + '\t' + "capy" + '\n').trim_start()).is_equal_to("capy" + '\n'),
+        assert_that((" " + '\t' + "capy" + '\n').trim_end()).is_equal_to(" " + '\t' + "capy"),
+        assert_that("capy".trim_start()).is_equal_to("capy"),
+        assert_that("capy".trim_end()).is_equal_to("capy"),
+    ])
+
+fun should_repeat_strings(): Assert =
+    assert_all([
+        assert_that("ha".repeat(3)).is_equal_to("hahaha"),
+        assert_that("ha".repeat(1)).is_equal_to("ha"),
+        assert_that("ha".repeat(0)).is_equal_to(""),
+        assert_that("ha".repeat(-2)).is_equal_to(""),
+        assert_that("".repeat(4)).is_equal_to(""),
+    ])
+
+fun should_find_substring_indexes(): Assert =
+    assert_all([
+        assert_that("banana".index_of("na")).contains(string_test_index(2)),
+        assert_that("banana".last_index_of("na")).contains(string_test_index(4)),
+        assert_that("banana".index_of("ba")).contains(FIRST_ELEMENT),
+        assert_that("banana".index_of("")).contains(FIRST_ELEMENT),
+        assert_that("banana".last_index_of("")).contains(string_test_index(6)),
+        assert_that("banana".index_of("zz")).is_empty(),
+        assert_that("banana".last_index_of("zz")).is_empty(),
+        assert_that("ba".index_of("banana")).is_empty(),
+        assert_that("ba".last_index_of("banana")).is_empty(),
     ])
 
 fun should_replace_all_occurrences(): Assert =

--- a/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
@@ -112,13 +112,10 @@ fun should_change_ascii_case(): Assert =
     assert_all([
         assert_that("Capy BARA 123!?".to_upper_case()).is_equal_to("CAPY BARA 123!?"),
         assert_that("Capy BARA 123!?".to_lower_case()).is_equal_to("capy bara 123!?"),
-        assert_that("ABC".tol_lower_case()).is_equal_to("abc"),
         assert_that(char { "a" }).succeeds(value =>
             assert_that(value.to_upper_case().to_string()).is_equal_to("A")),
         assert_that(char { "Z" }).succeeds(value =>
             assert_that(value.to_lower_case().to_string()).is_equal_to("z")),
-        assert_that(char { "B" }).succeeds(value =>
-            assert_that(value.tol_lower_case().to_string()).is_equal_to("b")),
         assert_that(char { "!" }).succeeds(value =>
             assert_that(value.to_upper_case().to_string()).is_equal_to("!")),
     ])


### PR DESCRIPTION
## What changed

- Added documented ASCII case conversion helpers for `String` and `char` in `capy.lang.String`.
- Added `to_upper_case`, `to_lower_case`, and the requested `tol_lower_case` compatibility alias.
- Added additional documented `String` helpers: `is_blank`, `trim_start`, `trim_end`, `repeat`, `index_of`, and `last_index_of`.
- Routed generated Java, Python, and JavaScript calls through the Capybara string runtime so behavior is consistent across targets.
- Added Capybara library tests for string and char case conversion plus the new string helpers.

## Why

Issue #260 requests string and char case helpers in the standard library. The extra helpers round out the basic string API with low-risk operations built from existing semantics.

## Impact

Capybara programs can convert ASCII letters between upper and lower case on strings and chars, trim one or both sides of documented trim whitespace, check blank strings, repeat strings, and find the first or last substring index. Missing substring searches return `None`.

## Validation

- `./gradlew :lib:capybara-lib:testCapybara`
