### PR TITLE
feat(#183): split constants in docs

### DIFF
--- a/.github/workflows/generate_capy_docs.yml
+++ b/.github/workflows/generate_capy_docs.yml
@@ -69,27 +69,76 @@ jobs:
 
           DOC_BRANCH="automation/capy-docs-${DOC_VERSION}"
           DOC_DIR="docs/capy-docs/${DOC_VERSION}"
+          GENERATED_DOC_DIR="build/capy-docs/${DOC_VERSION}"
 
           {
             echo "source_branch=${SOURCE_BRANCH}"
             echo "doc_version=${DOC_VERSION}"
             echo "doc_branch=${DOC_BRANCH}"
             echo "doc_dir=${DOC_DIR}"
+            echo "generated_doc_dir=${GENERATED_DOC_DIR}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Assemble Capy project
         run: ./gradlew :capy:assemble --no-daemon
 
       - name: Generate Capybara library docs
+        shell: bash
         run: |
-          ./gradlew :capy:run --no-daemon --args="docs -i ../lib/capybara-lib/src/main/capybara -o ../${{ steps.docs.outputs.doc_dir }}"
+          set -euo pipefail
+          GENERATED_DOC_DIR="${{ steps.docs.outputs.generated_doc_dir }}"
+          rm -rf "${GENERATED_DOC_DIR}"
+          CAPY_JAR="$(find capy/build/libs -maxdepth 1 -name 'capy-*.jar' ! -name '*-plain.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar' | sort | head -n 1)"
+          if [[ -z "${CAPY_JAR}" ]]; then
+            echo "::error::Capy jar was not assembled."
+            exit 1
+          fi
+          java -jar "${CAPY_JAR}" docs -i lib/capybara-lib/src/main/capybara -o "${GENERATED_DOC_DIR}"
+          if [[ ! -d "${GENERATED_DOC_DIR}" ]]; then
+            echo "::error::Capy docs were not generated into ${GENERATED_DOC_DIR}."
+            exit 1
+          fi
+
+      - name: Check generated docs changes
+        id: docs_diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          DOC_VERSION="${{ steps.docs.outputs.doc_version }}"
+          DOC_DIR="${{ steps.docs.outputs.doc_dir }}"
+          GENERATED_DOC_DIR="${{ steps.docs.outputs.generated_doc_dir }}"
+
+          if [[ -d "${DOC_DIR}" ]] && diff -qr -- "${DOC_DIR}" "${GENERATED_DOC_DIR}" >/tmp/capy-docs.diff; then
+            echo "Capy docs are already up to date for ${DOC_VERSION}."
+            echo "has_changes=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "Generated Capy docs differ for ${DOC_VERSION}."
+          if [[ -s /tmp/capy-docs.diff ]]; then
+            cat /tmp/capy-docs.diff
+          fi
+          echo "has_changes=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Apply generated docs
+        if: steps.docs_diff.outputs.has_changes == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          DOC_DIR="${{ steps.docs.outputs.doc_dir }}"
+          GENERATED_DOC_DIR="${{ steps.docs.outputs.generated_doc_dir }}"
+          rm -rf "${DOC_DIR}"
+          mkdir -p "$(dirname "${DOC_DIR}")"
+          cp -a "${GENERATED_DOC_DIR}" "${DOC_DIR}"
 
       - name: Configure git user
+        if: steps.docs_diff.outputs.has_changes == 'true'
         run: |
           git config user.name "CapyAutomata"
           git config user.email "CapyAutomata@capylang.dev"
 
       - name: Create docs pull request
+        if: steps.docs_diff.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -100,13 +149,12 @@ jobs:
           DOC_BRANCH="${{ steps.docs.outputs.doc_branch }}"
           DOC_DIR="${{ steps.docs.outputs.doc_dir }}"
 
-          if [[ -z "$(git status --short -- "${DOC_DIR}")" ]]; then
-            echo "Capy docs are already up to date for ${DOC_VERSION}."
-            exit 0
-          fi
-
           git switch -C "${DOC_BRANCH}"
           git add -A "${DOC_DIR}"
+          if git diff --cached --quiet; then
+            echo "No tracked Capy docs changes after applying generated docs for ${DOC_VERSION}."
+            exit 0
+          fi
           git commit -m "docs: update Capy docs ${DOC_VERSION}"
 
           REMOTE_DOC_SHA="$(git ls-remote --heads origin "${DOC_BRANCH}" | awk '{ print $1 }')"

--- a/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
@@ -41,6 +41,9 @@ class CapyDocsCommandIntegrationTest {
                 /// Tone docs
                 enum Tone { LOW, HIGH }
 
+                /// Answer docs
+                const ANSWER: int = 42
+
                 /// Describes a tone
                 fun Tone.describe(): String = "tone"
 
@@ -121,13 +124,18 @@ class CapyDocsCommandIntegrationTest {
                 .contains("Tone docs")
                 .contains("* `LOW`")
                 .contains("* `HIGH`")
+                .contains("== Constants")
+                .contains("=== const:public ANSWER: int")
+                .contains("Answer docs")
                 .contains("===== public Tone.describe(): String")
+                .doesNotContain("=== const:public ANSWER(): int")
                 .doesNotContain("\n=== public Box.describe")
                 .doesNotContain("\n=== public GenericBox[T].describe")
                 .doesNotContain("* `name`: `String`")
                 .doesNotContain("__capy_schema_type|Box")
                 .doesNotContain("ExampleDocs");
         assertThat(docsContent).containsSubsequence("* `HIGH`", "* `LOW`");
+        assertThat(docsContent).containsSubsequence("== Functions", "=== public documented_function", "== Constants", "=== const:public ANSWER: int", "== Annotations");
 
         var objectsFile = output.resolve("sample/Objects.adoc");
         assertThat(objectsFile).isRegularFile();

--- a/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
@@ -26,6 +26,9 @@ class CapyDocsCommandIntegrationTest {
                 /// Describes a box
                 fun Box.describe(): String = "box"
 
+                /// Hides a box
+                private fun Box.hidden(): String = "hidden"
+
                 /// Generic box docs
                 data GenericBox[T] { value: T }
 
@@ -44,11 +47,41 @@ class CapyDocsCommandIntegrationTest {
                 /// Answer docs
                 const ANSWER: int = 42
 
+                /// Hidden answer docs
+                private const HIDDEN_ANSWER: int = 7
+
                 /// Describes a tone
                 fun Tone.describe(): String = "tone"
 
                 /// Function docs
                 fun documented_function(box: Box, wrapped: GenericBox[Box]): GenericBox[Box] = wrapped
+
+                /// Hidden function docs
+                private fun hidden_function(): String = "hidden"
+
+                /// Hidden box docs
+                private data HiddenBox { value: String }
+
+                /// Hidden circle docs
+                private data HiddenCircle { radius: int }
+
+                /// Hidden visible circle docs
+                private data HiddenVisibleCircle { radius: int }
+
+                /// Visible shape docs
+                union VisibleShape = HiddenVisibleCircle | Box
+
+                /// Hidden square docs
+                private data HiddenSquare { size: int }
+
+                /// Hidden shape docs
+                private union HiddenShape = HiddenCircle | HiddenSquare
+
+                /// Hidden id docs
+                private type hidden_id -> String
+
+                /// Hidden marker docs
+                private annotation HiddenMarker on fun {}
                 """);
         writeSource(input.resolve("sample/Objects.coo"), """
                 /// Named docs
@@ -68,6 +101,9 @@ class CapyDocsCommandIntegrationTest {
                     /// Label field docs
                     field label: String = label
 
+                    /// Internal field docs
+                    private field internal: String = "secret"
+
                     /// Init docs
                     init {
                         return "ready"
@@ -78,6 +114,9 @@ class CapyDocsCommandIntegrationTest {
 
                     /// Render docs
                     def render(prefix: String): String = prefix + this.name()
+
+                    /// Internal render docs
+                    private def internal_render(): String = this.internal
                 }
                 """);
         writeSource(input.resolve("sample/Markers.cfun"), """
@@ -125,6 +164,8 @@ class CapyDocsCommandIntegrationTest {
                 .contains("Shape docs")
                 .contains("* xref:#type-Circle[Circle]")
                 .contains("* xref:#type-Square[Square]")
+                .contains("[[type-VisibleShape]]\n=== union VisibleShape")
+                .contains("Visible shape docs")
                 .contains("=== enum Tone")
                 .contains("Tone docs")
                 .contains("* `LOW`")
@@ -135,6 +176,19 @@ class CapyDocsCommandIntegrationTest {
                 .contains("===== public Tone.describe(): String")
                 .doesNotContain("=== const:public ANSWER(): int")
                 .doesNotContain("== Annotations")
+                .doesNotContain("HiddenBox")
+                .doesNotContain("HiddenCircle")
+                .doesNotContain("HiddenVisibleCircle")
+                .doesNotContain("HiddenSquare")
+                .doesNotContain("HiddenShape")
+                .doesNotContain("hidden_id")
+                .doesNotContain("hidden_function")
+                .doesNotContain("HIDDEN_ANSWER")
+                .doesNotContain("HiddenMarker")
+                .doesNotContain("Hidden box docs")
+                .doesNotContain("Hidden answer docs")
+                .doesNotContain("Hidden marker docs")
+                .doesNotContain("Hides a box")
                 .doesNotContain("\n=== public Box.describe")
                 .doesNotContain("\n=== public GenericBox[T].describe")
                 .doesNotContain("* `name`: `String`")
@@ -169,6 +223,9 @@ class CapyDocsCommandIntegrationTest {
                 .contains("Init docs")
                 .contains("===== public render(prefix: String): String")
                 .contains("Render docs")
+                .doesNotContain("internal")
+                .doesNotContain("Internal field docs")
+                .doesNotContain("Internal render docs")
                 .doesNotContain("== Functions")
                 .doesNotContain("== Constants")
                 .doesNotContain("== Annotations")

--- a/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
@@ -80,6 +80,10 @@ class CapyDocsCommandIntegrationTest {
                     def render(prefix: String): String = prefix + this.name()
                 }
                 """);
+        writeSource(input.resolve("sample/Markers.cfun"), """
+                /// Marker docs
+                annotation DocMarker on fun {}
+                """);
         writeSource(input.resolve("sample/nested/More.cfun"), """
                 /// More docs
                 data More { value: String }
@@ -94,6 +98,7 @@ class CapyDocsCommandIntegrationTest {
                 .contains("= Capybara Documentation")
                 .contains("=== sample")
                 .contains("* xref:sample/Docs.adoc[Docs]")
+                .contains("* xref:sample/Markers.adoc[Markers]")
                 .contains("* xref:sample/Objects.adoc[Objects]")
                 .contains("==== nested")
                 .contains("* xref:sample/nested/More.adoc[More]")
@@ -129,13 +134,14 @@ class CapyDocsCommandIntegrationTest {
                 .contains("Answer docs")
                 .contains("===== public Tone.describe(): String")
                 .doesNotContain("=== const:public ANSWER(): int")
+                .doesNotContain("== Annotations")
                 .doesNotContain("\n=== public Box.describe")
                 .doesNotContain("\n=== public GenericBox[T].describe")
                 .doesNotContain("* `name`: `String`")
                 .doesNotContain("__capy_schema_type|Box")
                 .doesNotContain("ExampleDocs");
         assertThat(docsContent).containsSubsequence("* `HIGH`", "* `LOW`");
-        assertThat(docsContent).containsSubsequence("== Functions", "=== public documented_function", "== Constants", "=== const:public ANSWER: int", "== Annotations");
+        assertThat(docsContent).containsSubsequence("== Functions", "=== public documented_function", "== Constants", "=== const:public ANSWER: int", "== Types");
 
         var objectsFile = output.resolve("sample/Objects.adoc");
         assertThat(objectsFile).isRegularFile();
@@ -163,9 +169,36 @@ class CapyDocsCommandIntegrationTest {
                 .contains("Init docs")
                 .contains("===== public render(prefix: String): String")
                 .contains("Render docs")
+                .doesNotContain("== Functions")
+                .doesNotContain("== Constants")
+                .doesNotContain("== Annotations")
+                .doesNotContain("== Types")
                 .doesNotContain("__capy_oo_method|Widget|render")
                 .doesNotContain("\n=== oo:");
         assertThat(objectsContent).containsSubsequence("* xref:#type-oo-sample-Greeting[Greeting]", "* xref:#type-oo-sample-Named[Named]");
+
+        var markersFile = output.resolve("sample/Markers.adoc");
+        assertThat(markersFile).isRegularFile();
+        assertThat(Files.readString(markersFile))
+                .contains("= Module Markers")
+                .contains("== Annotations")
+                .contains("=== public @DocMarker")
+                .contains("Marker docs")
+                .contains("* Repeatable: no")
+                .contains("* Targets: fun")
+                .doesNotContain("== Functions")
+                .doesNotContain("== Constants")
+                .doesNotContain("== Types");
+
+        var moreFile = output.resolve("sample/nested/More.adoc");
+        assertThat(moreFile).isRegularFile();
+        assertThat(Files.readString(moreFile))
+                .contains("= Module More")
+                .contains("== Types")
+                .contains("=== data More")
+                .doesNotContain("== Functions")
+                .doesNotContain("== Constants")
+                .doesNotContain("== Annotations");
     }
 
     private static void writeSource(Path file, String source) throws IOException {

--- a/capy/src/main/capybara/dev/capylang/compiler/CapybaraCompiler.cfun
+++ b/capy/src/main/capybara/dev/capylang/compiler/CapybaraCompiler.cfun
@@ -971,6 +971,7 @@ private fun compile_functions(definitions: List[Definition], allDefinitions: Lis
 /// Converts parsed data declaration into compiled metadata.
 private fun compile_data_declaration(declaration: DataDeclaration): List[CompiledFunction] =
     [compile_documented_schema_constant("__capy_schema_type|" + declaration.name, declaration.name, declaration.documentation, declaration.location)]
+        + [compile_schema_constant("__capy_schema_visibility|" + declaration.name, declaration.visibility, declaration.location)]
         + compile_data_schema_parameters(declaration.name, declaration.parameters, 0, declaration.location)
         + compile_data_schema_fields(declaration.name, declaration.fields, 0)
         + compile_data_schema_parents(declaration.name, declaration.parents, 0)
@@ -981,6 +982,7 @@ private fun compile_data_declaration(declaration: DataDeclaration): List[Compile
 private fun compile_enum_declaration(declaration: EnumDeclaration): List[CompiledFunction] =
     [
         compile_documented_schema_constant("__capy_schema_type|" + declaration.name, declaration.name, declaration.documentation, declaration.location),
+        compile_schema_constant("__capy_schema_visibility|" + declaration.name, "public", declaration.location),
         compile_schema_constant("__capy_schema_field|" + declaration.name + "|0", "name|String", declaration.location),
         compile_schema_constant("__capy_schema_field|" + declaration.name + "|1", "order|int", declaration.location),
     ] + compile_annotation_application_schema("__capy_schema_annotation|enum|" + declaration.name + "|", declaration.annotations, 0)

--- a/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
@@ -135,7 +135,7 @@ private fun asciidoc_type_targets(program: CompiledProgram): List[AsciiDocTypeTa
 
 private fun asciidoc_schema_type_targets(module: CompiledModule): List[AsciiDocTypeTarget] =
     asciidoc_schema_type_names(module.functions).reduce([], (targets, typeName) =>
-        if asciidoc_primitive_schema_type(typeName, module.functions)
+        if asciidoc_primitive_schema_type(typeName, module.functions) | !asciidoc_public_schema_type(typeName, module.functions)
         then targets
         else targets + asciidoc_type_target(typeName, typeName, module_doc_path(module))
     )
@@ -145,7 +145,9 @@ private fun asciidoc_backend_type_targets(module: CompiledModule): List[AsciiDoc
         .entries()
         .reduce([], (targets, entry) =>
             let type = entry[1]
-            targets + asciidoc_type_target(type.name, type.name, module_doc_path(module))
+            if asciidoc_private_visibility(type.visibility)
+            then targets
+            else targets + asciidoc_type_target(type.name, type.name, module_doc_path(module))
         )
 
 private fun asciidoc_object_type_targets(module: CompiledModule, units: List[CompiledObjectOrientedUnit]): List[AsciiDocTypeTarget] =
@@ -158,12 +160,16 @@ private fun asciidoc_object_type_targets(module: CompiledModule, units: List[Com
 
 private fun asciidoc_object_interface_type_targets(unit: CompiledObjectOrientedUnit, module: CompiledModule): List[AsciiDocTypeTarget] =
     unit.interfaces.reduce([], (targets, interface) =>
-        targets + asciidoc_type_target(asciidoc_object_interface_type_name(unit, interface.name), interface.name, module_doc_path(module))
+        if asciidoc_private_visibility(interface.visibility)
+        then targets
+        else targets + asciidoc_type_target(asciidoc_object_interface_type_name(unit, interface.name), interface.name, module_doc_path(module))
     )
 
 private fun asciidoc_object_class_type_targets(unit: CompiledObjectOrientedUnit, module: CompiledModule): List[AsciiDocTypeTarget] =
     unit.classes.reduce([], (targets, class) =>
-        targets + asciidoc_type_target(asciidoc_object_class_type_name(unit, class.name), class.name, module_doc_path(module))
+        if asciidoc_private_visibility(class.visibility)
+        then targets
+        else targets + asciidoc_type_target(asciidoc_object_class_type_name(unit, class.name), class.name, module_doc_path(module))
     )
 
 private fun asciidoc_type_target(name: String, displayName: String, path: String): AsciiDocTypeTarget =
@@ -218,7 +224,8 @@ private fun asciidoc_top_level_functions(functions: List[CompiledFunction], type
     )
 
 private fun asciidoc_top_level_function(function: CompiledFunction, functions: List[CompiledFunction], typeNames: List[String]): bool =
-    !asciidoc_schema_function(function)
+    !asciidoc_private_visibility(function.visibility)
+    & !asciidoc_schema_function(function)
     & !asciidoc_constant_function(function)
     & !asciidoc_object_helper_function(function)
     & !asciidoc_generated_local_function(function)
@@ -235,6 +242,7 @@ private fun asciidoc_top_level_constants(functions: List[CompiledFunction], type
 
 private fun asciidoc_top_level_constant(function: CompiledFunction, functions: List[CompiledFunction], typeNames: List[String]): bool =
     asciidoc_constant_function(function)
+    & !asciidoc_private_visibility(function.visibility)
     & !asciidoc_schema_function(function)
     & !asciidoc_object_helper_function(function)
     & !asciidoc_generated_local_function(function)
@@ -263,6 +271,16 @@ private fun asciidoc_constant_function(function: CompiledFunction): bool =
 
 private fun asciidoc_object_helper_function(function: CompiledFunction): bool =
     function.visibility.starts_with("oo")
+
+private fun asciidoc_private_visibility(visibility: String): bool =
+    visibility == "private"
+    | visibility == "local"
+    | visibility == "const:private"
+    | visibility == "const:local"
+    | visibility == "oo:private"
+    | visibility == "oo:local"
+    | visibility == "oo_interface_method:private"
+    | visibility == "oo_interface_method:local"
 
 private fun generate_parameters(parameters: List[CompiledFunctionParameter], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     parameters
@@ -551,7 +569,7 @@ private fun generate_schema_type_docs(functions: List[CompiledFunction], module:
     asciidoc_schema_type_names(functions)
         .sort((a,b) => a.compare(b))
         .reduce("", (content, typeName) =>
-            if asciidoc_primitive_schema_type(typeName, functions)
+            if asciidoc_primitive_schema_type(typeName, functions) | !asciidoc_public_schema_type(typeName, functions)
             then content
             else content + generate_schema_type_doc(typeName, functions, module, typeTargets)
         )
@@ -610,7 +628,7 @@ private fun generate_type_field_documentation(function: CompiledFunction): Strin
     else "+\n" + generate_documentation(function) + "\n"
 
 private fun generate_union_variant_docs(typeName: String, functions: List[CompiledFunction], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
-    let variants = asciidoc_union_variant_names(typeName, functions)
+    let variants = asciidoc_public_union_variant_names(typeName, functions)
     if variants.is_empty()
     then ""
     else "==== Variants\n\n"
@@ -618,6 +636,13 @@ private fun generate_union_variant_docs(typeName: String, functions: List[Compil
             .sort((a,b) => asciidoc_type_display_name(a, functions).compare(asciidoc_type_display_name(b, functions)))
             .reduce("", (content, variant) => content + "* {asciidoc_type_text(asciidoc_type_display_name(variant, functions), module, typeTargets)}\n")
         + "\n"
+
+private fun asciidoc_public_union_variant_names(typeName: String, functions: List[CompiledFunction]): List[String] =
+    asciidoc_union_variant_names(typeName, functions).reduce([], (acc, variant) =>
+        if asciidoc_public_schema_type(variant, functions)
+        then acc + variant
+        else acc
+    )
 
 private fun generate_enum_value_docs(typeName: String, functions: List[CompiledFunction]): String =
     let values = asciidoc_schema_values("__capy_schema_enum|" + typeName + "|", functions)
@@ -645,7 +670,8 @@ private fun generate_type_constant_docs(typeName: String, functions: List[Compil
 
 private fun asciidoc_type_functions(typeName: String, functions: List[CompiledFunction]): List[CompiledFunction] =
     functions.reduce([], (acc, function) =>
-        if !asciidoc_schema_function(function)
+        if !asciidoc_private_visibility(function.visibility)
+            & !asciidoc_schema_function(function)
             & !asciidoc_constant_function(function)
             & !asciidoc_object_helper_function(function)
             & !asciidoc_generated_local_function(function)
@@ -658,6 +684,7 @@ private fun asciidoc_type_functions(typeName: String, functions: List[CompiledFu
 private fun asciidoc_type_constants(typeName: String, functions: List[CompiledFunction]): List[CompiledFunction] =
     functions.reduce([], (acc, function) =>
         if asciidoc_constant_function(function)
+            & !asciidoc_private_visibility(function.visibility)
             & !asciidoc_schema_function(function)
             & !asciidoc_object_helper_function(function)
             & !asciidoc_generated_local_function(function)
@@ -699,6 +726,9 @@ private fun asciidoc_schema_parent_child_name(name: String): String =
 
 private fun asciidoc_primitive_schema_type(typeName: String, functions: List[CompiledFunction]): bool =
     !asciidoc_schema_value_named("__capy_schema_primitive|" + typeName, functions).is_empty()
+
+private fun asciidoc_public_schema_type(typeName: String, functions: List[CompiledFunction]): bool =
+    !asciidoc_private_visibility(asciidoc_schema_value_named("__capy_schema_visibility|" + typeName, functions))
 
 private fun asciidoc_schema_function(function: CompiledFunction): bool =
     function.visibility.starts_with("const:schema")
@@ -773,11 +803,13 @@ private fun generate_backend_type_docs(types: Dict[CompiledPrimitiveBackedType],
         .sort((a,b) => a[0].compare(b[0]))
         .reduce("", (content, entry) =>
             let type = entry[1]
-            content
-            + "[[{asciidoc_type_anchor(type.name)}]]\n"
-            + "=== {type.visibility} {type.name}: {type_name(type.backingType, module, typeTargets)}\n\n{generate_documentation_for_backend_type(type)}\n"
-            + generate_type_function_docs(type.name, functions, module, typeTargets)
-            + "\n"
+            if asciidoc_private_visibility(type.visibility)
+            then content
+            else content
+                + "[[{asciidoc_type_anchor(type.name)}]]\n"
+                + "=== {type.visibility} {type.name}: {type_name(type.backingType, module, typeTargets)}\n\n{generate_documentation_for_backend_type(type)}\n"
+                + generate_type_function_docs(type.name, functions, module, typeTargets)
+                + "\n"
         )
 
 private fun generate_documentation_for_backend_type(type: CompiledPrimitiveBackedType): String =
@@ -800,7 +832,11 @@ private fun generate_object_oriented_unit_docs(unit: CompiledObjectOrientedUnit,
 private fun generate_object_interface_docs(interfaces: List[CompiledObjectOrientedInterface], unit: CompiledObjectOrientedUnit, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     interfaces
         .sort((a,b) => a.name.compare(b.name))
-        .map(interface => generate_object_interface_doc(interface, unit, module, typeTargets))
+        .map(interface =>
+            if asciidoc_private_visibility(interface.visibility)
+            then ""
+            else generate_object_interface_doc(interface, unit, module, typeTargets)
+        )
         .reduce("", (content, doc) => content + doc)
 
 private fun generate_object_interface_doc(interface: CompiledObjectOrientedInterface, unit: CompiledObjectOrientedUnit, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
@@ -814,7 +850,11 @@ private fun generate_object_interface_doc(interface: CompiledObjectOrientedInter
 private fun generate_object_class_docs(classes: List[CompiledObjectOrientedClass], unit: CompiledObjectOrientedUnit, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     classes
         .sort((a,b) => a.name.compare(b.name))
-        .map(class => generate_object_class_doc(class, unit, module, typeTargets))
+        .map(class =>
+            if asciidoc_private_visibility(class.visibility)
+            then ""
+            else generate_object_class_doc(class, unit, module, typeTargets)
+        )
         .reduce("", (content, doc) => content + doc)
 
 private fun generate_object_class_doc(class: CompiledObjectOrientedClass, unit: CompiledObjectOrientedUnit, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
@@ -845,10 +885,11 @@ private fun generate_object_parent_docs(parents: List[CompiledTypeReference], mo
         + "\n"
 
 private fun generate_object_field_docs(fields: List[CompiledObjectOrientedField], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
-    if fields.is_empty()
+    let visibleFields = asciidoc_public_object_fields(fields)
+    if visibleFields.is_empty()
     then ""
     else "==== Fields\n\n"
-        + fields
+        + visibleFields
             .sort((a,b) => a.name.compare(b.name))
             .reduce("", (content, field) => content + generate_object_field_doc(field, module, typeTargets))
         + "\n"
@@ -856,6 +897,13 @@ private fun generate_object_field_docs(fields: List[CompiledObjectOrientedField]
 private fun generate_object_field_doc(field: CompiledObjectOrientedField, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     "* `{field.visibility} {field.name}`: {type_name(field.typeReference, module, typeTargets)}{object_field_initializer_label(field)}\n"
     + generate_object_member_documentation(field.documentation)
+
+private fun asciidoc_public_object_fields(fields: List[CompiledObjectOrientedField]): List[CompiledObjectOrientedField] =
+    fields.reduce([], (acc, field) =>
+        if asciidoc_private_visibility(field.visibility)
+        then acc
+        else acc + field
+    )
 
 private fun object_field_initializer_label(field: CompiledObjectOrientedField): String =
     if field.hasValue then " (default)" else ""
@@ -875,10 +923,11 @@ private fun generate_object_init_items(initBlocks: List[CompiledObjectOrientedIn
         + generate_object_init_items(initBlocks[1:], idx + 1)
 
 private fun generate_object_method_docs(methods: List[CompiledObjectOrientedMethod], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
-    if methods.is_empty()
+    let visibleMethods = asciidoc_public_object_methods(methods)
+    if visibleMethods.is_empty()
     then ""
     else "==== Methods\n\n"
-        + methods
+        + visibleMethods
             .sort((a,b) => a.name.compare(b.name))
             .map(method => generate_object_method_doc(method, module, typeTargets))
             .reduce("", (content, doc) => content + doc)
@@ -887,6 +936,13 @@ private fun generate_object_method_doc(method: CompiledObjectOrientedMethod, mod
     "===== {method.visibility} {method.name}({generate_parameters(method.parameters, module, typeTargets)}): {type_name(method.returnType, module, typeTargets)}\n\n"
     + generate_text_documentation(method.documentation)
     + "\n"
+
+private fun asciidoc_public_object_methods(methods: List[CompiledObjectOrientedMethod]): List[CompiledObjectOrientedMethod] =
+    methods.reduce([], (acc, method) =>
+        if asciidoc_private_visibility(method.visibility)
+        then acc
+        else acc + method
+    )
 
 private fun generate_object_member_documentation(documentation: List[String]): String =
     if documentation.is_empty()
@@ -897,12 +953,18 @@ private fun generate_annotation_docs(annotations: Dict[CompiledAnnotationDeclara
     annotations
         .entries()
         .sort((a,b) => a[0].compare(b[0]))
-        .reduce("", (content, entry) => content + generate_annotation_doc(entry[1]))
+        .reduce("", (content, entry) =>
+            let annotation = entry[1]
+            if asciidoc_private_visibility(annotation.visibility)
+            then content
+            else content + generate_annotation_doc(annotation)
+        )
 
 private fun generate_annotation_section_docs(annotations: Dict[CompiledAnnotationDeclaration]): String =
-    if annotations.is_empty()
+    let content = generate_annotation_docs(annotations)
+    if content.is_empty()
     then ""
-    else "== Annotations\n\n" + generate_annotation_docs(annotations) + "\n\n"
+    else "== Annotations\n\n" + content + "\n\n"
 
 private fun generate_annotation_doc(annotation: CompiledAnnotationDeclaration): String =
     "=== {annotation.visibility} @{annotation.name}\n\n"

--- a/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
@@ -181,6 +181,7 @@ private fun generate_asciidoc_docs_for_module(module: CompiledModule, objectOrie
         content: "= Module {module.name}\n\n"
         + "== Functions\n\n"
         + generate_function_docs(asciidoc_top_level_functions(module.functions, typeNames), "===", module, typeTargets) + "\n\n"
+        + generate_top_level_constant_docs(module.functions, typeNames, module, typeTargets)
         + "== Annotations\n\n"
         + generate_annotation_docs(module.annotations) + "\n\n"
         + "== Types\n\n"
@@ -195,6 +196,18 @@ private fun generate_function_docs(functions: List[CompiledFunction], heading: S
         .map(function => "{heading} {function.visibility} {function.name}({generate_parameters(function.parameters, module, typeTargets)}): {type_name(function.returnType, module, typeTargets)}\n\n{generate_documentation(function)}\n\n")
         .reduce("", (content, functionDoc) => content + functionDoc)
 
+private fun generate_constant_docs(constants: List[CompiledFunction], heading: String, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
+    constants
+        .sort((a,b) => a.name.compare(b.name))
+        .map(constant => "{heading} {constant.visibility} {constant.name}: {type_name(constant.returnType, module, typeTargets)}\n\n{generate_documentation(constant)}\n\n")
+        .reduce("", (content, constantDoc) => content + constantDoc)
+
+private fun generate_top_level_constant_docs(functions: List[CompiledFunction], typeNames: List[String], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
+    let constants = asciidoc_top_level_constants(functions, typeNames)
+    if constants.is_empty()
+    then ""
+    else "== Constants\n\n" + generate_constant_docs(constants, "===", module, typeTargets) + "\n\n"
+
 private fun asciidoc_top_level_functions(functions: List[CompiledFunction], typeNames: List[String]): List[CompiledFunction] =
     functions.reduce([], (acc, function) =>
         if asciidoc_top_level_function(function, functions, typeNames)
@@ -204,9 +217,25 @@ private fun asciidoc_top_level_functions(functions: List[CompiledFunction], type
 
 private fun asciidoc_top_level_function(function: CompiledFunction, functions: List[CompiledFunction], typeNames: List[String]): bool =
     !asciidoc_schema_function(function)
+    & !asciidoc_constant_function(function)
     & !asciidoc_object_helper_function(function)
     & !asciidoc_generated_local_function(function)
     & !function.name.starts_with("__capy_constructor|")
+    & !asciidoc_function_belongs_to_type(function, typeNames)
+    & !asciidoc_enum_value_function(function, functions)
+
+private fun asciidoc_top_level_constants(functions: List[CompiledFunction], typeNames: List[String]): List[CompiledFunction] =
+    functions.reduce([], (acc, function) =>
+        if asciidoc_top_level_constant(function, functions, typeNames)
+        then acc + function
+        else acc
+    )
+
+private fun asciidoc_top_level_constant(function: CompiledFunction, functions: List[CompiledFunction], typeNames: List[String]): bool =
+    asciidoc_constant_function(function)
+    & !asciidoc_schema_function(function)
+    & !asciidoc_object_helper_function(function)
+    & !asciidoc_generated_local_function(function)
     & !asciidoc_function_belongs_to_type(function, typeNames)
     & !asciidoc_enum_value_function(function, functions)
 
@@ -226,6 +255,9 @@ private fun asciidoc_enum_value_function(function: CompiledFunction, functions: 
 
 private fun asciidoc_generated_local_function(function: CompiledFunction): bool =
     function.name.contains("__local__")
+
+private fun asciidoc_constant_function(function: CompiledFunction): bool =
+    function.visibility.starts_with("const:")
 
 private fun asciidoc_object_helper_function(function: CompiledFunction): bool =
     function.visibility.starts_with("oo")
@@ -530,6 +562,7 @@ private fun generate_schema_type_doc(typeName: String, functions: List[CompiledF
     + generate_type_field_docs(typeName, functions, module, typeTargets)
     + generate_union_variant_docs(typeName, functions, module, typeTargets)
     + generate_enum_value_docs(typeName, functions)
+    + generate_type_constant_docs(typeName, functions, module, typeTargets)
     + generate_type_function_docs(typeName, functions, module, typeTargets)
 
 private fun asciidoc_type_kind(typeName: String, functions: List[CompiledFunction]): String =
@@ -594,12 +627,31 @@ private fun generate_type_function_docs(typeName: String, functions: List[Compil
     else "==== Functions\n\n"
         + generate_function_docs(ownedFunctions, "=====", module, typeTargets)
 
+private fun generate_type_constant_docs(typeName: String, functions: List[CompiledFunction], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
+    let ownedConstants = asciidoc_type_constants(typeName, functions)
+    if ownedConstants.is_empty()
+    then ""
+    else "==== Constants\n\n"
+        + generate_constant_docs(ownedConstants, "=====", module, typeTargets)
+
 private fun asciidoc_type_functions(typeName: String, functions: List[CompiledFunction]): List[CompiledFunction] =
     functions.reduce([], (acc, function) =>
         if !asciidoc_schema_function(function)
+            & !asciidoc_constant_function(function)
             & !asciidoc_object_helper_function(function)
             & !asciidoc_generated_local_function(function)
             & !function.name.starts_with("__capy_constructor|")
+            & asciidoc_function_owner(function) == typeName
+        then acc + function
+        else acc
+    )
+
+private fun asciidoc_type_constants(typeName: String, functions: List[CompiledFunction]): List[CompiledFunction] =
+    functions.reduce([], (acc, function) =>
+        if asciidoc_constant_function(function)
+            & !asciidoc_schema_function(function)
+            & !asciidoc_object_helper_function(function)
+            & !asciidoc_generated_local_function(function)
             & asciidoc_function_owner(function) == typeName
         then acc + function
         else acc

--- a/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
@@ -179,14 +179,10 @@ private fun generate_asciidoc_docs_for_module(module: CompiledModule, objectOrie
     Documentation {
         path: "/" + module_doc_path(module),
         content: "= Module {module.name}\n\n"
-        + "== Functions\n\n"
-        + generate_function_docs(asciidoc_top_level_functions(module.functions, typeNames), "===", module, typeTargets) + "\n\n"
+        + generate_top_level_function_docs(module.functions, typeNames, module, typeTargets)
         + generate_top_level_constant_docs(module.functions, typeNames, module, typeTargets)
-        + "== Annotations\n\n"
-        + generate_annotation_docs(module.annotations) + "\n\n"
-        + "== Types\n\n"
-        + generate_schema_type_docs(module.functions, module, typeTargets)
-        + generate_backend_type_docs(module.visiblePrimitiveBackedTypes, module.functions, module, typeTargets)
+        + generate_annotation_section_docs(module.annotations)
+        + generate_type_docs(module, typeTargets)
         + generate_object_oriented_docs(module, objectOrientedUnits, typeTargets)
     }
 
@@ -201,6 +197,12 @@ private fun generate_constant_docs(constants: List[CompiledFunction], heading: S
         .sort((a,b) => a.name.compare(b.name))
         .map(constant => "{heading} {constant.visibility} {constant.name}: {type_name(constant.returnType, module, typeTargets)}\n\n{generate_documentation(constant)}\n\n")
         .reduce("", (content, constantDoc) => content + constantDoc)
+
+private fun generate_top_level_function_docs(functions: List[CompiledFunction], typeNames: List[String], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
+    let topLevelFunctions = asciidoc_top_level_functions(functions, typeNames)
+    if topLevelFunctions.is_empty()
+    then ""
+    else "== Functions\n\n" + generate_function_docs(topLevelFunctions, "===", module, typeTargets) + "\n\n"
 
 private fun generate_top_level_constant_docs(functions: List[CompiledFunction], typeNames: List[String], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     let constants = asciidoc_top_level_constants(functions, typeNames)
@@ -554,6 +556,13 @@ private fun generate_schema_type_docs(functions: List[CompiledFunction], module:
             else content + generate_schema_type_doc(typeName, functions, module, typeTargets)
         )
 
+private fun generate_type_docs(module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
+    let content = generate_schema_type_docs(module.functions, module, typeTargets)
+        + generate_backend_type_docs(module.visiblePrimitiveBackedTypes, module.functions, module, typeTargets)
+    if content.is_empty()
+    then ""
+    else "== Types\n\n" + content
+
 private fun generate_schema_type_doc(typeName: String, functions: List[CompiledFunction], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     "[[{asciidoc_type_anchor(typeName)}]]\n"
     + "=== {asciidoc_type_kind(typeName, functions)} {asciidoc_type_display_name(typeName, functions)}\n\n"
@@ -889,6 +898,11 @@ private fun generate_annotation_docs(annotations: Dict[CompiledAnnotationDeclara
         .entries()
         .sort((a,b) => a[0].compare(b[0]))
         .reduce("", (content, entry) => content + generate_annotation_doc(entry[1]))
+
+private fun generate_annotation_section_docs(annotations: Dict[CompiledAnnotationDeclaration]): String =
+    if annotations.is_empty()
+    then ""
+    else "== Annotations\n\n" + generate_annotation_docs(annotations) + "\n\n"
 
 private fun generate_annotation_doc(annotation: CompiledAnnotationDeclaration): String =
     "=== {annotation.visibility} @{annotation.name}\n\n"

--- a/capy/src/main/java/dev/capylang/compiler/parser/NativeCapybaraParser.java
+++ b/capy/src/main/java/dev/capylang/compiler/parser/NativeCapybaraParser.java
@@ -1492,6 +1492,7 @@ public final class NativeCapybaraParser implements CapybaraParser, CapybaraValid
                 location
         ));
         definitions.add(schemaConstantDefinition("__capy_schema_type|" + name, name, documentation, location));
+        definitions.add(schemaConstantDefinition("__capy_schema_visibility|" + name, visibility, location));
 
         var typeParameters = dataTypeParameters(unionDeclaration);
         for (var i = 0; i < typeParameters.size(); i++) {
@@ -1580,6 +1581,7 @@ public final class NativeCapybaraParser implements CapybaraParser, CapybaraValid
                 location
         ));
         definitions.add(schemaConstantDefinition("__capy_schema_type|" + name, name, docComments(ctx.docComment()), location));
+        definitions.add(schemaConstantDefinition("__capy_schema_visibility|" + name, visibility, location));
         definitions.add(schemaConstantDefinition("__capy_schema_primitive|" + name, backingType.name(), location));
         definitions.add(schemaConstantDefinition(
                 "__capy_schema_field|" + name + "|0",


### PR DESCRIPTION
## Summary
- split `const:` entries into their own Capy docs sections instead of rendering them with functions
- add type-owned constants under each data/union/enum/object page before function docs
- render constant headings without `()` and keep empty constant sections omitted

## Validation
- `./gradlew :capy:integrationTest --tests dev.capylang.cli.CapyDocsCommandIntegrationTest --no-daemon`
- `./gradlew :capy:assemble --no-daemon`
- `java -jar capy/build/libs/capy-0.4.0-SNAPSHOT.jar docs -i lib/capybara-lib/src/main/capybara -o build/capy-docs`
- `git diff --check`