### PR TITLE
chore(#243): clarify performance diff links

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -6,7 +6,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 ## 2026-06-19 [f46942a](https://github.com/magx2/Capybara/commit/f46942aa64ec07cf07baefcc59bb83d06d70421e)
 
-[Changes since previous run](https://github.com/magx2/Capybara/compare/176dd6b54b5660641e58da2187cc6ef623bf4d72...f46942aa64ec07cf07baefcc59bb83d06d70421e)
+[Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/176dd6b54b5660641e58da2187cc6ef623bf4d72...f46942aa64ec07cf07baefcc59bb83d06d70421e)
 
 ### Java
 

--- a/performance/scripts/render-readme
+++ b/performance/scripts/render-readme
@@ -96,8 +96,11 @@ if csv_path.exists():
 
 previous_by_metric = {}
 delta_by_index = {}
+previous_run_by_index = {}
 for index, row in enumerate(rows):
     delta_by_index[index] = {}
+    if index > 0:
+        previous_run_by_index[index] = rows[index - 1]
     for backend, _ in backends:
         for step, _ in steps:
             metric = f"{backend}-{step}"
@@ -123,10 +126,11 @@ else:
     for index, row in reversed(list(enumerate(rows))):
         short_sha = row["commit_sha"]
         lines.append(f"## {row['date']} [{short_sha}]({commit_url(short_sha)})")
-        if index > 0:
-            previous_sha = rows[index - 1]["commit_sha"]
+        previous_run = previous_run_by_index.get(index)
+        if previous_run:
+            previous_sha = previous_run["commit_sha"]
             lines.append("")
-            lines.append(f"[Changes since previous run]({compare_url(previous_sha, short_sha)})")
+            lines.append(f"[Changes since previous benchmark check]({compare_url(previous_sha, short_sha)})")
         lines.append("")
         for backend, backend_title in backends:
             lines.append(f"### {backend_title}")


### PR DESCRIPTION
## Summary

- make the README compare-link source explicit by storing the previous benchmark result row
- relabel generated compare links as `Changes since previous benchmark check`
- regenerate `performance/README.md` with the clarified label

## Impacted Modules

- `performance/scripts/render-readme`
- `performance/README.md`

## Validation

- `performance/scripts/render-readme`
- `bash -n performance/scripts/render-readme`
- `git diff --check`

Refs #243
