### PR TITLE
fix(#183): omit const prefix in docs headings

### DIFF
--- a/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
@@ -171,10 +171,11 @@ class CapyDocsCommandIntegrationTest {
                 .contains("* `LOW`")
                 .contains("* `HIGH`")
                 .contains("== Constants")
-                .contains("=== const:public ANSWER: int")
+                .contains("=== public ANSWER: int")
                 .contains("Answer docs")
                 .contains("===== public Tone.describe(): String")
                 .doesNotContain("=== const:public ANSWER(): int")
+                .doesNotContain("=== const:public ANSWER: int")
                 .doesNotContain("== Annotations")
                 .doesNotContain("HiddenBox")
                 .doesNotContain("HiddenCircle")
@@ -195,7 +196,7 @@ class CapyDocsCommandIntegrationTest {
                 .doesNotContain("__capy_schema_type|Box")
                 .doesNotContain("ExampleDocs");
         assertThat(docsContent).containsSubsequence("* `HIGH`", "* `LOW`");
-        assertThat(docsContent).containsSubsequence("== Functions", "=== public documented_function", "== Constants", "=== const:public ANSWER: int", "== Types");
+        assertThat(docsContent).containsSubsequence("== Functions", "=== public documented_function", "== Constants", "=== public ANSWER: int", "== Types");
 
         var objectsFile = output.resolve("sample/Objects.adoc");
         assertThat(objectsFile).isRegularFile();

--- a/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
@@ -201,8 +201,13 @@ private fun generate_function_docs(functions: List[CompiledFunction], heading: S
 private fun generate_constant_docs(constants: List[CompiledFunction], heading: String, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     constants
         .sort((a,b) => a.name.compare(b.name))
-        .map(constant => "{heading} {constant.visibility} {constant.name}: {type_name(constant.returnType, module, typeTargets)}\n\n{generate_documentation(constant)}\n\n")
+        .map(constant => "{heading} {asciidoc_constant_visibility(constant.visibility)} {constant.name}: {type_name(constant.returnType, module, typeTargets)}\n\n{generate_documentation(constant)}\n\n")
         .reduce("", (content, constantDoc) => content + constantDoc)
+
+private fun asciidoc_constant_visibility(visibility: String): String =
+    if visibility.starts_with("const:")
+    then visibility["const:".size().value, visibility.size().value]
+    else visibility
 
 private fun generate_top_level_function_docs(functions: List[CompiledFunction], typeNames: List[String], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     let topLevelFunctions = asciidoc_top_level_functions(functions, typeNames)


### PR DESCRIPTION
## Summary
- render constants in Capy docs with normal visibility labels like `public EMPTY: size`
- keep `const:` as internal compiled visibility, but strip it from AsciiDoc constant headings
- update CLI docs integration coverage for the rendered heading

## Validation
- `./gradlew :capy:integrationTest --tests dev.capylang.cli.CapyDocsCommandIntegrationTest --no-daemon`
- `./gradlew :capy:assemble --no-daemon`
- `java -jar capy/build/libs/capy-0.4.0-SNAPSHOT.jar docs -i lib/capybara-lib/src/main/capybara -o build/capy-docs`
- `rg -n '^=+ const:' build/capy-docs` returned no matches
- `git diff --check`