### PR TITLE
docs(#183): add capybara library examples

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/collection/Dict.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Dict.cfun
@@ -4,6 +4,13 @@ from /capy/lang/Option import { * }
 
 /// Native String-keyed map type backed by the runtime Dict implementation.
 /// Dict literals use braces with String keys: {"one": 1, "two": 2}.
+///
+/// Example:
+/// ```cfun
+/// let base = { "name": "Ada" }
+/// base + { "role": "admin" }
+/// ```
+/// Dictionaries are immutable: adding or removing entries returns a new `Dict`.
 data Dict[T] { <native> }
 
 /// Returns the number of entries in this Dict.
@@ -13,9 +20,14 @@ fun Dict[T].size(): size = <native>
 fun Dict[T].is_empty(): bool = this.size() == EMPTY
 
 /// Returns this Dict as a List of `(key, value)` tuples.
+///
+/// Example: `{"one": 1}.entries()` returns `[("one", 1)]`.
 fun Dict[T].entries(): List[Tuple[String, T]] = <native>
 
 /// Returns a new Dict with `entry` added or replaced.
+///
+/// Example: `{"name": "Ada"} + ("name", "Grace")` returns a dictionary where
+/// `name` is `Grace`.
 fun Dict[T].`+`(entry: Tuple[String, T]): Dict[T] = <native>
 
 /// Returns a new Dict with all entries from `other` added or replaced.
@@ -57,6 +69,12 @@ fun Dict[T].contains_key(key: String): bool =
 fun Dict[T].`?`(key: String): bool = this.contains_key(key)
 
 /// Combines all entries from left to right.
+///
+/// Example:
+/// ```cfun
+/// {"a": 1, "b": 2} |> 0, (total, _, value) => total + value
+/// ```
+/// Returns `3`.
 fun Dict[T].reduce(initial: R, reducer: (R, String, T) => R): R =
     this.entries().reduce(initial, (acc, entry) => reducer(acc, entry[0], entry[1]))
 
@@ -64,6 +82,12 @@ fun Dict[T].reduce(initial: R, reducer: (R, String, T) => R): R =
 fun Dict[T].`|>`(initial: R, reducer: (R, String, T) => R): R = this.reduce(initial, reducer)
 
 /// Transforms each entry using `map`.
+///
+/// Example:
+/// ```cfun
+/// {"a": 1, "b": 2} | (_, value) => value * 10
+/// ```
+/// Returns `{"a": 10, "b": 20}` while preserving keys.
 fun Dict[T].map(map: (String, T) => Y): Dict[Y] =
     this.entries().reduce({:}, (acc, entry) => acc + (entry[0], map(entry[0], entry[1])))
 
@@ -71,6 +95,12 @@ fun Dict[T].map(map: (String, T) => Y): Dict[Y] =
 fun Dict[T].`|`(map: (String, T) => Y): Dict[Y] = this.map(map)
 
 /// Returns a new Dict containing only entries that satisfy `predicate`.
+///
+/// Example:
+/// ```cfun
+/// {"debug": true, "prod": false} |- (_, enabled) => enabled
+/// ```
+/// Returns only the `debug` entry.
 fun Dict[T].filter(predicate: (String, T) => bool): Dict[T] =
     this.entries().reduce({:}, (acc, entry) =>
         if predicate(entry[0], entry[1])
@@ -88,4 +118,6 @@ fun Dict[T].reject(predicate: (String, T) => bool): Dict[T] =
 fun Dict[T].`|-`(predicate: (String, T) => bool): Dict[T] = this.filter(predicate)
 
 /// Returns the value for key; equivalent to dict[key].
+///
+/// Example: `{"name": "Ada"}.get("name")` returns `Some { value: "Ada" }`.
 fun Dict[T].get(key: String): Option[T] = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/List.cfun
@@ -7,6 +7,14 @@ from /capy/meta_prog/Recursive import { Recursive }
 
 /// Native ordered collection type backed by the runtime List implementation.
 /// List literals use square brackets: [1, 2, 3].
+///
+/// Example:
+/// ```cfun
+/// let values = [1, 2, 3]
+/// values + 4
+/// ```
+/// Lists are immutable: `values + 4` returns a new list and leaves `values`
+/// unchanged.
 data List[T] { <native> }
 
 /// Returns the number of values in this List.
@@ -75,6 +83,12 @@ fun List[T].contains(value: T): bool =
 fun List[T].`?`(value: T): bool = this.contains(value)
 
 /// Combines all values from left to right.
+///
+/// Example:
+/// ```cfun
+/// [1, 2, 3] |> 0, (total, value) => total + value
+/// ```
+/// Returns `6`.
 fun List[T].reduce(initial: R, reducer: (R, T) => R): R =
     @Recursive
     fun reduce(list: List[T], idx: int, acc: R, reducer: (R, T) => R): R =
@@ -102,6 +116,15 @@ fun List[T].fold(reducer: (T, T) => T): Option[T] =
     case Some { value } -> Some { reduce(this, 1, value, reducer) }
 
 /// Transforms each value using `map`.
+///
+/// `map` returns a lazy `Seq`, so call `as_list()` when a materialized list is
+/// needed.
+///
+/// Example:
+/// ```cfun
+/// ([1, 2, 3] | value => value * 2).as_list()
+/// ```
+/// Returns `[2, 4, 6]`.
 fun List[T].map(map: T => Y): Seq[Y] =
     fun map_values(list: List[T], idx: int, map: T => Y): Seq[Y] =
         match list[idx] with
@@ -114,6 +137,12 @@ fun List[T].map(map: T => Y): Seq[Y] =
 fun List[T].`|`(map: T => Y): Seq[Y] = this.map(map)
 
 /// Returns a sequence containing only values that satisfy `predicate`.
+///
+/// Example:
+/// ```cfun
+/// ([1, 2, 3, 4] |- value => value > 2).as_list()
+/// ```
+/// Returns `[3, 4]`.
 fun List[T].filter(predicate: T => bool): Seq[T] =
     fun filter(list: List[T], idx: int, predicate: T => bool): Seq[T] =
         match list[idx] with
@@ -141,6 +170,12 @@ fun List[T].reject(predicate: T => bool): Seq[T] =
 fun List[T].`|-`(predicate: T => bool): Seq[T] = this.filter(predicate)
 
 /// Applies `map` to each value and concatenates the resulting lists.
+///
+/// Example:
+/// ```cfun
+/// ([1, 2] |* value => [value, value * 10]).as_list()
+/// ```
+/// Returns `[1, 10, 2, 20]`.
 fun List[T].flat_map(map: T => List[Y]): Seq[Y] = to_seq(this.reduce([], (acc, value) => acc + map(value)))
 
 /// Applies `map` to each value and concatenates the resulting lists.
@@ -152,9 +187,13 @@ fun List[T].`|*`(map: T => List[Y]): Seq[Y] = this.flat_map(map)
 fun List[T].sort(compare: (T, T) => Ordering): List[T] = sort_list(this, compare)
 
 /// Returns the value at idx using the same bounds and negative-index rules as list[idx].
+///
+/// Example: `[10, 20, 30].get(-1)` returns `Some { value: 30 }`.
 fun List[T].get(idx: index): Option[T] = <native>
 
 /// Returns the values in the half-open range [from, to) using the same bounds and negative-index rules as list[from:to].
+///
+/// Example: `[10, 20, 30, 40].get(1, 3)` returns `[20, 30]`.
 fun List[T].get(from: int, to: int): List[T] = <native>
 
 private fun sort_list(list: List[T], compare: (T, T) => Ordering): List[T] =

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Seq.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Seq.cfun
@@ -5,8 +5,23 @@ from /capy/collection/Dict import { * }
 from /capy/lang/Option import { Option, None, Some }
 from /capy/meta_prog/Recursive import { Recursive }
 
+/// Lazy sequence that can be finite or infinite.
+///
+/// A `Seq` is either a `Cons` value with a current element and delayed rest, or
+/// `End` for an empty sequence. Use `take` before materializing an infinite
+/// sequence.
+///
+/// Example:
+/// ```cfun
+/// natural_seq()
+///     .filter(value => value % 2 == 0)
+///     .take(3)
+/// ```
+/// Returns `[0, 2, 4]`.
 union Seq[T] = Cons[T] | End
+/// Non-empty sequence node.
 data Cons[T] { value: T, rest: () => Seq[T] }
+/// Empty sequence node.
 data End {}
 /// Returns an infinite sequence of natural numbers starting at `0`.
 ///
@@ -47,6 +62,8 @@ fun powers_of_2_seq() = powers_seq(2)
 /// Collects the first `n` elements into a `List`.
 ///
 /// This method is safe to use with infinite sequences.
+///
+/// Example: `powers_of_2_seq().take(4)` returns `[1, 2, 4, 8]`.
 fun Seq[T].take(n: size): List[T] =
     @Recursive
     fun take(seq: Seq[T], n: int, list: List[T]): List[T] =
@@ -72,6 +89,12 @@ fun Seq[T].as_list(): List[T] =
     as_list(this, [])
 
 /// Converts a `List` into a finite `Seq`.
+///
+/// Example:
+/// ```cfun
+/// to_seq([1, 2, 3]).map(value => value + 1).as_list()
+/// ```
+/// Returns `[2, 3, 4]`.
 fun to_seq(list: List[T]): Seq[T] =
     let initial: Seq[T] = End {}
     list |> initial, (acc, value) => acc + Cons { value, () => End {} }
@@ -118,6 +141,7 @@ fun Seq[T].filter(pred: T => bool): Seq[T] =
     ---
     filter(this, pred)
 
+/// Operator alias for `filter`.
 fun Seq[T].`|-`(pred: T => bool): Seq[T] = this.filter(pred)
 
 /// Returns a sequence without elements that satisfy `pred`.
@@ -190,11 +214,18 @@ fun Seq[T].`+`(other: Seq[T]): Seq[T] =
     add(this, other)
 
 /// Transforms each element using `map`.
+///
+/// Example:
+/// ```cfun
+/// (to_seq([1, 2, 3]) | value => value * 2).as_list()
+/// ```
+/// Returns `[2, 4, 6]`.
 fun Seq[T].`|`(map: T => Y): Seq[Y] =
     match this with
     case End -> End {}
     case Cons { value, rest } -> Cons { map(value), () => (rest() | map) }
 
+/// Transforms each element using `map`.
 fun Seq[T].map(map: T => Y): Seq[Y] =
     match this with
     case End -> End {}
@@ -203,7 +234,7 @@ fun Seq[T].map(map: T => Y): Seq[Y] =
 /// Applies `map` and flattens the resulting sequences.
 ///
 /// Example:
-/// `[1, 2, 3, 4, ...] |* x => [x, 2*x, 3*x]`
+/// `natural_seq() |* x => to_seq([x, 2*x, 3*x])`
 /// produces:
 /// `[1, 2, 3, 2, 4, 6, 4, 8, 12, ...]`
 fun Seq[T].`|*`(map: T => Seq[Y]): Seq[Y] =
@@ -215,6 +246,7 @@ fun Seq[T].`|*`(map: T => Seq[Y]): Seq[Y] =
     ---
     flat_map(this, map)
 
+/// Applies `map` and flattens the resulting sequences.
 fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
     fun flat_map(seq: Seq[T], map: T => Seq[Y]) =
         match seq with
@@ -225,6 +257,14 @@ fun Seq[T].flat_map(map: T => Seq[Y]): Seq[Y] =
     flat_map(this, map)
 
 /// Combines all elements from left to right.
+///
+/// Important: reducing an infinite sequence does not terminate.
+///
+/// Example:
+/// ```cfun
+/// to_seq([1, 2, 3]) |> 0, (total, value) => total + value
+/// ```
+/// Returns `6`.
 fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
     @Recursive
     fun reduce(seq: Seq[T], acc: R, reducer: (R, T) => R): R =
@@ -234,6 +274,7 @@ fun Seq[T].reduce(initial: R, reducer: (R, T) => R): R =
     ---
     reduce(this, initial, reducer)
 
+/// Operator alias for `reduce`.
 fun Seq[T].`|>`(initial: R, reducer: (R, T) => R): R = this.reduce(initial, reducer)
 
 /// Combines elements from left to right using the first element as the accumulator.

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Set.cfun
@@ -7,6 +7,13 @@ from /capy/collection/Seq import { * }
 ///
 /// For a one-value Set, include a trailing comma: {1,}.
 /// Without the comma, {1} is parsed as a grouped expression, not as a Set.
+///
+/// Example:
+/// ```cfun
+/// let tags = {"compiler", "docs"}
+/// tags + "json"
+/// ```
+/// Sets are immutable and contain each value at most once.
 data Set[T] { <native> }
 
 /// Returns the number of values in this Set.
@@ -290,6 +297,13 @@ fun Set[T].power_set(): Set[Set[T]] =
 fun Set[T].`℘`(): Set[Set[T]] = this.power_set()
 
 /// Combines all values from left to right.
+///
+/// Example:
+/// ```cfun
+/// {1, 2, 3} |> 0, (total, value) => total + value
+/// ```
+/// The iteration order is runtime-defined, so use reducers that do not depend
+/// on a specific set order.
 fun Set[T].reduce(initial: R, reducer: (R, T) => R): R =
     this.to_list().reduce(initial, reducer)
 
@@ -297,12 +311,24 @@ fun Set[T].reduce(initial: R, reducer: (R, T) => R): R =
 fun Set[T].`|>`(initial: R, reducer: (R, T) => R): R = this.reduce(initial, reducer)
 
 /// Transforms each value using `map`.
+///
+/// `map` returns a lazy `Seq`.
+///
+/// Example:
+/// ```cfun
+/// ({1, 2, 3} | value => value * 2).as_list()
+/// ```
 fun Set[T].map(map: T => Y): Seq[Y] = this.to_list().map(map)
 
 /// Transforms each value using `map`.
 fun Set[T].`|`(map: T => Y): Seq[Y] = this.map(map)
 
 /// Returns a sequence containing only values that satisfy `predicate`.
+///
+/// Example:
+/// ```cfun
+/// ({1, 2, 3, 4} |- value => value > 2).as_list()
+/// ```
 fun Set[T].filter(predicate: T => bool): Seq[T] = this.to_list().filter(predicate)
 
 /// Returns a sequence without values that satisfy `predicate`.
@@ -312,6 +338,11 @@ fun Set[T].reject(predicate: T => bool): Seq[T] = this.to_list().reject(predicat
 fun Set[T].`|-`(predicate: T => bool): Seq[T] = this.filter(predicate)
 
 /// Applies `map` to each value and concatenates the resulting sets.
+///
+/// Example:
+/// ```cfun
+/// ({1, 2} |* value => {value, value * 10}).as_list()
+/// ```
 fun Set[T].flat_map(map: T => Set[Y]): Seq[Y] =
     this.to_list().flat_map(value => map(value).to_list())
 

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Clock.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Clock.cfun
@@ -1,5 +1,14 @@
 from /capy/date_time/DateTime import { * }
 from /capy/lang/Effect import { * }
 
+/// Returns the current date-time as an effect.
+///
+/// Example:
+/// ```cfun
+/// let current <- now()
+/// current.to_iso_8601()
+/// ```
+/// The value is effectful because the current time comes from the runtime
+/// environment.
 fun now(): Effect[DateTime] =
     delay(() => UNIX_EPOCH)

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -51,6 +51,13 @@ private const MONTH_TO_DAY_BIAS: int = 2
 ///
 /// The constructor validates the provided values and returns an error for
 /// impossible dates.
+///
+/// Example:
+/// ```cfun
+/// Date { day: 29, month: FEBRUARY, year: 2024 }
+/// Date { day: 29, month: FEBRUARY, year: 2025 }
+/// ```
+/// The leap-year date succeeds; the invalid 2025 date returns `Error`.
 data Date {
     day: int,
     month: month,
@@ -81,6 +88,8 @@ fun Date.last_day_of_month(): Date =
         else Date! { day: 30, month: this.month, year: this.year }
 
 /// Converts this date to days since Unix epoch (`1970-01-01`).
+///
+/// Example: `UNIX_DATE.to_days_since_unix_epoch()` returns `0`.
 fun Date.to_days_since_unix_epoch(): int =
     let month_value = this.month.value
     let y = if month_value <= 2 then this.year - 1 else this.year
@@ -92,6 +101,8 @@ fun Date.to_days_since_unix_epoch(): int =
     era * DAYS_PER_400_YEARS + doe - UNIX_EPOCH_CIVIL_OFFSET_DAYS
 
 /// Converts days since Unix epoch (`1970-01-01`) to `Date`.
+///
+/// Example: `from_days_since_unix_epoch(1)` returns `1970-01-02`.
 fun from_days_since_unix_epoch(days_since_epoch: int): Date =
     let z: int = days_since_epoch + UNIX_EPOCH_CIVIL_OFFSET_DAYS
     let era: int = floor_div(z, DAYS_PER_400_YEARS)
@@ -106,9 +117,17 @@ fun from_days_since_unix_epoch(days_since_epoch: int): Date =
     Date! { day, month: month! { month_value }, year }
 
 /// Adds days to this date.
+///
+/// Example: `UNIX_DATE.add_days(31)` returns `1970-02-01`.
 fun Date.add_days(days: int): Date = from_days_since_unix_epoch(this.to_days_since_unix_epoch() + days)
 
 /// Adds years and months to this date, clamping the day to target month length.
+///
+/// Example:
+/// ```cfun
+/// Date! { day: 31, month: JANUARY, year: 2024 }.add_years_months(0, 1)
+/// ```
+/// Returns `2024-02-29`, because February 2024 has no day 31.
 fun Date.add_years_months(years: int, months: int): Date =
     fun floor_mod(a: int, b: int): int = a - floor_div(a, b) * b
     fun days_in_month(year: int, value: month): int =
@@ -129,6 +148,9 @@ fun Date.add_years_months(years: int, months: int): Date =
     }
 
 /// Formats this date as an ISO 8601 calendar date.
+///
+/// Example: `Date! { day: 5, month: JUNE, year: 2026 }.to_iso_8601()`
+/// returns `2026-06-05`.
 fun Date.to_iso_8601(): String =
     @Recursive
     fun pad_left(value: String, size: int): String =
@@ -149,6 +171,13 @@ fun Date.to_iso_8601(): String =
     + pad_left("" + this.day, 2)
 
 /// Parses an ISO 8601 calendar date in basic or extended complete form.
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("2026-06-05")
+/// from_iso_8601("20260605")
+/// ```
+/// Both forms return the same `Date`.
 fun from_iso_8601(iso: String): Result[Date] =
     data Parse[T] { buffer: String, value: T }
     fun invalid(message: String): String = "Invalid ISO 8601 date format: " + message

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/DateTime.cfun
@@ -9,15 +9,26 @@ from /capy/lang/String import { * }
 from /capy/meta_prog/Recursive import { Recursive }
 
 /// Combination of a UTC calendar date and time of day.
+///
+/// Example:
+/// ```cfun
+/// DateTime { date: UNIX_DATE, time: MIDNIGHT }
+/// ```
+/// Use `from_iso_8601` for parsing strings and `from_timestamp` for Unix
+/// timestamp values.
 data DateTime { date: Date, time: Time }
 
 /// Unix epoch date-time (`1970-01-01T00:00:00Z`).
 const UNIX_EPOCH: DateTime = DateTime { date: UNIX_DATE, time: MIDNIGHT }
 
 /// Returns Unix timestamp (seconds since `1970-01-01T00:00:00Z`).
+///
+/// Example: `UNIX_EPOCH.timestamp()` returns `0L`.
 fun DateTime.timestamp(): long = 1L * this.date.to_days_since_unix_epoch() * SECONDS_IN_DAY + this.time.to_seconds()
 
 /// Converts a Unix timestamp (seconds since `1970-01-01T00:00:00Z`) to a `DateTime`.
+///
+/// Example: `from_timestamp(86400L)` returns `1970-01-02T00:00:00Z`.
 fun from_timestamp(timestamp: long): DateTime =
     let seconds_in_day = 1L * SECONDS_IN_DAY
     let days = floor_div(timestamp, seconds_in_day)
@@ -29,6 +40,15 @@ fun from_timestamp(timestamp: long): DateTime =
     }
 
 /// Adds a `Duration` to this `DateTime`.
+///
+/// Example:
+/// ```cfun
+/// UNIX_EPOCH + DateDuration {
+///     years: 0, months: 0, days: 1,
+///     hours: 2, minutes: 0, seconds: 0
+/// }
+/// ```
+/// Returns `1970-01-02T02:00:00Z`.
 fun DateTime.plus(duration: Duration): DateTime =
     let date_with_months = this.date.add_years_months(duration.years(), duration.months())
     let days_from_hours = floor_div(duration.hours(), HOURS_IN_DAY)
@@ -55,6 +75,12 @@ fun DateTime.minus(duration: Duration): DateTime = this.plus(duration.negate())
 fun DateTime.`-`(duration: Duration): DateTime = this.minus(duration)
 
 /// Returns the duration from `other` to this `DateTime`.
+///
+/// Example:
+/// ```cfun
+/// from_timestamp(90L).minus(UNIX_EPOCH)
+/// ```
+/// Returns a duration of 1 minute and 30 seconds.
 fun DateTime.minus(other: DateTime): Duration =
     fun positive_duration_from_seconds(total_seconds: long): Duration =
         let days = floor_div(total_seconds, SECONDS_IN_DAY)
@@ -106,6 +132,13 @@ fun DateTime.`<`(other: DateTime): bool = this.less_than(other)
 fun DateTime.`>`(other: DateTime): bool = this.greater_than(other)
 
 /// Formats this date-time as a canonical UTC ISO 8601 string.
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("2026-06-18T14:30:00+02:00")
+///     .map(datetime => datetime.to_iso_8601())
+/// ```
+/// Returns `2026-06-18T12:30:00Z` after applying the offset.
 fun DateTime.to_iso_8601(): String =
     fun format_utc(datetime: DateTime): String =
         datetime.date.to_iso_8601() + "T" + datetime.time.to_iso_8601() + "Z"
@@ -131,6 +164,13 @@ fun DateTime.to_iso_8601(): String =
     format_utc(normalize_to_utc(this))
 
 /// Parses a UTC ISO 8601 date-time in basic or extended form.
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("2026-06-18T12:30:00Z")
+/// from_iso_8601("20260618T123000Z")
+/// ```
+/// Both forms return the same UTC `DateTime`.
 fun from_iso_8601(iso: String): Result[DateTime] =
     data Split { left: String, right: String }
     data SplitScan { left: String, right: String, seen_separator: bool }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -19,6 +19,12 @@ from /capy/meta_prog/Recursive import { Recursive }
 /// `Duration` is a sum type:
 /// - `DateDuration` for year/month/day/time durations
 /// - `WeekDuration` for ISO week-only durations like `P2W`
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("P3Y6M4DT12H30M5S")
+/// ```
+/// Returns a `DateDuration` with date and time components populated.
 union Duration = DateDuration | WeekDuration
 
 /// Duration expressed with calendar and clock components.
@@ -95,6 +101,15 @@ fun Duration.to_iso_8601(): String =
 /// - only integer values are supported
 ///
 /// Returns `Error` with a readable message when the input is invalid.
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("PT90S")
+/// from_iso_8601("P2W")
+/// from_iso_8601("P0003-06-04T12:30:05")
+/// ```
+/// These return a 90-second date duration, a two-week duration, and a combined
+/// extended duration respectively.
 fun from_iso_8601(iso: String): Result[Duration] =
     data Parse[T] { buffer: String, value: T }
     data Parts {
@@ -389,6 +404,10 @@ fun from_iso_8601(iso: String): Result[Duration] =
 
 
 /// Returns this duration with all components negated.
+/// Returns the same duration with every component sign inverted.
+///
+/// Example: `DateDuration { years: 0, months: 0, days: 1, hours: 0, minutes: 0, seconds: 0 }.negate()`
+/// returns a negative one-day duration.
 fun Duration.negate(): Duration =
     match this with
     case WeekDuration { weeks } -> WeekDuration { weeks: 0 - weeks }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Interval.cfun
@@ -6,16 +6,41 @@ from /capy/lang/String import { * }
 from /capy/meta_prog/Recursive import { Recursive }
 
 /// ISO 8601 interval represented using UTC date-time endpoints.
+///
+/// An interval can be stored as start/end, start/duration, or duration/end.
+///
+/// Example:
+/// ```cfun
+/// DateTimeStartDuration {
+///     start: UNIX_EPOCH,
+///     duration: DateDuration {
+///         years: 0, months: 0, days: 1,
+///         hours: 0, minutes: 0, seconds: 0
+///     }
+/// }
+/// ```
 union Interval =
     DateTimeStartEnd
     | DateTimeStartDuration
     | DateTimeDurationEnd
 
+/// Interval stored with explicit start and end date-times.
 data DateTimeStartEnd { start: DateTime, end: DateTime }
+/// Interval stored with a start date-time and duration.
 data DateTimeStartDuration { start: DateTime, duration: Duration }
+/// Interval stored with a duration and end date-time.
 data DateTimeDurationEnd { duration: Duration, end: DateTime }
 
 /// Formats this interval as canonical ISO 8601 using `/` as the separator.
+///
+/// Example:
+/// ```cfun
+/// DateTimeStartEnd {
+///     start: UNIX_EPOCH,
+///     end: from_timestamp(3600L)
+/// }.to_iso_8601()
+/// ```
+/// Returns `1970-01-01T00:00:00Z/1970-01-01T01:00:00Z`.
 fun Interval.to_iso_8601(): String =
     match this with
     case DateTimeStartEnd { start, end } -> start.to_iso_8601() + "/" + end.to_iso_8601()
@@ -23,6 +48,9 @@ fun Interval.to_iso_8601(): String =
     case DateTimeDurationEnd { duration, end } -> duration.to_iso_8601() + "/" + end.to_iso_8601()
 
 /// Returns the interval start date-time.
+///
+/// For `DateTimeDurationEnd`, the start is calculated by subtracting the
+/// duration from the end.
 fun Interval.start(): DateTime =
     match this with
     case DateTimeStartEnd { start, _ } -> start
@@ -30,6 +58,9 @@ fun Interval.start(): DateTime =
     case DateTimeDurationEnd { duration, end } -> end.minus(duration)
 
 /// Returns the interval end date-time.
+///
+/// For `DateTimeStartDuration`, the end is calculated by adding the duration to
+/// the start.
 fun Interval.end(): DateTime =
     match this with
     case DateTimeStartEnd { _, end } -> end
@@ -49,6 +80,13 @@ fun Interval.duration(): Duration =
 /// - `<duration>/<end>`
 ///
 /// Also accepts `--` as an alternate input separator and canonicalizes back to `/`.
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("1970-01-01T00:00:00Z/P1D")
+/// from_iso_8601("P1D/1970-01-02T00:00:00Z")
+/// ```
+/// Both describe a one-day interval.
 fun from_iso_8601(iso: String): Result[Interval] =
     data Split { left: String, right: String }
     data SplitScan { left: String, right: String, seen_separator: bool }

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
@@ -64,6 +64,16 @@ fun second.`==`(other: second): bool = this.value == other.value
 
 /// Clock time represented in 24-hour format.
 /// Component types validate `hour`, `minute`, `second`, and optional UTC offset.
+///
+/// Example:
+/// ```cfun
+/// Time {
+///     hour: hour! { 9 },
+///     minute: minute! { 30 },
+///     second: ZERO_SECOND,
+///     offset_minutes: None {}
+/// }
+/// ```
 data Time {
     hour: hour,
     minute: minute,
@@ -75,6 +85,8 @@ const MIDNIGHT: Time = Time { hour: ZERO_HOUR, minute: ZERO_MINUTE, second: ZERO
 const NOON: Time = Time { hour: NOON_HOUR, minute: ZERO_MINUTE, second: ZERO_SECOND, offset_minutes: None {} }
 
 /// Converts this time to seconds since midnight.
+///
+/// Example: `NOON.to_seconds()` returns `43200`.
 fun Time.to_seconds(): int = this.hour.value * SECONDS_IN_HOUR + this.minute.value * SECONDS_IN_MINUTE + this.second.value
 /// Converts this time to minutes since midnight, truncating seconds.
 fun Time.to_minutes(): int = this.hour.value * MINUTES_IN_HOUR + this.minute.value
@@ -85,6 +97,8 @@ fun Time.round_to_minutes(): Time = Time { hour: this.hour, minute: this.minute,
 /// Returns a new time with minutes and seconds set to `0`.
 fun Time.round_to_hours(): Time = Time { hour: this.hour, minute: ZERO_MINUTE, second: ZERO_SECOND, offset_minutes: this.offset_minutes }
 /// Adds seconds and wraps around a 24-hour day.
+///
+/// Example: `MIDNIGHT.add_seconds(-1)` returns `23:59:59`.
 fun Time.add_seconds(seconds: int): Time =
     fun normalize_day_seconds(total_seconds: int): int = /capy/lang/Math.floor_mod(total_seconds, SECONDS_IN_DAY)
     ---
@@ -99,6 +113,17 @@ fun Time.add_minutes(minutes: int): Time = this.add_seconds(minutes * SECONDS_IN
 fun Time.add_hours(hours: int): Time = this.add_seconds(hours * SECONDS_IN_HOUR)
 
 /// Formats this time as an ISO 8601 extended time.
+///
+/// Example:
+/// ```cfun
+/// Time {
+///     hour: hour! { 14 },
+///     minute: minute! { 5 },
+///     second: second! { 9 },
+///     offset_minutes: Some { value: offset_minutes! { 120 } }
+/// }.to_iso_8601()
+/// ```
+/// Returns `14:05:09+02:00`.
 fun Time.to_iso_8601(): String =
     @Recursive
     fun pad_left(value: String, size: int): String =
@@ -127,6 +152,13 @@ fun Time.to_iso_8601(): String =
       case Some { value } -> format_offset(value)
 
 /// Parses an ISO 8601 time in basic or extended complete form.
+///
+/// Example:
+/// ```cfun
+/// from_iso_8601("14:05:09Z")
+/// from_iso_8601("140509+0200")
+/// ```
+/// Offset-aware inputs preserve their offset in `offset_minutes`.
 fun from_iso_8601(iso: String): Result[Time] =
     data Parse[T] { buffer: String, value: T }
     data ZoneParse { buffer: String, offset_minutes: Option[offset_minutes] }

--- a/lib/capybara-lib/src/main/capybara/capy/io/ByteSize.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/ByteSize.cfun
@@ -17,6 +17,13 @@ const ONE_KIB: byte_count = byte_count! { 1024L }
 const ONE_MIB: byte_count = byte_count! { 1048576L }
 const ONE_GIB: byte_count = byte_count! { 1073741824L }
 
+/// Adds two byte counts, returning `Error` on long overflow.
+///
+/// Example:
+/// ```cfun
+/// ONE_KIB + ONE_MIB
+/// ```
+/// Returns `Success` containing `1049600` bytes.
 fun byte_count.plus(other: byte_count): Result[byte_count] =
     if this.value > MAX_LONG_VALUE - other.value
     then Error { message: "byte_count addition overflow" }
@@ -24,17 +31,25 @@ fun byte_count.plus(other: byte_count): Result[byte_count] =
 
 fun byte_count.`+`(other: byte_count): Result[byte_count] = this.plus(other)
 
+/// Subtracts `other` from this byte count.
+///
+/// The result is an error when subtraction would produce a negative byte count.
 fun byte_count.minus(other: byte_count): Result[byte_count] =
     byte_count { this.value - other.value }
 
 fun byte_count.`-`(other: byte_count): Result[byte_count] = this.minus(other)
 
+/// Converts this byte count to kibibytes.
+///
+/// Example: `ONE_MIB.to_kib()` returns `1024.0`.
 fun byte_count.to_kib(): double =
     this.value / BYTES_IN_KIB
 
+/// Converts this byte count to mebibytes.
 fun byte_count.to_mib(): double =
     this.value / BYTES_IN_MIB
 
+/// Converts this byte count to gibibytes.
 fun byte_count.to_gib(): double =
     this.value / BYTES_IN_GIB
 
@@ -44,12 +59,17 @@ fun byte_count.`<`(other: byte_count): bool = this.value < other.value
 fun byte_count.`<=`(other: byte_count): bool = this.value <= other.value
 fun byte_count.`==`(other: byte_count): bool = this.value == other.value
 
+/// Function form of `left + right`.
 fun add_byte_count(left: byte_count, right: byte_count): Result[byte_count] = left.plus(right)
 
+/// Function form of `left - right`.
 fun subtract_byte_count(left: byte_count, right: byte_count): Result[byte_count] = left.minus(right)
 
+/// Function form of `value.to_kib()`.
 fun byte_count_to_kib(value: byte_count): double = value.to_kib()
 
+/// Function form of `value.to_mib()`.
 fun byte_count_to_mib(value: byte_count): double = value.to_mib()
 
+/// Function form of `value.to_gib()`.
 fun byte_count_to_gib(value: byte_count): double = value.to_gib()

--- a/lib/capybara-lib/src/main/capybara/capy/io/Console.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Console.cfun
@@ -2,6 +2,13 @@ from /capy/lang/Effect import { * }
 from /capy/lang/Option import { * }
 
 /// Writes a string to standard output without a trailing newline and returns the consumed value.
+///
+/// Example:
+/// ```cfun
+/// let _ <- print("status: ")
+/// println("ready")
+/// ```
+/// Use `println` when a trailing newline should be written.
 fun print(text: String): Effect[String] = <native>
 
 /// Writes a byte to standard output without a trailing newline and returns the consumed value.
@@ -26,6 +33,9 @@ fun print(text: bool): Effect[bool] = <native>
 fun print(text: List[byte]): Effect[List[byte]] = <native>
 
 /// Writes a string to standard output followed by a newline and returns the consumed value.
+///
+/// `println` is useful in `main` effects because it preserves the printed value
+/// for later effect composition.
 fun println(text: String): Effect[String] = <native>
 
 /// Writes a byte to standard output followed by a newline and returns the consumed value.
@@ -50,6 +60,12 @@ fun println(text: bool): Effect[bool] = <native>
 fun println(text: List[byte]): Effect[List[byte]] = <native>
 
 /// Writes a string to standard error without a trailing newline and returns the consumed value.
+///
+/// Example:
+/// ```cfun
+/// let _ <- print_error("warning: ")
+/// println_error("configuration missing")
+/// ```
 fun print_error(text: String): Effect[String] = <native>
 
 /// Writes a byte to standard error without a trailing newline and returns the consumed value.
@@ -74,6 +90,9 @@ fun print_error(text: bool): Effect[bool] = <native>
 fun print_error(text: List[byte]): Effect[List[byte]] = <native>
 
 /// Writes a string to standard error followed by a newline and returns the consumed value.
+///
+/// Use this for diagnostics, progress messages, or errors that should not be
+/// mixed with normal program output.
 fun println_error(text: String): Effect[String] = <native>
 
 /// Writes a byte to standard error followed by a newline and returns the consumed value.
@@ -98,4 +117,12 @@ fun println_error(text: bool): Effect[bool] = <native>
 fun println_error(text: List[byte]): Effect[List[byte]] = <native>
 
 /// Reads one line from standard input, or None at end of input.
+///
+/// Example:
+/// ```cfun
+/// let line <- read_line()
+/// match line with
+/// case Some { value } -> println("hello " + value)
+/// case None -> println_error("no input")
+/// ```
 fun read_line(): Effect[Option[String]] = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/io/IO.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/IO.cfun
@@ -4,15 +4,35 @@ from /capy/lang/Effect import { * }
 from /capy/lang/Result import { * }
 
 /// Reads the entire file as UTF-8 text.
+///
+/// Example:
+/// ```cfun
+/// let content_result <- read_text(from_string("notes/today.txt"))
+/// match content_result with
+/// case Success { text } -> text
+/// case Error { message } -> "Could not read file: " + message
+/// ```
+/// File operations are effects because they interact with the host file system.
+/// The inner `Result` reports path, permission, or decoding failures.
 fun read_text(path: Path): Effect[Result[String]] = <native>
 
 /// Reads all lines from the file as UTF-8 text.
+///
+/// The returned list contains text lines without requiring callers to split the
+/// file manually.
 fun read_lines(path: Path): Effect[Result[List[String]]] = <native>
 
 /// Reads the entire file as bytes.
 fun read_bytes(path: Path): Effect[Result[List[byte]]] = <native>
 
 /// Writes UTF-8 text to the file, replacing existing content, and returns the consumed text.
+///
+/// Example:
+/// ```cfun
+/// let path = from_string("build/report.txt")
+/// let written <- write_text(path, "ready\n")
+/// ```
+/// Use `append_text` when existing content should be preserved.
 fun write_text(path: Path, text: String): Effect[Result[String]] = <native>
 
 /// Writes UTF-8 lines to the file, replacing existing content, and returns the consumed lines.
@@ -22,6 +42,12 @@ fun write_lines(path: Path, lines: List[String]): Effect[Result[List[String]]] =
 fun write_bytes(path: Path, bytes: List[byte]): Effect[Result[List[byte]]] = <native>
 
 /// Appends UTF-8 text to the file, creating the file when needed, and returns the consumed text.
+///
+/// Example:
+/// ```cfun
+/// let _ <- append_text(from_string("app.log"), "started\n")
+/// ```
+/// The file is created if it does not already exist.
 fun append_text(path: Path, text: String): Effect[Result[String]] = <native>
 
 /// Appends UTF-8 lines to the file, creating the file when needed, and returns the consumed lines.
@@ -31,6 +57,12 @@ fun append_lines(path: Path, lines: List[String]): Effect[Result[List[String]]] 
 fun append_bytes(path: Path, bytes: List[byte]): Effect[Result[List[byte]]] = <native>
 
 /// Returns true when the path exists.
+///
+/// Example:
+/// ```cfun
+/// let present <- exists(from_string("config.json"))
+/// if present then "configured" else "missing config"
+/// ```
 fun exists(path: Path): Effect[bool] = <native>
 
 /// Returns true when the path exists and is a regular file.
@@ -40,6 +72,8 @@ fun is_file(path: Path): Effect[bool] = <native>
 fun is_directory(path: Path): Effect[bool] = <native>
 
 /// Returns the size of a file in bytes.
+///
+/// The byte count can be converted with `to_kib`, `to_mib`, or `to_gib`.
 fun size(path: Path): Effect[Result[byte_count]] = <native>
 
 /// Creates a new empty file and returns the created path.
@@ -49,6 +83,12 @@ fun create_file(path: Path): Effect[Result[Path]] = <native>
 fun create_directory(path: Path): Effect[Result[Path]] = <native>
 
 /// Creates a directory and any missing parent directories, returning the created path.
+///
+/// Example:
+/// ```cfun
+/// let created <- create_directories(from_string("reports/2026/06"))
+/// ```
+/// Use this for nested output directories where parent paths may not exist yet.
 fun create_directories(path: Path): Effect[Result[Path]] = <native>
 
 /// Lists direct child entries of a directory.
@@ -58,12 +98,16 @@ fun list_entries(path: Path): Effect[Result[List[Path]]] = <native>
 fun delete(path: Path): Effect[Result[bool]] = <native>
 
 /// Copies a file and returns the target path. Fails if the target already exists.
+///
+/// Use `copy_replace` when overwriting the target is intentional.
 fun copy(source: Path, target: Path): Effect[Result[Path]] = <native>
 
 /// Copies a file and returns the target path, replacing an existing target.
 fun copy_replace(source: Path, target: Path): Effect[Result[Path]] = <native>
 
 /// Moves a file or directory and returns the target path. Fails if the target already exists.
+///
+/// Use `move_replace` when overwriting the target is intentional.
 fun move(source: Path, target: Path): Effect[Result[Path]] = <native>
 
 /// Moves a file or directory and returns the target path, replacing an existing target.

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -6,14 +6,36 @@ from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 from /capy/meta_prog/Recursive import { Recursive }
 
+/// Kind of root used by a `Path`.
+///
+/// `RELATIVE` paths are resolved from the current working directory,
+/// `ABSOLUTE` paths start at `/`, and `HOME` paths start at `~`.
 enum PathRoot { RELATIVE, ABSOLUTE, HOME }
 
+/// Portable path value split into a root and path segments.
+///
+/// Build paths with `from_string` or the `/` operator instead of manually
+/// constructing segments.
+///
+/// Example:
+/// ```cfun
+/// let path = from_string("~/projects") / "capybara" / "README.md"
+/// path.is_absolute()
+/// ```
+/// The root remains `HOME`, and each joined segment is normalized separately.
 data Path {
     root: PathRoot,
     prefix: Option[String],
     segments: List[String]
 }
 
+/// Parses a string path and normalizes empty, `.`, and `..` segments.
+///
+/// Example:
+/// ```cfun
+/// from_string("/var/log/../tmp/app.log")
+/// ```
+/// Produces an absolute path with segments `["var", "tmp", "app.log"]`.
 fun from_string(path_string: String): Path =
     @Recursive
     fun segments(value: String, current: String, acc: List[String]): List[String] =
@@ -51,6 +73,13 @@ fun from_string(path_string: String): Path =
         segments: segments(value, "", [])
     }.normalize()
 
+/// Returns a new path with `segment` appended.
+///
+/// Example:
+/// ```cfun
+/// from_string("reports") / "junit" / "TEST-main.xml"
+/// ```
+/// The original path is unchanged.
 fun Path.`/`(segment: String) =
     Path {
         root: this.root,
@@ -58,6 +87,10 @@ fun Path.`/`(segment: String) =
         segments: this.segments + segment
     }
 
+/// Returns a new path with `other` path segments appended.
+///
+/// The root of `this` is preserved, so use this to join a base directory with a
+/// relative child path.
 fun Path.`/`(other: Path) =
     Path {
         root: this.root,
@@ -65,6 +98,10 @@ fun Path.`/`(other: Path) =
         segments: this.segments + other.segments
     }
 
+/// Returns the final segment name, or the root name for root paths.
+///
+/// Examples: `from_string("/tmp/app.log").name()` returns `app.log`,
+/// while `from_string("/").name()` returns `/`.
 fun Path.name(): String =
     match this.prefix with
     case Some { v } -> v
@@ -74,6 +111,13 @@ fun Path.name(): String =
         case ABSOLUTE -> '/'
         case HOME -> '~'
 
+/// Returns the parent path, or `None` when this path has no parent segment.
+///
+/// Example:
+/// ```cfun
+/// from_string("docs/api/json.md").parent()
+/// ```
+/// Returns `Some` containing `docs/api`.
 fun Path.parent(): Option[Path] =
     if this.segments.is_empty() then None {}
     else Some {
@@ -84,13 +128,25 @@ fun Path.parent(): Option[Path] =
         }
     }
 
+/// Returns true for absolute and home-rooted paths.
 fun Path.is_absolute(): bool =
     match this.root with
     case RELATIVE -> false
     case _ -> true
 
+/// Returns true when the path has a root but no child segments.
 fun Path.is_root(): bool = this.segments.size() == EMPTY
 
+/// Returns a path with redundant segments removed.
+///
+/// Relative leading `..` segments are preserved; absolute and home paths do not
+/// move above their root.
+///
+/// Example:
+/// ```cfun
+/// from_string("src/./main/../test").normalize()
+/// ```
+/// Produces the relative path `src/test`.
 fun Path.normalize(): Path =
     @Recursive
     fun normalize_path(root: PathRoot, segments: List[String], acc: List[String]): List[String] =

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Effect.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Effect.cfun
@@ -1,10 +1,28 @@
+/// Deferred computation that may interact with the outside world.
+///
+/// `Effect` values are composed with `map`, `flat_map`, `|`, `|*`, or `let`
+/// binding. They run at the runtime boundary, or when `unsafe_run` is called
+/// explicitly.
+///
+/// Example:
+/// ```cfun
+/// let program =
+///     delay(() => "Ada")
+///         .map(name => "hello " + name)
+/// ```
+/// `program` is still an `Effect[String]`; the thunk has not run yet.
 union Effect[T] = UnsafeEffect[T]
 
 private data UnsafeEffect[T] { unsafe_thunk: () => T }
 
+/// Wraps a pure value in an effect.
 fun pure(value: T): Effect[T] =
     UnsafeEffect { unsafe_thunk: () => value }
 
+/// Defers a thunk until the effect is executed.
+///
+/// Use this for computations that should not happen while the effect is being
+/// constructed.
 fun delay(thunk: () => T): Effect[T] =
     UnsafeEffect { unsafe_thunk: thunk }
 
@@ -12,17 +30,33 @@ private fun _run(effect: Effect[T]): T =
     match effect with
     case UnsafeEffect { unsafe_thunk } -> unsafe_thunk()
 
+/// Executes the effect immediately and returns its value.
+///
+/// Prefer normal effect composition in application code. `unsafe_run` is useful
+/// for tests, adapters, or runtime boundaries that intentionally leave the
+/// effect model.
 fun Effect[T].unsafe_run(): T =
     _run(this)
 
+/// Transforms the produced value without executing the effect immediately.
 fun Effect[T].map(map: T => Y): Effect[Y] =
     delay(() => map(_run(this)))
 
+/// Sequences this effect and then returns the effect produced by `flatmap`.
+///
+/// Example:
+/// ```cfun
+/// read_text(path).flat_map(result =>
+///     print(result.reduce(text => text, err => err))
+/// )
+/// ```
 fun Effect[T].flat_map(flatmap: T => Effect[Y]): Effect[Y] =
     delay(() => _run(flatmap(_run(this))))
 
+/// Operator alias for `map`.
 fun Effect[T].`|`(map: T => Y): Effect[Y] =
     this.map(map)
 
+/// Operator alias for `flat_map`.
 fun Effect[T].`|*`(flatmap: T => Effect[Y]): Effect[Y] =
     this.flat_map(flatmap)

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Option.cfun
@@ -1,4 +1,11 @@
 /// Optional value that is either present as Some or absent as None.
+///
+/// Example:
+/// ```cfun
+/// let nickname: Option[String] = Some { value: "Ada" }
+/// nickname.map(name => name + "!")
+/// ```
+/// The result is `Some { value: "Ada!" }`. Mapping `None` returns `None`.
 union Option[T] = Some[T] | None
 
 /// Present Option value.
@@ -8,6 +15,9 @@ data Some[T] { value: T }
 data None {}
 
 /// Transforms a present value using `map`; equivalent to `this.map(map)`.
+///
+/// Example: `Some { value: 2 } | value => value * 2` returns
+/// `Some { value: 4 }`.
 fun Option[T].`|`(map: T => Y): Option[Y] = this.map(map)
 
 /// Transforms a present value using `map`, or returns None when empty.
@@ -17,9 +27,17 @@ fun Option[T].map(map: T => Y): Option[Y] =
     case Some s -> Some { map(s.value) }
 
 /// Applies `flatmap` to a present value; equivalent to `this.flat_map(flatmap)`.
+///
+/// Use this when the mapping function already returns an `Option`.
 fun Option[T].`|*`(flatmap: T => Option[Y]): Option[Y] = this.flat_map(flatmap)
 
 /// Applies `flatmap` to a present value, or returns None when empty.
+///
+/// Example:
+/// ```cfun
+/// Some { value: "capy" }.flat_map(text => text[0])
+/// ```
+/// The outer option stays empty if the original value is `None`.
 fun Option[T].flat_map(flatmap: T => Option[Y]): Option[Y] =
     match this with
     case None -> None {}

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Regex.cfun
@@ -7,9 +7,25 @@ from /capy/collection/Seq import { * }
 from /capy/lang/String import { * }
 from /capy/meta_prog/Recursive import { Recursive }
 
+/// Regular expression value used by matching, replacement, and split helpers.
+///
+/// Regex values can be created from regex literals or with `from_literal`.
+///
+/// Example:
+/// ```cfun
+/// let digits = from_literal("\\d+", "")
+/// digits.matches("123")
+/// ```
 data Regex { pattern: String, flags: String }
+/// Single regex match.
 data Match { group_value: String }
 
+/// Builds a regex value from a pattern and flags.
+///
+/// Prefer regex literals when the pattern is known at compile time:
+/// ```cfun
+/// let digits = regex/\d+/
+/// ```
 fun from_literal(pattern: String, flags: String): Regex = Regex { pattern, flags }
 
 private fun drop_prefix(value: String, size: int): String =
@@ -54,27 +70,62 @@ private fun split(pattern: String, input: String, current: String, acc: List[Str
     ---
     split(pattern, input, current, acc)
 
+/// Returns true when the input matches this regex pattern.
+///
+/// Example: `regex/capy/.matches("capybara")` returns true.
 fun Regex.matches(input: String): bool = input ? this.pattern
 
+/// Returns the first match, or `None` when no match exists.
 fun Regex.find(input: String): Option[Match] =
     match find_all(this.pattern, input, [])[0] with
     case Some { value } -> Some { value }
     case None -> None {}
 
+/// Returns all matches as a lazy sequence.
+///
+/// Example:
+/// ```cfun
+/// regex/na/.find_all("banana").map(match => match.group_value).as_list()
+/// ```
+/// Produces `["na", "na"]`.
 fun Regex.find_all(input: String): /capy/collection/Seq[Match] =
     /capy/collection/Seq.to_seq(find_all(this.pattern, input, []))
 
+/// Returns a function that replaces matches with `replacement`.
+///
+/// Example:
+/// ```cfun
+/// let redact_digits = regex/\d+/.replace("#")
+/// redact_digits("room 42")
+/// ```
+/// Returns `room #`.
 fun Regex.replace(replacement: String): String => String = value => value.replace(this.pattern, replacement)
 
+/// Splits `input` around this regex pattern.
 fun Regex.split(input: String): List[String] =
     split(this.pattern, input, "", [])
 
+/// Operator alias for `matches`.
 fun Regex.`?`(input: String): bool = this.matches(input)
+/// Operator alias for `find`.
 fun Regex.`~`(input: String): Option[Match] = this.find(input)
+/// Operator alias for `find_all`.
 fun Regex.`~~`(input: String): /capy/collection/Seq[Match] = this.find_all(input)
+/// Operator alias for `replace`.
+///
+/// Example:
+/// ```cfun
+/// (regex/\d+/ ~> "#")("a1b22")
+/// ```
+/// Returns `a#b#`.
 fun Regex.`~>`(replacement: String): String => String = this.replace(replacement)
+/// Operator alias for `split`.
 fun Regex.`/>`(input: String): List[String] = this.split(input)
 
+/// Returns the capture group at `idx`.
+///
+/// Current matches expose the full match at index `0`.
 fun Match.group(idx: index): Option[String] = if idx == FIRST_ELEMENT then Some { value: this.group_value } else None {}
 
+/// Returns all capture groups for this match.
 fun Match.groups(): List[Option[String]] = [Some { value: this.group_value }]

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
@@ -1,4 +1,13 @@
 /// Fallible value that is either a Success with a value or an Error with a message.
+///
+/// Example:
+/// ```cfun
+/// "42".to_int()
+///     .map(value => value * 2)
+///     .or_else(0)
+/// ```
+/// Successful results flow through `map` and `flat_map`; errors skip the
+/// transformation and preserve the message.
 union Result[T] = Success[T] | Error
 
 /// Successful Result value.
@@ -8,6 +17,9 @@ data Success[T] { value: T }
 data Error { message: String }
 
 /// Transforms a successful value using `map`; equivalent to `this.map(map)`.
+///
+/// Example: `Success { value: 2 } | value => value * 2` returns
+/// `Success { value: 4 }`.
 fun Result[T].`|`(map: T => Y): Result[Y] = this.map(map)
 
 /// Transforms a successful value using `map`, or propagates an Error unchanged.
@@ -17,6 +29,8 @@ fun Result[T].map(map: T => Y): Result[Y] =
     case Success s -> Success { map(s.value) }
 
 /// Applies `flatmap` to a successful value; equivalent to `this.flat_map(flatmap)`.
+///
+/// Use this when the mapping function already returns a `Result`.
 fun Result[T].`|*`(flatmap: T => Result[Y]): Result[Y] = this.flat_map(flatmap)
 
 /// Applies `flatmap` to a successful value, or propagates an Error unchanged.
@@ -26,12 +40,21 @@ fun Result[T].flat_map(flatmap: T => Result[Y]): Result[Y] =
     case Success s -> flatmap(s.value)
 
 /// Returns the successful value, or `v` when this Result is an Error.
+///
+/// Example: `"bad".to_int().or_else(0)` returns `0`.
 fun Result[T].or_else(v: T): T =
     match this with
     case Error _ -> v
     case Success { v } -> v
 
 /// Returns this Result when successful, or `r` when this Result is an Error.
+///
+/// Example:
+/// ```cfun
+/// primary_config().or(default_config())
+/// ```
+/// Uses `default_config()` only as the replacement result when the original is
+/// an error.
 fun Result[T].or(r: Result[T]): Result[T] =
     match this with
     case Error _ -> r
@@ -44,6 +67,16 @@ fun Result[T].`|>`(reduce: Tuple[T => R, String => R]): R =
     case Error { msg } -> reduce[1](msg)
 
 /// Reduces a Result by applying `on_success` to Success or `on_error` to Error.
+///
+/// Example:
+/// ```cfun
+/// "42".to_int().reduce(
+///     value => "parsed " + value,
+///     message => "failed: " + message
+/// )
+/// ```
+/// This is useful at boundaries where a fallible value must become a single
+/// non-Result value.
 fun Result[T].reduce(on_success: T => R, on_error: String => R): R = this |> (on_success, on_error)
 
 /// Reduces a Result by applying `on_success` to Success or `on_error` to Error.

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Annotations.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Annotations.cfun
@@ -1,4 +1,12 @@
 /// Marks a declaration as deprecated while preserving it for compatibility.
+///
+/// Example:
+/// ```cfun
+/// @Deprecated { message: "Use full_name instead", since: "1.4.0" }
+/// fun display_name(user: User): String = user.full_name
+/// ```
+/// The declaration stays available, while tools can show the deprecation
+/// message and version to users.
 annotation Deprecated on fun, method, const, data, union, enum, type, deriver, class, interface, trait, field, init {
     message: String
     since: String = ""

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/NativeProvider.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/NativeProvider.cfun
@@ -1,4 +1,12 @@
-/// Marks a function returning Effect[Interface] as a compile-time native provider.
+/// Marks a function returning `Effect[Interface]` as a compile-time native provider.
+///
+/// Example:
+/// ```cfun
+/// @NativeProvider { qualifier: "systemClock" }
+/// fun clock_provider(): Effect[Clock] = <native>
+/// ```
+/// The compiler can use the annotated provider to wire a host-native
+/// implementation for an interface.
 annotation NativeProvider on fun {
     qualifier: String = ""
 }

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Recursive.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Recursive.cfun
@@ -1,2 +1,13 @@
 /// Marks a function as a compiler-verified direct tail-recursion contract.
+///
+/// Example:
+/// ```cfun
+/// @Recursive
+/// fun sum(values: List[int], acc: int): int =
+///     match values[0] with
+///     case None -> acc
+///     case Some { value } -> sum(values[1:], acc + value)
+/// ```
+/// Use this on helper functions where recursive calls must stay in tail
+/// position.
 annotation Recursive on fun {}

--- a/lib/capybara-lib/src/main/capybara/capy/meta_prog/Reflection.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/meta_prog/Reflection.cfun
@@ -1,10 +1,16 @@
+/// Reflection type metadata for either functional or object-oriented symbols.
+///
+/// `name` is the declaration name and `pkg` describes the package where that
+/// declaration was defined.
 union AnyInfo { name: String, pkg: PackageInfo } = CFunInfo | CooInfo
+/// Functional Capybara type metadata.
 union CFunInfo = DataInfo
     | ListInfo
     | SetInfo
     | DictInfo
     | TupleInfo
     | FunctionTypeInfo
+/// Object-oriented Capybara type metadata.
 union CooInfo =
     InterfaceInfo
     | ObjectInfo
@@ -12,8 +18,10 @@ union CooInfo =
     | MethodInfo
 
 // COMMON
+/// Package metadata for reflected declarations.
 data PackageInfo { name: String, path: String }
 
+/// Annotation argument value captured by reflection.
 union AnnotationValue =
     AnnotationString
     | AnnotationInt
@@ -24,17 +32,27 @@ union AnnotationValue =
     | AnnotationTypeName
     | AnnotationNothing
 
+/// Reflected string annotation argument.
 data AnnotationString { value: String }
+/// Reflected int annotation argument.
 data AnnotationInt { value: int }
+/// Reflected long annotation argument.
 data AnnotationLong { value: long }
+/// Reflected double annotation argument.
 data AnnotationDouble { value: double }
+/// Reflected float annotation argument.
 data AnnotationFloat { value: float }
+/// Reflected bool annotation argument.
 data AnnotationBool { value: bool }
+/// Reflected type-name annotation argument.
 data AnnotationTypeName { value: String }
+/// Reflected annotation argument without a value.
 data AnnotationNothing {}
 
+/// Named annotation argument.
 data AnnotationArgumentInfo { name: String, value: AnnotationValue }
 
+/// Reflected annotation with package metadata and argument values.
 data AnnotationInfo {
     name: String,
     pkg: PackageInfo,
@@ -42,25 +60,49 @@ data AnnotationInfo {
 }
 
 // CFUN
+/// Function type metadata.
 data FunctionTypeInfo { params: List[AnyInfo], return_type: AnyInfo }
 
+/// Data declaration metadata without runtime field values.
 data DataInfo { name: String, pkg: PackageInfo, annotations: List[AnnotationInfo] }
 
+/// Field declaration metadata.
 data FieldInfo { name: String, type: AnyInfo, annotations: List[AnnotationInfo] }
+/// Field metadata plus the runtime value stored in a reflected data instance.
 data FieldValueInfo { name: String, type: AnyInfo, value: any, annotations: List[AnnotationInfo] }
+/// Runtime data value metadata, including constructor name and field values.
 data DataValueInfo { name: String, pkg: PackageInfo, fields: List[FieldValueInfo], annotations: List[AnnotationInfo] }
 
 // CFUN > COLLECTIONS
+/// List type metadata.
 data ListInfo { element_type: AnyInfo }
+/// Set type metadata.
 data SetInfo { element_type: AnyInfo }
+/// Dict type metadata.
 data DictInfo { value_type: AnyInfo }
+/// Tuple type metadata.
 data TupleInfo { elements: List[AnyInfo] }
 
 // COO
+/// Interface metadata.
 data InterfaceInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+/// Object metadata.
 data ObjectInfo { open: bool, fields: List[FieldInfo], methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+/// Trait metadata.
 data TraitInfo { methods: List[MethodInfo], parents: Set[AnyInfo], annotations: List[AnnotationInfo] }
+/// Method metadata.
 data MethodInfo { name: String, pkg: PackageInfo, params: List[FieldInfo], return_type: AnyInfo, annotations: List[AnnotationInfo] }
 
 /// Returns reflection metadata and field values for a concrete data value.
+///
+/// Example:
+/// ```cfun
+/// data User { name: String, age: int }
+///
+/// let info = reflection(User { name: "Ada", age: 36 })
+/// info.fields | field => field.name
+/// ```
+/// `info.name` is `User`, and the reflected fields expose both metadata and
+/// runtime values. This is useful for generic serializers, diagnostics, and
+/// documentation tools.
 fun reflection(obj: data): DataValueInfo = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -12,30 +12,77 @@ from /capy/meta_prog/Recursive import { Recursive }
 
 private const TYPED_JSON_ENVELOPE_FIELD: String = "$capybaraTypedJson"
 
+/// JSON abstract syntax tree used by Capybara's parser and serializer.
+///
+/// Use `JsonObject` and `JsonArray` when you want to build JSON explicitly,
+/// or use `to_json` / `Jsonable` when converting Capy data values by
+/// reflection.
+///
+/// Example:
+/// ```cfun
+/// let user = JsonObject {
+///     value: {
+///         "name": JsonString { value: "Ada" },
+///         "tags": JsonArray { value: [JsonString { value: "admin" }] }
+///     }
+/// }
+///
+/// serialize(user)
+/// ```
+/// Produces an object string with escaped keys and values, such as
+/// `{"name":"Ada","tags":["admin"]}`.
 union Json = JsonObject | JsonArray | JsonValue
+/// JSON object represented as a dictionary of JSON values keyed by strings.
 data JsonObject { value: Dict[Json] }
+/// Returns an object containing entries from both objects.
+///
+/// When both objects contain the same key, the value from `other` replaces the
+/// value from `this`.
 fun JsonObject.`+`(other: JsonObject): JsonObject = JsonObject { value: this.value + other.value }
+/// Returns an object with one entry added or replaced.
+///
+/// Example:
+/// ```cfun
+/// JsonObject { value: { "name": JsonString { value: "Ada" } } }
+///     + ("active", JsonBool { value: true })
+/// ```
+/// The resulting object has both `name` and `active` fields.
 fun JsonObject.`+`(other: Tuple[String, Json]): JsonObject = JsonObject { value: this.value + other }
+/// Returns the JSON value for `key`, or `None` when the field is missing.
 fun JsonObject.get(key: String): Option[Json] =
     let initial: Option[Json] = None {}
     this.value |> initial, (acc, item_key, item_value) =>
         if item_key == key then Some { item_value } else acc
 
+/// JSON array represented as an ordered list of JSON values.
 data JsonArray { value: List[Json] }
+/// Returns an array with values from both arrays.
 fun JsonArray.`+`(other: JsonArray): JsonArray = JsonArray { value: this.value + other.value }
+/// Returns an array with one value appended.
 fun JsonArray.`+`(other: Json): JsonArray = JsonArray { value: this.value + other }
+/// Returns the value at `idx`, or `None` when the index is outside the array.
 fun JsonArray.get(idx: index): Option[Json] = this.value[idx]
 
+/// Scalar JSON values and wrappers for object and array values.
 union JsonValue = JsonString | JsonValueObject | JsonNumber | JsonValueArray | JsonBool | JsonNull
+/// JSON string value.
 data JsonString { value: String }
+/// JSON number value.
+///
+/// Integers and longs use `JsonNumberLong`; fractional values use
+/// `JsonNumberDouble`.
 union JsonNumber = JsonNumberDouble | JsonNumberLong
 data JsonNumberDouble { value: double }
 data JsonNumberLong { value: long }
+/// JSON object value wrapper.
 data JsonValueObject { value: JsonObject }
 fun JsonValueObject.get(key: String): Option[Json] = this.value.get(key)
+/// JSON array value wrapper.
 data JsonValueArray { value: JsonArray }
 fun JsonValueArray.get(idx: index): Option[Json] = this.value.get(idx)
+/// JSON boolean value.
 data JsonBool { value: bool }
+/// JSON null value.
 data JsonNull {}
 
 /// Typed JSON representation that preserves Capy metadata.
@@ -89,10 +136,52 @@ data TypedJsonBool { value: bool }
 /// Typed null value.
 data TypedJsonNull {}
 
+/// Derives a `to_json()` method for data declarations.
+///
+/// Use this when a data type should expose a convenient instance method for
+/// plain JSON conversion.
+///
+/// Example:
+/// ```cfun
+/// data User { name: String, age: int, active: bool } derive Jsonable
+///
+/// let json = User { name: "Ada", age: 36, active: true }.to_json()
+/// ```
+/// `json` is `Success { JsonObject { ... } }` with fields named `name`,
+/// `age`, and `active`.
 deriver Jsonable {
     fun to_json(): Result[JsonObject] = to_json(receiver)
 }
 
+/// Converts a Capy data value into a plain JSON object.
+///
+/// Supported field values include strings, numbers, booleans, lists, sets,
+/// dictionaries, `Option`, `Result`, enums, nested data values, and values that
+/// are already JSON. `None` becomes `JsonNull`; `Some` is encoded as its value;
+/// `Success` is encoded as its value; `Error` is encoded as its message.
+///
+/// Example:
+/// ```cfun
+/// enum Status { ACTIVE, DISABLED }
+/// data Profile {
+///     name: String,
+///     tags: List[String],
+///     status: Status,
+///     nickname: Option[String]
+/// }
+///
+/// to_json(Profile {
+///     name: "Ada",
+///     tags: ["compiler", "math"],
+///     status: Status.ACTIVE,
+///     nickname: None {}
+/// })
+/// ```
+/// The result is a `JsonObject` where `tags` is a JSON array, `status` is the
+/// string `"ACTIVE"`, and `nickname` is `null`.
+///
+/// If any field cannot be represented as JSON, the result is `Error` with the
+/// failing field name in the message.
 fun to_json(obj: data): Result[JsonObject] =
     data JsonEntry { key: String, value: Result[Json] }
     fun merge_json_entry(acc: Result[Dict[Json]], json_entry: JsonEntry): Result[Dict[Json]] =
@@ -160,6 +249,16 @@ fun to_json(obj: data): Result[JsonObject] =
         }
     JsonObject { values }
 
+/// Converts any JSON node to a compact JSON string.
+///
+/// Example:
+/// ```cfun
+/// stringify(JsonArray {
+///     value: [JsonString { value: "Ada" }, JsonNumberLong { value: 42 }]
+/// })
+/// ```
+/// Returns `["Ada",42]`. Strings and object keys are escaped according to JSON
+/// string rules.
 fun stringify(json: Json): String =
     match json with
     case JsonObject { v } ->
@@ -183,6 +282,9 @@ fun stringify(json: Json): String =
     case JsonBool { value } -> value + ""
     case JsonNull -> "null"
 
+/// Converts a JSON object to a compact JSON string.
+///
+/// This is a convenience wrapper around `stringify` for object roots.
 fun serialize(obj: JsonObject): String = stringify(obj)
 
 /// Converts a Capy data value into typed JSON metadata.
@@ -620,6 +722,14 @@ private fun escape_string(value: String): String =
     ---
     value |> '', (acc, char) => acc + escape_char(char)
 
+/// Parses a JSON object string into a `JsonObject`.
+///
+/// Example:
+/// ```cfun
+/// deserialize('{"name":"Ada","active":true}')
+/// ```
+/// Returns `Success` with `JsonString` and `JsonBool` field values. Invalid JSON
+/// returns `Error` with a parser message.
 fun deserialize(json: String): Result[JsonObject] =
     let parse <- deserialize_json_object(json)
     if parse.parsing_string.size() == 0
@@ -864,6 +974,21 @@ private fun is_white_space(s: String): bool =
     ---
     is_white_space(s, white_spaces)
 
+/// Converts a Capy dictionary of supported values into a JSON object.
+///
+/// Example:
+/// ```cfun
+/// deserialize({
+///     "name": "Ada",
+///     "score": 42,
+///     "profile": {
+///         "city": "London"
+///     }
+/// })
+/// ```
+/// This is useful when callers already have dictionary-shaped data and do not
+/// need a custom data declaration. Supported values are strings, numeric
+/// primitives, nested dictionaries, and existing `Json` values.
 fun deserialize(dict: Dict[any]): Result[JsonObject] =
     fun initial_result(): Result[Dict[Json]] = Success { {:} }
     fun to_json_value(value: any): Result[Json] =

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -12,8 +12,23 @@ from /capy/date_time/DateTime import { * }
 from /capy/date_time/Duration import { * }
 from /capy/date_time/Interval import { * }
 
+/// Result of one assertion check.
 data Assertion { result: bool, message: String, type: String }
 
+/// Chainable assertion value produced by `assert_that`.
+///
+/// Assertions are lazy: each assertion stores suppliers that the test runner
+/// evaluates later. Chain methods to describe all expectations for one value,
+/// and use `assert_all` to combine expectations for several values.
+///
+/// Example:
+/// ```cfun
+/// assert_all([
+///     assert_that("capybara").starts_with("capy").contains("bara"),
+///     assert_that([1, 2, 3]).has_size(3).contains(2),
+///     assert_that(Success { value: 42 }).succeeds(42)
+/// ])
+/// ```
 union Assert { assertions: List[() => Assertion] } =
     TechnicalAssert
     | StringAssert | IntAssert | LongAssert | DoubleAssert | FloatAssert | BoolAssert
@@ -21,8 +36,10 @@ union Assert { assertions: List[() => Assertion] } =
     | DateAssert | TimeAssert | DateTimeAssert | DurationAssert | IntervalAssert
     | ListAssert | SetAssert | DictAssert | SeqAssert
 
+/// Returns true when at least one assertion in the chain fails.
 fun Assert.failed(): bool = (this.assertions | supplier => supplier().result).any(r => !r)
 
+/// Returns true when every assertion in the chain succeeds.
 fun Assert.succeeded(): bool = !this.failed()
 
 private data TechnicalAssert { assertions: List[() => Assertion] }
@@ -45,11 +62,23 @@ data SetAssert[T] { value: Set[T] }
 data DictAssert[T] { value: Dict[T] }
 data SeqAssert[T] { value: Seq[T] }
 
+/// Combines several assertion chains into one `Assert`.
+///
+/// Use this when a test case needs to verify multiple independent values.
+///
+/// Example:
+/// ```cfun
+/// test("profile is valid", () => assert_all([
+///     assert_that(profile.name).is_equal_to("Ada"),
+///     assert_that(profile.age).is_between(1, 150)
+/// ]))
+/// ```
 fun assert_all(asserts: List[Assert]): Assert =
     let initial: List[() => Assertion] = []
     let assertions: List[() => Assertion] = asserts |> initial, (acc, assert) => acc + assert.assertions
     TechnicalAssert { assertions: assertions }
 
+/// Adds a string equality assertion to the chain.
 fun StringAssert.is_equal_to(other: String): StringAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -61,6 +90,7 @@ fun StringAssert.is_equal_to(other: String): StringAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the string starts with `other`.
 fun StringAssert.starts_with(other: String): StringAssert =
     let assertion = Assertion {
        result: this.value.starts_with(other),
@@ -83,6 +113,7 @@ fun StringAssert.does_not_start_with(other: String): StringAssert =
        assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the string contains `other`.
 fun StringAssert.contains(other: String): StringAssert =
     let assertion = Assertion {
        result: this.value ? other,
@@ -94,6 +125,7 @@ fun StringAssert.contains(other: String): StringAssert =
        assertions: this.assertions + () => assertion
     }
 
+/// Adds an int equality assertion to the chain.
 fun IntAssert.is_equal_to(other: int): IntAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -139,6 +171,7 @@ fun IntAssert.is_less_or_equals_than(other: int): IntAssert =
 
 fun IntAssert.is_zero(): IntAssert = this.is_equal_to(0)
 fun IntAssert.is_one(): IntAssert = this.is_equal_to(1)
+/// Adds assertions that the int is between `start` and `end`, inclusive.
 fun IntAssert.is_between(start: int, end: int): IntAssert =
     this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
@@ -332,6 +365,7 @@ fun BoolAssert.is_equal_to(other: bool): BoolAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the bool is true.
 fun BoolAssert.is_true(): BoolAssert =
     let assertion = Assertion {
         result: this.value,
@@ -343,6 +377,7 @@ fun BoolAssert.is_true(): BoolAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the bool is false.
 fun BoolAssert.is_false(): BoolAssert =
     let assertion = Assertion {
         result: !this.value,
@@ -387,6 +422,7 @@ fun OptionAssert[T].is_equal_to(other: /capy/lang/Option[T]): OptionAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the option is `Some` with `other`.
 fun OptionAssert[T].contains(other: T): OptionAssert[T] =
     let assertion = Assertion {
         result: match this.value with
@@ -400,6 +436,7 @@ fun OptionAssert[T].contains(other: T): OptionAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the option is `None`.
 fun OptionAssert[T].is_empty(): OptionAssert[T] =
     let assertion = Assertion {
         result: match this.value with
@@ -424,6 +461,7 @@ fun ResultAssert[T].is_equal_to(other: /capy/lang/Result[T]): ResultAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the result is `Success`.
 fun ResultAssert[T].succeeds(): ResultAssert[T] =
     let assertion = Assertion {
         result:
@@ -438,6 +476,9 @@ fun ResultAssert[T].succeeds(): ResultAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the result is `Success` containing `other`.
+///
+/// Example: `assert_that("42".to_int()).succeeds(42)`.
 fun ResultAssert[T].succeeds(other: T): ResultAssert[T] =
     let assertion = Assertion {
         result:
@@ -452,6 +493,15 @@ fun ResultAssert[T].succeeds(other: T): ResultAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the result is `Success`, then runs nested assertions
+/// against the success value.
+///
+/// Example:
+/// ```cfun
+/// assert_that(load_user()).succeeds(user =>
+///     assert_that(user.name).is_equal_to("Ada")
+/// )
+/// ```
 fun ResultAssert[T].succeeds(assert: T => Assert): ResultAssert[T] =
     let assertions: List[() => Assertion] =
         match this.value with
@@ -468,6 +518,7 @@ fun ResultAssert[T].succeeds(assert: T => Assert): ResultAssert[T] =
         assertions: this.assertions + assertions
     }
 
+/// Adds an assertion that the result is `Error`.
 fun ResultAssert[T].fails(): ResultAssert[T] =
     let assertion = Assertion {
         result: {
@@ -483,6 +534,7 @@ fun ResultAssert[T].fails(): ResultAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the result is `Error` with the expected message.
 fun ResultAssert[T].fails(message: String): ResultAssert[T] =
     let assertion = Assertion {
         result: {
@@ -889,6 +941,7 @@ fun ListAssert[T].is_equal_to(other: List[T]): ListAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the list size equals `other`.
 fun ListAssert[T].has_size(other: int): ListAssert[T] =
     let assertion = Assertion {
         result: this.value.size() == other,
@@ -911,6 +964,7 @@ fun ListAssert[T].is_empty(): ListAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the list contains `other`.
 fun ListAssert[T].contains(other: T): ListAssert[T] =
     let assertion = Assertion {
         result: this.value.any(v => v == other),
@@ -1021,6 +1075,7 @@ fun DictAssert[T].is_empty(): DictAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the dict contains `other` as a key.
 fun DictAssert[T].contains_key(other: String): DictAssert[T] =
     let assertion = Assertion {
         result: this.value.any((k, v) => k == other),
@@ -1109,22 +1164,41 @@ fun SeqAssert[T].does_not_contain(other: T): SeqAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Starts a string assertion chain.
+///
+/// Example:
+/// ```cfun
+/// assert_that("capybara").starts_with("capy").contains("bara")
+/// ```
 fun assert_that(value: String) = StringAssert { value: value, assertions: [] }
 fun assert_that(value: size) = IntAssert { value: value.value, assertions: [] }
+/// Starts an int assertion chain.
 fun assert_that(value: int) = IntAssert { value: value, assertions: [] }
 fun assert_that(value: long) = LongAssert { value: value, assertions: [] }
 fun assert_that(value: double) = DoubleAssert { value: value, assertions: [] }
 fun assert_that(value: float) = FloatAssert { value: value, assertions: [] }
+/// Starts a bool assertion chain.
 fun assert_that(value: bool) = BoolAssert { value: value, assertions: [] }
 fun assert_that(value: Date) = DateAssert { value: value, assertions: [] }
 fun assert_that(value: Time) = TimeAssert { value: value, assertions: [] }
 fun assert_that(value: DateTime) = DateTimeAssert { value: value, assertions: [] }
 fun assert_that(value: Duration) = DurationAssert { value: value, assertions: [] }
 fun assert_that(value: Interval) = IntervalAssert { value: value, assertions: [] }
+/// Starts a list assertion chain.
 fun assert_that(value: List[T]): ListAssert[T] = ListAssert { value: value, assertions: [] }
 fun assert_that(value: Set[T]): SetAssert[T] = SetAssert { value: value, assertions: [] }
 fun assert_that(value: Dict[T]): DictAssert[T] = DictAssert { value: value, assertions: [] }
 fun assert_that(value: Seq[T]): SeqAssert[T] = SeqAssert { value: value, assertions: [] }
+/// Starts an option assertion chain.
 fun assert_that(value: Option[T]) = OptionAssert { value: value, assertions: [] }
+/// Starts a result assertion chain.
+///
+/// Example:
+/// ```cfun
+/// assert_that(parse_user(raw)).succeeds(user =>
+///     assert_that(user.name).is_equal_to("Ada")
+/// )
+/// ```
 fun assert_that(value: Result[T]) = ResultAssert { value: value, assertions: [] }
+/// Starts a data assertion chain using data equality or containment checks.
 fun assert_that(value: data) = DataAssert { value: value, assertions: [] }

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -18,13 +18,30 @@ from /capy/lang/TimeUnit import { * }
 from /capy/serialization/Json import { JsonString, stringify }
 from /capy/meta_prog/Recursive import { Recursive }
 
+/// Test suite source file with test cases and a run timestamp.
 data TestFile { file_name: String, test_cases: List[TestCase], timestamp_millis: long }
+/// Single test case and its executable assertion supplier.
 data TestCase { name: String, result: TestResult, assertions_count: int, execution_time: double, assert_supplier: () => Assert }
+/// Test execution result.
 union TestResult = Passed | Failed
+/// Successful test execution.
 data Passed {}
+/// Failed test execution with assertion message and assertion type.
 data Failed { message: String, type: String }
+/// Test runner logging mode.
 enum LogType { NONE, LOG, TEAM_CITY }
 
+/// Builds a test file from already constructed test cases.
+///
+/// Example:
+/// ```cfun
+/// test_file("/capy/lang/StringTest.cfun", [
+///     test("starts_with", () =>
+///         assert_that("capybara").starts_with("capy")
+///     )
+/// ])
+/// ```
+/// The timestamp is captured from `now()` when the effect runs.
 fun test_file(file_name: String, test_cases: List[TestCase]): Effect[TestFile] =
     let current <- now()
     TestFile {
@@ -33,6 +50,10 @@ fun test_file(file_name: String, test_cases: List[TestCase]): Effect[TestFile] =
         timestamp_millis: current.timestamp() * 1000L
     }
 
+/// Builds a test file from effectful test cases.
+///
+/// Use this overload when test cases need setup effects before they can be
+/// added to the suite.
 fun test_file(file_name: String, test_cases: List[Effect[TestCase]]): Effect[TestFile] =
     let current <- now()
     let unwrapped_test_cases <- unwrap_test_cases(test_cases)
@@ -50,6 +71,10 @@ private fun unwrap_test_cases(test_cases: List[Effect[TestCase]]): Effect[List[T
         let unwrapped_test_cases <- unwrap_test_cases(test_cases[1:])
         [test_case] + unwrapped_test_cases
 
+/// Creates a test case from a name and lazy assertion supplier.
+///
+/// The supplier is evaluated by the runner, so expensive or failing assertions
+/// should stay inside the lambda.
 fun test(name: String, assert_supplier: () => Assert): TestCase =
     TestCase {
         name: name,
@@ -115,14 +140,18 @@ private fun execute(assertions: List[() => Assertion]): TestResult =
     }
     case None -> Passed {}
 
+/// Returns true when this executed test case passed.
 fun TestCase.succeeded(): bool = !this.failed()
 
+/// Returns true when this executed test case failed.
 fun TestCase.failed(): bool =
     match this.result with
     case Passed -> false
     case Failed -> true
 
+/// Report format emitted by the test runner.
 enum ReportType { JUNIT, CTRF, JEST }
+/// Generated test report value.
 union Report = JUnitReport | CtrfReport | JestReport
 
 /// See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml)
@@ -161,21 +190,63 @@ fun JUnitFailure.`+`(other_message: String): JUnitFailure =
         call_stack: this.call_stack
     }
 
+/// CTRF JSON report payload.
 data CtrfReport { report: String }
+/// Jest JSON report payload.
 data JestReport { report: String }
 
+/// One generated test report output.
 data TestOutput { path: Path, content: String, failed: bool }
+/// Result of writing a test run to disk.
 data TestRun { outputs: List[TestOutput], written_files: List[Path], failure_summary: String, failed: bool }
 
+/// Generates report outputs in memory from already executed test files.
+///
+/// This overload does not evaluate test bodies or call `execute_test_files`.
+/// Freshly built `test(...)` values keep their initial result state, so use the
+/// overload with `output_dir` when the test assertions should run as part of
+/// report generation.
+///
+/// Example:
+/// ```cfun
+/// let reported_case = TestCase {
+///     name: "starts_with",
+///     result: Passed {},
+///     assertions_count: 1,
+///     execution_time: 0.001,
+///     assert_supplier: () => assert_that(true).is_true()
+/// }
+/// let reported_suite = TestFile {
+///     file_name: "/capy/lang/StringTest.cfun",
+///     test_cases: [reported_case],
+///     timestamp_millis: 0L
+/// }
+/// let outputs = run_tests(JUNIT, [reported_suite])
+/// ```
+/// Use the overload with `output_dir` to write report files.
 fun run_tests(rtype: ReportType, test_files: List[TestFile]): List[TestOutput] =
     match rtype with
     case JUNIT -> junit_run_tests(test_files)
     case CTRF -> ctrf_run_tests(test_files)
     case JEST -> jest_run_tests(test_files)
 
+/// Runs test files, writes reports under `output_dir`, and returns the written
+/// output summary.
 fun run_tests(rtype: ReportType, output_dir: Path, test_files: List[TestFile]): Effect[Result[TestRun]] =
     run_tests(rtype, output_dir, NONE, test_files)
 
+/// Runs test files with the requested report type and logging mode.
+///
+/// Example:
+/// ```cfun
+/// let suite <- test_file("/capy/lang/StringTest.cfun", [
+///     test("starts_with", () =>
+///         assert_that("capybara").starts_with("capy")
+///     )
+/// ])
+/// run_tests(JUNIT, from_string("build/test-results"), LOG, [suite])
+/// ```
+/// `TEAM_CITY` emits service messages while tests execute.
 fun run_tests(rtype: ReportType, output_dir: Path, log_type: LogType, test_files: List[TestFile]): Effect[Result[TestRun]] =
     execute_test_files(log_type, test_files).flat_map(executed_test_files =>
         write_test_run(rtype, output_dir, executed_test_files)
@@ -201,9 +272,11 @@ private fun write_test_run(rtype: ReportType, output_dir: Path, executed_test_fi
             )
     )
 
+/// Runs tests, writes reports, and prints a failure summary.
 fun run_tests_and_print_summary(rtype: ReportType, output_dir: Path, test_files: List[TestFile]): Effect[Result[TestRun]] =
     run_tests_and_print_summary(rtype, output_dir, NONE, test_files)
 
+/// Runs tests with logging, writes reports, and prints a failure summary.
 fun run_tests_and_print_summary(rtype: ReportType, output_dir: Path, log_type: LogType, test_files: List[TestFile]): Effect[Result[TestRun]] =
     run_tests(rtype, output_dir, log_type, test_files).flat_map(run_result =>
         match run_result with
@@ -213,6 +286,8 @@ fun run_tests_and_print_summary(rtype: ReportType, output_dir: Path, log_type: L
     )
 
 /// Writes every test output under the given output directory and returns normalized relative paths.
+///
+/// Existing files that already have the same content are left untouched.
 fun write_test_outputs(output_dir: Path, test_outputs: List[TestOutput]): Effect[Result[List[Path]]] =
     match test_outputs[0] with
     case None -> pure(Success { [] })


### PR DESCRIPTION
## What changed
- Added Markdown doc comments with `cfun` examples across `lib/capybara-lib` collection, date/time, IO, lang, meta_prog, serialization, and test APIs.
- Expanded JSON docs around `Json`, `JsonObject`, `JsonArray`, typed JSON metadata, `Jsonable`, `to_json`, `stringify`, `serialize`, and `deserialize`.
- Added docs for IO, meta_prog, `CapyTest`, and `Assert` APIs as requested.

## Impacted modules
- `lib/capybara-lib`

## Verification
- `git diff --check origin/feature/#184-rewrite-capy-to-Capybara...HEAD`
- `rg -n '```capybara|<<<<<<<|=======|>>>>>>>' lib/capybara-lib/src/main/capybara` returned no matches
- `./gradlew clean :lib:capybara-lib:compileCapybara :lib:capybara-lib:testCapybara`
