### PR TITLE
fix(#183): render docs links

### DIFF
--- a/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/cli/CapyDocsCommandIntegrationTest.java
@@ -54,6 +54,7 @@ class CapyDocsCommandIntegrationTest {
                 fun Tone.describe(): String = "tone"
 
                 /// Function docs
+                /// [Spec](https://example.com/spec)
                 fun documented_function(box: Box, wrapped: GenericBox[Box]): GenericBox[Box] = wrapped
 
                 /// Hidden function docs
@@ -149,8 +150,9 @@ class CapyDocsCommandIntegrationTest {
         var docsContent = Files.readString(docsFile);
         assertThat(docsContent)
                 .contains("= Module Docs")
-                .contains("documented_function(box: xref:#type-Box[Box], wrapped: xref:#type-GenericBox[GenericBox][xref:#type-Box[Box]]): xref:#type-GenericBox[GenericBox][xref:#type-Box[Box]]")
+                .contains("documented_function(box: xref:#type-Box[Box], wrapped: xref:#type-GenericBox[GenericBox]&#91;xref:#type-Box[Box]&#93;): xref:#type-GenericBox[GenericBox]&#91;xref:#type-Box[Box]&#93;")
                 .contains("Function docs")
+                .contains("https://example.com/spec[Spec]")
                 .contains("[[type-Box]]\n=== data Box")
                 .contains("Box docs")
                 .contains("* `value`: String")
@@ -194,6 +196,8 @@ class CapyDocsCommandIntegrationTest {
                 .doesNotContain("\n=== fun Box.describe")
                 .doesNotContain("\n=== fun GenericBox[T].describe")
                 .doesNotContain("* `name`: `String`")
+                .doesNotContain("xref:#type-GenericBox[GenericBox][xref:#type-Box[Box]]")
+                .doesNotContain("[Spec](https://example.com/spec)")
                 .doesNotContain("__capy_schema_type|Box")
                 .doesNotContain("ExampleDocs");
         assertThat(docsContent).containsSubsequence("* `HIGH`", "* `LOW`");

--- a/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/doc/AsciiDocGenerator.cfun
@@ -295,10 +295,59 @@ private fun generate_documentation(function: CompiledFunction): String =
     generate_text_documentation(function.documentation)
 
 private fun generate_text_documentation(documentation: List[String]): String =
-    documentation.reduce("", (content, docLine) => content + docLine + "\n")
+    documentation.reduce("", (content, docLine) => content + asciidoc_documentation_line(docLine) + "\n")
 
 private fun generate_documentation_for_annotation(annotation: CompiledAnnotationDeclaration): String =
-    annotation.documentation.reduce("", (content, docLine) => content + docLine + "\n")
+    generate_text_documentation(annotation.documentation)
+
+private fun asciidoc_documentation_line(line: String): String =
+    asciidoc_markdown_links(line)
+
+private fun asciidoc_markdown_links(value: String): String =
+    let open = asciidoc_first_index_of(value, "[", 0)
+    if open < 0
+    then value
+    else asciidoc_markdown_link_from_open(value, open)
+
+private fun asciidoc_markdown_link_from_open(value: String, open: int): String =
+    if asciidoc_markdown_link_image(value, open)
+    then asciidoc_markdown_link_skip(value, open)
+    else asciidoc_markdown_link_from_close(value, open, asciidoc_first_index_of(value, "]", open + 1))
+
+private fun asciidoc_markdown_link_from_close(value: String, open: int, close: int): String =
+    if close < 0 | !asciidoc_markdown_link_has_url_start(value, close)
+    then asciidoc_markdown_link_skip(value, open)
+    else asciidoc_markdown_link_from_url_end(value, open, close, asciidoc_first_index_of(value, ")", close + 2))
+
+private fun asciidoc_markdown_link_from_url_end(value: String, open: int, close: int, urlEnd: int): String =
+    if urlEnd < 0
+    then value
+    else asciidoc_markdown_link_from_parts(value, open, close, urlEnd)
+
+private fun asciidoc_markdown_link_from_parts(value: String, open: int, close: int, urlEnd: int): String =
+    let label = value[open + 1, close]
+    let url = value[close + 2, urlEnd]
+    if label.is_empty() | !asciidoc_external_url(url)
+    then asciidoc_markdown_link_skip(value, open)
+    else value[0, open] + url + "[" + label + "]" + asciidoc_markdown_links(value[urlEnd + 1, value.size().value])
+
+private fun asciidoc_markdown_link_skip(value: String, open: int): String =
+    value[0, open + 1] + asciidoc_markdown_links(value[open + 1, value.size().value])
+
+private fun asciidoc_markdown_link_image(value: String, open: int): bool =
+    if open <= 0
+    then false
+    else match value[open - 1] with
+    case None -> false
+    case Some { char } -> char == "!"
+
+private fun asciidoc_markdown_link_has_url_start(value: String, close: int): bool =
+    match value[close + 1] with
+    case None -> false
+    case Some { char } -> char == "("
+
+private fun asciidoc_external_url(url: String): bool =
+    url.starts_with("https://") | url.starts_with("http://")
 
 private fun generate_parameter(parameter: CompiledFunctionParameter, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     "{parameter.name}: {type_name(parameter.typeReference, module, typeTargets)}"
@@ -328,7 +377,13 @@ private fun asciidoc_simple_qualified_name(name: String): String =
 private fun type_arguments(arguments: List[CompiledTypeReference], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     if arguments.is_empty()
     then ""
-    else "[" + join_type_names(arguments, module, typeTargets) + "]"
+    else asciidoc_generic_start() + join_type_names(arguments, module, typeTargets) + asciidoc_generic_end()
+
+private fun asciidoc_generic_start(): String =
+    "&#91;"
+
+private fun asciidoc_generic_end(): String =
+    "&#93;"
 
 private fun join_type_names(arguments: List[CompiledTypeReference], module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     match arguments[0] with
@@ -372,9 +427,9 @@ private fun asciidoc_type_text(typeText: String, module: CompiledModule, typeTar
         if bracket < 0
         then asciidoc_type_reference_link(typeText.trim(), module, typeTargets)
         else asciidoc_type_reference_link(typeText[0, bracket].trim(), module, typeTargets)
-            + "["
+            + asciidoc_generic_start()
             + asciidoc_type_text_arguments(typeText[bracket + 1, typeText.size().value - 1], module, typeTargets)
-            + "]"
+            + asciidoc_generic_end()
 
 private fun asciidoc_type_text_arguments(typeText: String, module: CompiledModule, typeTargets: List[AsciiDocTypeTarget]): String =
     let comma = asciidoc_top_level_comma(typeText, 0, 0)
@@ -813,7 +868,7 @@ private fun generate_backend_type_docs(types: Dict[CompiledPrimitiveBackedType],
         )
 
 private fun generate_documentation_for_backend_type(type: CompiledPrimitiveBackedType): String =
-    type.documentation.reduce("", (content, docLine) => content + docLine + "\n")
+    generate_text_documentation(type.documentation)
 
 private fun generate_object_oriented_docs(module: CompiledModule, units: List[CompiledObjectOrientedUnit], typeTargets: List[AsciiDocTypeTarget]): String =
     match units[0] with

--- a/docs/capy-docs/SNAPSHOT/capy/collection/CollectionTypes.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/collection/CollectionTypes.adoc
@@ -21,11 +21,11 @@ Zero-based collection position.
 
 ==== Functions
 
-===== fun index.`+`(offset: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-index[index]]
+===== fun index.`+`(offset: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-index[index]&#93;
 
 
 
-===== fun index.`+`(offset: int): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-index[index]]
+===== fun index.`+`(offset: int): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-index[index]&#93;
 
 
 
@@ -69,15 +69,15 @@ Zero-based collection position.
 
 
 
-===== fun index.next(): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-index[index]]
+===== fun index.next(): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-index[index]&#93;
 
 
 
-===== fun index.plus(offset: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-index[index]]
+===== fun index.plus(offset: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-index[index]&#93;
 
 
 
-===== fun index.plus(offset: int): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-index[index]]
+===== fun index.plus(offset: int): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-index[index]&#93;
 
 
 
@@ -93,19 +93,19 @@ Collection size value.
 
 ==== Functions
 
-===== fun size.`+`(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.`+`(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
-===== fun size.`+`(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.`+`(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
-===== fun size.`-`(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.`-`(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
-===== fun size.`-`(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.`-`(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
@@ -149,19 +149,19 @@ Collection size value.
 
 
 
-===== fun size.minus(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.minus(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
-===== fun size.minus(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.minus(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
-===== fun size.plus(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.plus(other: xref:#type-size[size]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 
-===== fun size.plus(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-size[size]]
+===== fun size.plus(other: int): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-size[size]&#93;
 
 
 

--- a/docs/capy-docs/SNAPSHOT/capy/collection/Dict.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/collection/Dict.adoc
@@ -17,7 +17,7 @@ Dictionaries are immutable: adding or removing entries returns a new `Dict`.
 
 ==== Functions
 
-===== fun Dict[T].`+`(entry: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][xref:../../capy/lang/String.adoc#type-String[String], T]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].`+`(entry: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;xref:../../capy/lang/String.adoc#type-String[String], T&#93;): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict with `entry` added or replaced.
 
@@ -25,17 +25,17 @@ Example: `{"name": "Ada"} + ("name", "Grace")` returns a dictionary where
 `name` is `Grace`.
 
 
-===== fun Dict[T].`+`(other: xref:#type-Dict[Dict][T]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].`+`(other: xref:#type-Dict[Dict]&#91;T&#93;): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict with all entries from `other` added or replaced.
 
 
-===== fun Dict[T].`-`(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].`-`(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict without `key`.
 
 
-===== fun Dict[T].`-`(other: xref:#type-Dict[Dict][T]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].`-`(other: xref:#type-Dict[Dict]&#91;T&#93;): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict without keys contained in `other`.
 
@@ -45,7 +45,7 @@ Returns a new Dict without keys contained in `other`.
 Returns true when this Dict contains the given key.
 
 
-===== fun Dict[T].`|-`(predicate: (String,T)=>bool): xref:#type-Dict[Dict][T]
+===== fun Dict[T].`|-`(predicate: (String,T)=>bool): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict containing only entries that satisfy `predicate`.
 
@@ -55,7 +55,7 @@ Returns a new Dict containing only entries that satisfy `predicate`.
 Combines all entries from left to right.
 
 
-===== fun Dict[T].`|`(map: (String,T)=>Y): xref:#type-Dict[Dict][Y]
+===== fun Dict[T].`|`(map: (String,T)=>Y): xref:#type-Dict[Dict]&#91;Y&#93;
 
 Transforms each entry using `map`.
 
@@ -77,14 +77,14 @@ Returns true when at least one entry satisfies `predicate`.
 Returns true when this Dict contains the given key.
 
 
-===== fun Dict[T].entries(): xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][xref:../../capy/lang/String.adoc#type-String[String], T]]
+===== fun Dict[T].entries(): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;xref:../../capy/lang/String.adoc#type-String[String], T&#93;&#93;
 
 Returns this Dict as a List of `(key, value)` tuples.
 
 Example: `{"one": 1}.entries()` returns `[("one", 1)]`.
 
 
-===== fun Dict[T].filter(predicate: (String,T)=>bool): xref:#type-Dict[Dict][T]
+===== fun Dict[T].filter(predicate: (String,T)=>bool): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict containing only entries that satisfy `predicate`.
 
@@ -95,7 +95,7 @@ Example:
 Returns only the `debug` entry.
 
 
-===== fun Dict[T].get(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+===== fun Dict[T].get(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 Returns the value for key; equivalent to dict[key].
 
@@ -107,7 +107,7 @@ Example: `{"name": "Ada"}.get("name")` returns `Some { value: "Ada" }`.
 Returns true when this Dict has no entries.
 
 
-===== fun Dict[T].map(map: (String,T)=>Y): xref:#type-Dict[Dict][Y]
+===== fun Dict[T].map(map: (String,T)=>Y): xref:#type-Dict[Dict]&#91;Y&#93;
 
 Transforms each entry using `map`.
 
@@ -118,22 +118,22 @@ Example:
 Returns `{"a": 10, "b": 20}` while preserving keys.
 
 
-===== fun Dict[T].minus(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].minus(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict without `key`.
 
 
-===== fun Dict[T].minus(other: xref:#type-Dict[Dict][T]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].minus(other: xref:#type-Dict[Dict]&#91;T&#93;): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict without keys contained in `other`.
 
 
-===== fun Dict[T].plus(entry: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][xref:../../capy/lang/String.adoc#type-String[String], T]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].plus(entry: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;xref:../../capy/lang/String.adoc#type-String[String], T&#93;): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict with `entry` added or replaced.
 
 
-===== fun Dict[T].plus(other: xref:#type-Dict[Dict][T]): xref:#type-Dict[Dict][T]
+===== fun Dict[T].plus(other: xref:#type-Dict[Dict]&#91;T&#93;): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict with all entries from `other` added or replaced.
 
@@ -149,7 +149,7 @@ Example:
 Returns `3`.
 
 
-===== fun Dict[T].reject(predicate: (String,T)=>bool): xref:#type-Dict[Dict][T]
+===== fun Dict[T].reject(predicate: (String,T)=>bool): xref:#type-Dict[Dict]&#91;T&#93;
 
 Returns a new Dict without entries that satisfy `predicate`.
 

--- a/docs/capy-docs/SNAPSHOT/capy/collection/List.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/collection/List.adoc
@@ -18,22 +18,22 @@ unchanged.
 
 ==== Functions
 
-===== fun List[T].`+`(value: T): xref:#type-List[List][T]
+===== fun List[T].`+`(value: T): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List with `value` appended.
 
 
-===== fun List[T].`+`(other: xref:#type-List[List][T]): xref:#type-List[List][T]
+===== fun List[T].`+`(other: xref:#type-List[List]&#91;T&#93;): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List with all values from `other` appended.
 
 
-===== fun List[T].`-`(value: T): xref:#type-List[List][T]
+===== fun List[T].`-`(value: T): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List without values equal to `value`.
 
 
-===== fun List[T].`-`(other: xref:#type-List[List][T]): xref:#type-List[List][T]
+===== fun List[T].`-`(other: xref:#type-List[List]&#91;T&#93;): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List without values contained in `other`.
 
@@ -43,12 +43,12 @@ Returns a new List without values contained in `other`.
 Returns true when this List contains the given value.
 
 
-===== fun List[T].`|*`(map: T=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun List[T].`|*`(map: T=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` to each value and concatenates the resulting lists.
 
 
-===== fun List[T].`|-`(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+===== fun List[T].`|-`(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence containing only values that satisfy `predicate`.
 
@@ -58,7 +58,7 @@ Returns a sequence containing only values that satisfy `predicate`.
 Combines all values from left to right.
 
 
-===== fun List[T].`|`(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun List[T].`|`(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each value using `map`.
 
@@ -80,7 +80,7 @@ Returns true when at least one value satisfies `predicate`.
 Returns true when this List contains the given value.
 
 
-===== fun List[T].filter(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+===== fun List[T].filter(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence containing only values that satisfy `predicate`.
 
@@ -91,7 +91,7 @@ Example:
 Returns `[3, 4]`.
 
 
-===== fun List[T].flat_map(map: T=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun List[T].flat_map(map: T=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` to each value and concatenates the resulting lists.
 
@@ -102,21 +102,21 @@ Example:
 Returns `[1, 10, 2, 20]`.
 
 
-===== fun List[T].fold(reducer: (T,T)=>T): xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+===== fun List[T].fold(reducer: (T,T)=>T): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 Combines values from left to right using the first value as the accumulator.
 
 Empty lists return `None`. Non-empty lists return `Some` with the folded value.
 
 
-===== fun List[T].get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+===== fun List[T].get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 Returns the value at idx using the same bounds and negative-index rules as list[idx].
 
 Example: `[10, 20, 30].get(-1)` returns `Some { value: 30 }`.
 
 
-===== fun List[T].get(from: int, to: int): xref:#type-List[List][T]
+===== fun List[T].get(from: int, to: int): xref:#type-List[List]&#91;T&#93;
 
 Returns the values in the half-open range [from, to) using the same bounds and negative-index rules as list[from:to].
 
@@ -128,7 +128,7 @@ Example: `[10, 20, 30, 40].get(1, 3)` returns `[20, 30]`.
 Returns true when this List has no values.
 
 
-===== fun List[T].map(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun List[T].map(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each value using `map`.
 
@@ -142,22 +142,22 @@ Example:
 Returns `[2, 4, 6]`.
 
 
-===== fun List[T].minus(value: T): xref:#type-List[List][T]
+===== fun List[T].minus(value: T): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List without values equal to `value`.
 
 
-===== fun List[T].minus(other: xref:#type-List[List][T]): xref:#type-List[List][T]
+===== fun List[T].minus(other: xref:#type-List[List]&#91;T&#93;): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List without values contained in `other`.
 
 
-===== fun List[T].plus(value: T): xref:#type-List[List][T]
+===== fun List[T].plus(value: T): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List with `value` appended.
 
 
-===== fun List[T].plus(other: xref:#type-List[List][T]): xref:#type-List[List][T]
+===== fun List[T].plus(other: xref:#type-List[List]&#91;T&#93;): xref:#type-List[List]&#91;T&#93;
 
 Returns a new List with all values from `other` appended.
 
@@ -173,7 +173,7 @@ Example:
 Returns `6`.
 
 
-===== fun List[T].reject(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+===== fun List[T].reject(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence without values that satisfy `predicate`.
 
@@ -183,7 +183,7 @@ Returns a sequence without values that satisfy `predicate`.
 Returns the number of values in this List.
 
 
-===== fun List[T].sort(compare: (T,T)=>Ordering): xref:#type-List[List][T]
+===== fun List[T].sort(compare: (T,T)=>Ordering): xref:#type-List[List]&#91;T&#93;
 
 Returns this List sorted with `compare`.
 

--- a/docs/capy-docs/SNAPSHOT/capy/collection/Seq.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/collection/Seq.adoc
@@ -2,38 +2,38 @@
 
 == Functions
 
-=== fun fibonacci_seq(): xref:#type-Seq[Seq][int]
+=== fun fibonacci_seq(): xref:#type-Seq[Seq]&#91;int&#93;
 
 Returns an infinite Fibonacci sequence: `1, 1, 2, 3, 5, 8, 13, ...`.
 
 
-=== fun natural_seq(): xref:#type-Seq[Seq][int]
+=== fun natural_seq(): xref:#type-Seq[Seq]&#91;int&#93;
 
 Returns an infinite sequence of natural numbers starting at `0`.
 
 To start at `1`, drop the first element.
 
 
-=== fun ones_seq(): xref:#type-Seq[Seq][int]
+=== fun ones_seq(): xref:#type-Seq[Seq]&#91;int&#93;
 
 Returns an infinite sequence of ones.
 
 
-=== fun powers_of_2_seq(): xref:#type-Seq[Seq][int]
+=== fun powers_of_2_seq(): xref:#type-Seq[Seq]&#91;int&#93;
 
 Returns an infinite sequence of powers of `2`: `2^0, 2^1, 2^2, ...`.
 
 The first element is `1` because `2^0 = 1`.
 
 
-=== fun powers_seq(base: int): xref:#type-Seq[Seq][int]
+=== fun powers_seq(base: int): xref:#type-Seq[Seq]&#91;int&#93;
 
 Returns an infinite sequence of powers of `base`: `base^0, base^1, base^2, ...`.
 
 The first element is always `1` because `x^0 = 1`.
 
 
-=== fun to_seq(list: xref:../../capy/collection/List.adoc#type-List[List][T]): xref:#type-Seq[Seq][T]
+=== fun to_seq(list: xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;): xref:#type-Seq[Seq]&#91;T&#93;
 
 Converts a `List` into a finite `Seq`.
 
@@ -44,17 +44,17 @@ to_seq([1, 2, 3]).map(value => value + 1).as_list()
 Returns `[2, 3, 4]`.
 
 
-=== fun to_seq(list: xref:../../capy/collection/Set.adoc#type-Set[Set][T]): xref:#type-Seq[Seq][T]
+=== fun to_seq(list: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;T&#93;): xref:#type-Seq[Seq]&#91;T&#93;
 
 Converts a `Set` into a finite `Seq`.
 
 
-=== fun to_seq(list: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][T]): xref:#type-Seq[Seq][xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][xref:../../capy/lang/String.adoc#type-String[String], T]]
+=== fun to_seq(list: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;T&#93;): xref:#type-Seq[Seq]&#91;xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;xref:../../capy/lang/String.adoc#type-String[String], T&#93;&#93;
 
 Converts a `Dict` into a finite `Seq` of `(key, value)` tuples.
 
 
-=== fun zeros_seq(): xref:#type-Seq[Seq][int]
+=== fun zeros_seq(): xref:#type-Seq[Seq]&#91;int&#93;
 
 Returns an infinite sequence of zeros.
 
@@ -97,19 +97,19 @@ Returns `[0, 2, 4]`.
 
 ==== Variants
 
-* xref:#type-Cons[Cons][T]
+* xref:#type-Cons[Cons]&#91;T&#93;
 * xref:#type-End[End]
 
 ==== Functions
 
-===== fun Seq[T].`+`(other: xref:#type-Seq[Seq][T]): xref:#type-Seq[Seq][T]
+===== fun Seq[T].`+`(other: xref:#type-Seq[Seq]&#91;T&#93;): xref:#type-Seq[Seq]&#91;T&#93;
 
 Concatenates this sequence with `other`.
 
 If this sequence is infinite, `other` is never reached.
 
 
-===== fun Seq[T].`|*`(map: T=>Seq[Y]): xref:#type-Seq[Seq][Y]
+===== fun Seq[T].`|*`(map: T=>Seq[Y]): xref:#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` and flattens the resulting sequences.
 
@@ -119,7 +119,7 @@ produces:
 `[1, 2, 3, 2, 4, 6, 4, 8, 12, ...]`
 
 
-===== fun Seq[T].`|-`(pred: T=>bool): xref:#type-Seq[Seq][T]
+===== fun Seq[T].`|-`(pred: T=>bool): xref:#type-Seq[Seq]&#91;T&#93;
 
 Operator alias for `filter`.
 
@@ -129,7 +129,7 @@ Operator alias for `filter`.
 Operator alias for `reduce`.
 
 
-===== fun Seq[T].`|`(map: T=>Y): xref:#type-Seq[Seq][Y]
+===== fun Seq[T].`|`(map: T=>Y): xref:#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each element using `map`.
 
@@ -147,19 +147,19 @@ Returns `true` if at least one element satisfies `pred`.
 This is equivalent to checking whether `first_match(pred)` returns `Some`.
 
 
-===== fun Seq[T].as_list(): xref:../../capy/collection/List.adoc#type-List[List][T]
+===== fun Seq[T].as_list(): xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;
 
 Collects the entire sequence into a `List`.
 
 Important: calling this on an infinite sequence does not terminate.
 
 
-===== fun Seq[T].drop(n: xref:../../capy/collection/CollectionTypes.adoc#type-size[size]): xref:#type-Seq[Seq][T]
+===== fun Seq[T].drop(n: xref:../../capy/collection/CollectionTypes.adoc#type-size[size]): xref:#type-Seq[Seq]&#91;T&#93;
 
 Skips the first `n` elements of the sequence.
 
 
-===== fun Seq[T].drop_until(pred: T=>bool): xref:#type-Seq[Seq][T]
+===== fun Seq[T].drop_until(pred: T=>bool): xref:#type-Seq[Seq]&#91;T&#93;
 
 Drops elements until `pred` becomes `true`.
 
@@ -170,7 +170,7 @@ Example:
 The first element that satisfies `pred` is included in the result.
 
 
-===== fun Seq[T].filter(pred: T=>bool): xref:#type-Seq[Seq][T]
+===== fun Seq[T].filter(pred: T=>bool): xref:#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence containing only elements that satisfy `pred`.
 
@@ -180,33 +180,33 @@ natural_seq().filter(x => x % 2 == 0)
 ```
 
 
-===== fun Seq[T].first(): xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+===== fun Seq[T].first(): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 Returns the first element wrapped in `Option`.
 
 Returns `None` for an empty sequence.
 
 
-===== fun Seq[T].first_match(pred: T=>bool): xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+===== fun Seq[T].first_match(pred: T=>bool): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 Returns the first element matching `pred`, wrapped in `Option`.
 
 Returns `None` when no element matches.
 
 
-===== fun Seq[T].flat_map(map: T=>Seq[Y]): xref:#type-Seq[Seq][Y]
+===== fun Seq[T].flat_map(map: T=>Seq[Y]): xref:#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` and flattens the resulting sequences.
 
 
-===== fun Seq[T].fold(reducer: (T,T)=>T): xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+===== fun Seq[T].fold(reducer: (T,T)=>T): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 Combines elements from left to right using the first element as the accumulator.
 
 Empty sequences return `None`. Non-empty sequences return `Some` with the folded value.
 
 
-===== fun Seq[T].map(map: T=>Y): xref:#type-Seq[Seq][Y]
+===== fun Seq[T].map(map: T=>Y): xref:#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each element using `map`.
 
@@ -224,12 +224,12 @@ to_seq([1, 2, 3]) |> 0, (total, value) => total + value
 Returns `6`.
 
 
-===== fun Seq[T].reject(pred: T=>bool): xref:#type-Seq[Seq][T]
+===== fun Seq[T].reject(pred: T=>bool): xref:#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence without elements that satisfy `pred`.
 
 
-===== fun Seq[T].take(n: xref:../../capy/collection/CollectionTypes.adoc#type-size[size]): xref:../../capy/collection/List.adoc#type-List[List][T]
+===== fun Seq[T].take(n: xref:../../capy/collection/CollectionTypes.adoc#type-size[size]): xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;
 
 Collects the first `n` elements into a `List`.
 
@@ -238,21 +238,21 @@ This method is safe to use with infinite sequences.
 Example: `powers_of_2_seq().take(4)` returns `[1, 2, 4, 8]`.
 
 
-===== fun Seq[T].take_last(n: xref:../../capy/collection/CollectionTypes.adoc#type-size[size]): xref:../../capy/collection/List.adoc#type-List[List][T]
+===== fun Seq[T].take_last(n: xref:../../capy/collection/CollectionTypes.adoc#type-size[size]): xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;
 
 Collects the last `n` elements into a `List`.
 
 Important: calling this on an infinite sequence does not terminate.
 
 
-===== fun Seq[T].until(pred: T=>bool): xref:#type-Seq[Seq][T]
+===== fun Seq[T].until(pred: T=>bool): xref:#type-Seq[Seq]&#91;T&#93;
 
 Returns elements from the start of the sequence until `pred` becomes `true`.
 
 The element that satisfies `pred` is not included.
 
 
-===== fun Seq[T].zip(other: xref:#type-Seq[Seq][Y]): xref:#type-Seq[Seq][xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][T, Y]]
+===== fun Seq[T].zip(other: xref:#type-Seq[Seq]&#91;Y&#93;): xref:#type-Seq[Seq]&#91;xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;T, Y&#93;&#93;
 
 Zips two sequences into a sequence of tuples.
 

--- a/docs/capy-docs/SNAPSHOT/capy/collection/Set.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/collection/Set.adoc
@@ -20,22 +20,22 @@ Sets are immutable and contain each value at most once.
 
 ==== Functions
 
-===== fun Set[T].`+`(value: T): xref:#type-Set[Set][T]
+===== fun Set[T].`+`(value: T): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set with `value` included.
 
 
-===== fun Set[T].`+`(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].`+`(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set with all values from `other` included.
 
 
-===== fun Set[T].`-`(value: T): xref:#type-Set[Set][T]
+===== fun Set[T].`-`(value: T): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set without `value`.
 
 
-===== fun Set[T].`-`(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].`-`(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set without values contained in `other`.
 
@@ -45,12 +45,12 @@ Returns a new Set without values contained in `other`.
 Returns true when this Set contains the given value.
 
 
-===== fun Set[T].`|*`(map: T=>Set[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun Set[T].`|*`(map: T=>Set[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` to each value and concatenates the resulting sets.
 
 
-===== fun Set[T].`|-`(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+===== fun Set[T].`|-`(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence containing only values that satisfy `predicate`.
 
@@ -60,12 +60,12 @@ Returns a sequence containing only values that satisfy `predicate`.
 Combines all values from left to right.
 
 
-===== fun Set[T].`|`(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun Set[T].`|`(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each value using `map`.
 
 
-===== fun Set[T].`×`(other: xref:#type-Set[Set][U]): xref:#type-Set[Set][xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][T, U]]
+===== fun Set[T].`×`(other: xref:#type-Set[Set]&#91;U&#93;): xref:#type-Set[Set]&#91;xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;T, U&#93;&#93;
 
 Returns all ordered pairs from this Set and `other`.
 
@@ -78,7 +78,7 @@ Examples:
 Symbolic alias for `cartesian_product`.
 
 
-===== fun Set[T].`℘`(): xref:#type-Set[Set][xref:#type-Set[Set][T]]
+===== fun Set[T].`℘`(): xref:#type-Set[Set]&#91;xref:#type-Set[Set]&#91;T&#93;&#93;
 
 Returns the Set of all subsets of this Set.
 
@@ -91,7 +91,7 @@ Examples:
 Symbolic alias for `power_set`.
 
 
-===== fun Set[T].`∩`(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].`∩`(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns values present in both Sets.
 
@@ -104,7 +104,7 @@ Examples and counter-examples:
 Symbolic alias for `intersection`.
 
 
-===== fun Set[T].`∪`(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].`∪`(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Combines all values from both Sets.
 
@@ -117,7 +117,7 @@ Examples and counter-examples:
 Symbolic alias for `union`.
 
 
-===== fun Set[T].`⊂`(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].`⊂`(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when this Set is strictly contained in `other`.
 
@@ -130,7 +130,7 @@ Examples and counter-examples:
 Symbolic alias for `is_proper_subset_of`.
 
 
-===== fun Set[T].`⊃`(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].`⊃`(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when this Set strictly contains `other`.
 
@@ -143,7 +143,7 @@ Examples and counter-examples:
 Symbolic alias for `is_proper_superset_of`.
 
 
-===== fun Set[T].`⊆`(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].`⊆`(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when every value in this Set exists in `other`.
 
@@ -157,7 +157,7 @@ Examples and counter-examples:
 Symbolic alias for `is_subset_of`.
 
 
-===== fun Set[T].`⊇`(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].`⊇`(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when this Set contains every value in `other`.
 
@@ -171,7 +171,7 @@ Examples and counter-examples:
 Symbolic alias for `is_superset_of`.
 
 
-===== fun Set[T].`△`(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].`△`(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns values present in exactly one of the Sets.
 
@@ -196,7 +196,7 @@ Empty sets return true.
 Returns true when at least one value satisfies `predicate`.
 
 
-===== fun Set[T].cartesian_product(other: xref:#type-Set[Set][U]): xref:#type-Set[Set][xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][T, U]]
+===== fun Set[T].cartesian_product(other: xref:#type-Set[Set]&#91;U&#93;): xref:#type-Set[Set]&#91;xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;T, U&#93;&#93;
 
 Returns all ordered pairs from this Set and `other`.
 
@@ -216,7 +216,7 @@ Examples:
 Returns true when this Set contains the given value.
 
 
-===== fun Set[T].difference(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].difference(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns values present in this Set but not in `other`.
 
@@ -230,7 +230,7 @@ Examples and counter-examples:
 ```
 
 
-===== fun Set[T].filter(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+===== fun Set[T].filter(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence containing only values that satisfy `predicate`.
 
@@ -240,7 +240,7 @@ Example:
 ```
 
 
-===== fun Set[T].flat_map(map: T=>Set[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun Set[T].flat_map(map: T=>Set[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` to each value and concatenates the resulting sets.
 
@@ -250,7 +250,7 @@ Example:
 ```
 
 
-===== fun Set[T].intersection(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].intersection(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns values present in both Sets.
 
@@ -269,7 +269,7 @@ Examples and counter-examples:
 Returns true when this Set has no values.
 
 
-===== fun Set[T].is_proper_subset_of(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].is_proper_subset_of(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when this Set is strictly contained in `other`.
 
@@ -283,7 +283,7 @@ Examples and counter-examples:
 ```
 
 
-===== fun Set[T].is_proper_superset_of(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].is_proper_superset_of(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when this Set strictly contains `other`.
 
@@ -297,7 +297,7 @@ Examples and counter-examples:
 ```
 
 
-===== fun Set[T].is_subset_of(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].is_subset_of(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when every value in this Set exists in `other`.
 
@@ -310,7 +310,7 @@ Examples and counter-examples:
 ```
 
 
-===== fun Set[T].is_superset_of(other: xref:#type-Set[Set][T]): bool
+===== fun Set[T].is_superset_of(other: xref:#type-Set[Set]&#91;T&#93;): bool
 
 Returns true when this Set contains every value in `other`.
 
@@ -323,7 +323,7 @@ Examples and counter-examples:
 ```
 
 
-===== fun Set[T].map(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun Set[T].map(map: T=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each value using `map`.
 
@@ -335,27 +335,27 @@ Example:
 ```
 
 
-===== fun Set[T].minus(value: T): xref:#type-Set[Set][T]
+===== fun Set[T].minus(value: T): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set without `value`.
 
 
-===== fun Set[T].minus(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].minus(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set without values contained in `other`.
 
 
-===== fun Set[T].plus(value: T): xref:#type-Set[Set][T]
+===== fun Set[T].plus(value: T): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set with `value` included.
 
 
-===== fun Set[T].plus(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].plus(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns a new Set with all values from `other` included.
 
 
-===== fun Set[T].power_set(): xref:#type-Set[Set][xref:#type-Set[Set][T]]
+===== fun Set[T].power_set(): xref:#type-Set[Set]&#91;xref:#type-Set[Set]&#91;T&#93;&#93;
 
 Returns the Set of all subsets of this Set.
 
@@ -382,7 +382,7 @@ The iteration order is runtime-defined, so use reducers that do not depend
 on a specific set order.
 
 
-===== fun Set[T].reject(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+===== fun Set[T].reject(predicate: T=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 Returns a sequence without values that satisfy `predicate`.
 
@@ -392,7 +392,7 @@ Returns a sequence without values that satisfy `predicate`.
 Returns the number of values in this Set.
 
 
-===== fun Set[T].symmetric_difference(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].symmetric_difference(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Returns values present in exactly one of the Sets.
 
@@ -406,12 +406,12 @@ Examples:
 ```
 
 
-===== fun Set[T].to_list(): xref:../../capy/collection/List.adoc#type-List[List][T]
+===== fun Set[T].to_list(): xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;
 
 Returns the Set values as a List.
 
 
-===== fun Set[T].union(other: xref:#type-Set[Set][T]): xref:#type-Set[Set][T]
+===== fun Set[T].union(other: xref:#type-Set[Set]&#91;T&#93;): xref:#type-Set[Set]&#91;T&#93;
 
 Combines all values from both Sets.
 

--- a/docs/capy-docs/SNAPSHOT/capy/date_time/Clock.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/date_time/Clock.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun now(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/date_time/DateTime.adoc#type-DateTime[DateTime]]
+=== fun now(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/date_time/DateTime.adoc#type-DateTime[DateTime]&#93;
 
 Returns the current date-time as an effect.
 

--- a/docs/capy-docs/SNAPSHOT/capy/date_time/Date.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/date_time/Date.adoc
@@ -9,7 +9,7 @@ Converts days since Unix epoch (`1970-01-01`) to `Date`.
 Example: `from_days_since_unix_epoch(1)` returns `1970-01-02`.
 
 
-=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Date[Date]]
+=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Date[Date]&#93;
 
 Parses an ISO 8601 calendar date in basic or extended complete form.
 

--- a/docs/capy-docs/SNAPSHOT/capy/date_time/DateTime.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/date_time/DateTime.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-DateTime[DateTime]]
+=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-DateTime[DateTime]&#93;
 
 Parses a UTC ISO 8601 date-time in basic or extended form.
 

--- a/docs/capy-docs/SNAPSHOT/capy/date_time/Duration.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/date_time/Duration.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Duration[Duration]]
+=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Duration[Duration]&#93;
 
 Parses an ISO 8601 duration string.
 
@@ -72,7 +72,7 @@ DateDuration { years: 3, months: 6, days: 4, hours: 12, minutes: 30, seconds: 5 
 [[type-Duration]]
 === union Duration
 
-[ISO 8601 - Durations](https://en.wikipedia.org/wiki/ISO_860101)
+https://en.wikipedia.org/wiki/ISO_860101[ISO 8601 - Durations]
 
 Represents a calendar/time duration using integer components.
 

--- a/docs/capy-docs/SNAPSHOT/capy/date_time/Interval.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/date_time/Interval.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Interval[Interval]]
+=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Interval[Interval]&#93;
 
 Parses an ISO 8601 interval in one of these forms:
 - `<start>/<end>`

--- a/docs/capy-docs/SNAPSHOT/capy/date_time/Time.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/date_time/Time.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Time[Time]]
+=== fun from_iso_8601(iso: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Time[Time]&#93;
 
 Parses an ISO 8601 time in basic or extended complete form.
 
@@ -94,7 +94,7 @@ Time {
 
 * `hour`: xref:#type-hour[hour]
 * `minute`: xref:#type-minute[minute]
-* `offset_minutes`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-offset_minutes[offset_minutes]]
+* `offset_minutes`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-offset_minutes[offset_minutes]&#93;
 * `second`: xref:#type-second[second]
 
 ==== Functions

--- a/docs/capy-docs/SNAPSHOT/capy/io/ByteSize.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/io/ByteSize.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun add_byte_count(left: xref:#type-byte_count[byte_count], right: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-byte_count[byte_count]]
+=== fun add_byte_count(left: xref:#type-byte_count[byte_count], right: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-byte_count[byte_count]&#93;
 
 Function form of `left + right`.
 
@@ -22,7 +22,7 @@ Function form of `value.to_kib()`.
 Function form of `value.to_mib()`.
 
 
-=== fun subtract_byte_count(left: xref:#type-byte_count[byte_count], right: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-byte_count[byte_count]]
+=== fun subtract_byte_count(left: xref:#type-byte_count[byte_count], right: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-byte_count[byte_count]&#93;
 
 Function form of `left - right`.
 
@@ -70,11 +70,11 @@ Non-negative number of bytes.
 
 ==== Functions
 
-===== fun byte_count.`+`(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-byte_count[byte_count]]
+===== fun byte_count.`+`(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-byte_count[byte_count]&#93;
 
 
 
-===== fun byte_count.`-`(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-byte_count[byte_count]]
+===== fun byte_count.`-`(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-byte_count[byte_count]&#93;
 
 
 
@@ -98,14 +98,14 @@ Non-negative number of bytes.
 
 
 
-===== fun byte_count.minus(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-byte_count[byte_count]]
+===== fun byte_count.minus(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-byte_count[byte_count]&#93;
 
 Subtracts `other` from this byte count.
 
 The result is an error when subtraction would produce a negative byte count.
 
 
-===== fun byte_count.plus(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-byte_count[byte_count]]
+===== fun byte_count.plus(other: xref:#type-byte_count[byte_count]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-byte_count[byte_count]&#93;
 
 Adds two byte counts, returning `Error` on long overflow.
 

--- a/docs/capy-docs/SNAPSHOT/capy/io/Console.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/io/Console.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun print(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/String.adoc#type-String[String]]
+=== fun print(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Writes a string to standard output without a trailing newline and returns the consumed value.
 
@@ -14,42 +14,42 @@ println("ready")
 Use `println` when a trailing newline should be written.
 
 
-=== fun print(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][byte]
+=== fun print(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;byte&#93;
 
 Writes a byte to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][int]
+=== fun print(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;int&#93;
 
 Writes an int to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][long]
+=== fun print(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;long&#93;
 
 Writes a long to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][float]
+=== fun print(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;float&#93;
 
 Writes a float to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][double]
+=== fun print(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;double&#93;
 
 Writes a double to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun print(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Writes a bool to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print(text: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/collection/List.adoc#type-List[List][byte]]
+=== fun print(text: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;
 
 Writes bytes to standard output without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/String.adoc#type-String[String]]
+=== fun print_error(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Writes a string to standard error without a trailing newline and returns the consumed value.
 
@@ -60,42 +60,42 @@ println_error("configuration missing")
 ```
 
 
-=== fun print_error(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][byte]
+=== fun print_error(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;byte&#93;
 
 Writes a byte to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][int]
+=== fun print_error(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;int&#93;
 
 Writes an int to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][long]
+=== fun print_error(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;long&#93;
 
 Writes a long to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][float]
+=== fun print_error(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;float&#93;
 
 Writes a float to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][double]
+=== fun print_error(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;double&#93;
 
 Writes a double to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun print_error(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Writes a bool to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun print_error(text: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/collection/List.adoc#type-List[List][byte]]
+=== fun print_error(text: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;
 
 Writes bytes to standard error without a trailing newline and returns the consumed value.
 
 
-=== fun println(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/String.adoc#type-String[String]]
+=== fun println(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Writes a string to standard output followed by a newline and returns the consumed value.
 
@@ -103,42 +103,42 @@ Writes a string to standard output followed by a newline and returns the consume
 for later effect composition.
 
 
-=== fun println(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][byte]
+=== fun println(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;byte&#93;
 
 Writes a byte to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][int]
+=== fun println(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;int&#93;
 
 Writes an int to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][long]
+=== fun println(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;long&#93;
 
 Writes a long to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][float]
+=== fun println(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;float&#93;
 
 Writes a float to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][double]
+=== fun println(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;double&#93;
 
 Writes a double to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun println(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Writes a bool to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println(text: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/collection/List.adoc#type-List[List][byte]]
+=== fun println(text: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;
 
 Writes bytes to standard output followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/String.adoc#type-String[String]]
+=== fun println_error(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Writes a string to standard error followed by a newline and returns the consumed value.
 
@@ -146,42 +146,42 @@ Use this for diagnostics, progress messages, or errors that should not be
 mixed with normal program output.
 
 
-=== fun println_error(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][byte]
+=== fun println_error(text: byte): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;byte&#93;
 
 Writes a byte to standard error followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][int]
+=== fun println_error(text: int): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;int&#93;
 
 Writes an int to standard error followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][long]
+=== fun println_error(text: long): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;long&#93;
 
 Writes a long to standard error followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][float]
+=== fun println_error(text: float): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;float&#93;
 
 Writes a float to standard error followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][double]
+=== fun println_error(text: double): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;double&#93;
 
 Writes a double to standard error followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun println_error(text: bool): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Writes a bool to standard error followed by a newline and returns the consumed value.
 
 
-=== fun println_error(text: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/collection/List.adoc#type-List[List][byte]]
+=== fun println_error(text: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;
 
 Writes bytes to standard error followed by a newline and returns the consumed value.
 
 
-=== fun read_line(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]]
+=== fun read_line(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Reads one line from standard input, or None at end of input.
 

--- a/docs/capy-docs/SNAPSHOT/capy/io/IO.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/io/IO.adoc
@@ -2,17 +2,17 @@
 
 == Functions
 
-=== fun append_bytes(path: xref:../../capy/io/Path.adoc#type-Path[Path], bytes: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][byte]]]
+=== fun append_bytes(path: xref:../../capy/io/Path.adoc#type-Path[Path], bytes: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;&#93;
 
 Appends bytes to the file, creating the file when needed, and returns the consumed bytes.
 
 
-=== fun append_lines(path: xref:../../capy/io/Path.adoc#type-Path[Path], lines: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]]]
+=== fun append_lines(path: xref:../../capy/io/Path.adoc#type-Path[Path], lines: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;&#93;
 
 Appends UTF-8 lines to the file, creating the file when needed, and returns the consumed lines.
 
 
-=== fun append_text(path: xref:../../capy/io/Path.adoc#type-Path[Path], text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+=== fun append_text(path: xref:../../capy/io/Path.adoc#type-Path[Path], text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Appends UTF-8 text to the file, creating the file when needed, and returns the consumed text.
 
@@ -23,19 +23,19 @@ let _ <- append_text(from_string("app.log"), "started\n")
 The file is created if it does not already exist.
 
 
-=== fun copy(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun copy(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Copies a file and returns the target path. Fails if the target already exists.
 
 Use `copy_replace` when overwriting the target is intentional.
 
 
-=== fun copy_replace(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun copy_replace(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Copies a file and returns the target path, replacing an existing target.
 
 
-=== fun create_directories(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun create_directories(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Creates a directory and any missing parent directories, returning the created path.
 
@@ -46,22 +46,22 @@ let created <- create_directories(from_string("reports/2026/06"))
 Use this for nested output directories where parent paths may not exist yet.
 
 
-=== fun create_directory(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun create_directory(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Creates a single directory and returns the created path.
 
 
-=== fun create_file(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun create_file(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Creates a new empty file and returns the created path.
 
 
-=== fun delete(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][bool]]
+=== fun delete(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;bool&#93;&#93;
 
 Deletes a file or empty directory and returns true when something was deleted.
 
 
-=== fun exists(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun exists(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Returns true when the path exists.
 
@@ -72,39 +72,39 @@ if present then "configured" else "missing config"
 ```
 
 
-=== fun is_directory(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun is_directory(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Returns true when the path exists and is a directory.
 
 
-=== fun is_file(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+=== fun is_file(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Returns true when the path exists and is a regular file.
 
 
-=== fun list_entries(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/io/Path.adoc#type-Path[Path]]]]
+=== fun list_entries(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;&#93;
 
 Lists direct child entries of a directory.
 
 
-=== fun move(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun move(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Moves a file or directory and returns the target path. Fails if the target already exists.
 
 Use `move_replace` when overwriting the target is intentional.
 
 
-=== fun move_replace(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/Path.adoc#type-Path[Path]]]
+=== fun move_replace(source: xref:../../capy/io/Path.adoc#type-Path[Path], target: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;
 
 Moves a file or directory and returns the target path, replacing an existing target.
 
 
-=== fun read_bytes(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][byte]]]
+=== fun read_bytes(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;&#93;
 
 Reads the entire file as bytes.
 
 
-=== fun read_lines(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]]]
+=== fun read_lines(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;&#93;
 
 Reads all lines from the file as UTF-8 text.
 
@@ -112,7 +112,7 @@ The returned list contains text lines without requiring callers to split the
 file manually.
 
 
-=== fun read_text(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+=== fun read_text(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Reads the entire file as UTF-8 text.
 
@@ -127,24 +127,24 @@ File operations are effects because they interact with the host file system.
 The inner `Result` reports path, permission, or decoding failures.
 
 
-=== fun size(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/ByteSize.adoc#type-byte_count[byte_count]]]
+=== fun size(path: xref:../../capy/io/Path.adoc#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/ByteSize.adoc#type-byte_count[byte_count]&#93;&#93;
 
 Returns the size of a file in bytes.
 
 The byte count can be converted with `to_kib`, `to_mib`, or `to_gib`.
 
 
-=== fun write_bytes(path: xref:../../capy/io/Path.adoc#type-Path[Path], bytes: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][byte]]]
+=== fun write_bytes(path: xref:../../capy/io/Path.adoc#type-Path[Path], bytes: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;&#93;
 
 Writes bytes to the file, replacing existing content, and returns the consumed bytes.
 
 
-=== fun write_lines(path: xref:../../capy/io/Path.adoc#type-Path[Path], lines: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]]]
+=== fun write_lines(path: xref:../../capy/io/Path.adoc#type-Path[Path], lines: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;&#93;
 
 Writes UTF-8 lines to the file, replacing existing content, and returns the consumed lines.
 
 
-=== fun write_text(path: xref:../../capy/io/Path.adoc#type-Path[Path], text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+=== fun write_text(path: xref:../../capy/io/Path.adoc#type-Path[Path], text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Writes UTF-8 text to the file, replacing existing content, and returns the consumed text.
 

--- a/docs/capy-docs/SNAPSHOT/capy/io/Path.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/io/Path.adoc
@@ -34,9 +34,9 @@ The root remains `HOME`, and each joined segment is normalized separately.
 
 ==== Fields
 
-* `prefix`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
+* `prefix`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 * `root`: xref:#type-PathRoot[PathRoot]
-* `segments`: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]
+* `segments`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 ==== Functions
 
@@ -59,52 +59,52 @@ The root of `this` is preserved, so use this to join a base directory with a
 relative child path.
 
 
-===== fun Path.append_bytes(bytes: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][byte]]]
+===== fun Path.append_bytes(bytes: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;&#93;
 
 Appends bytes to this path, creating the file when needed, and returns the consumed bytes.
 
 
-===== fun Path.append_lines(lines: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]]]
+===== fun Path.append_lines(lines: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;&#93;
 
 Appends UTF-8 lines to this path, creating the file when needed, and returns the consumed lines.
 
 
-===== fun Path.append_text(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+===== fun Path.append_text(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Appends UTF-8 text to this path, creating the file when needed, and returns the consumed text.
 
 
-===== fun Path.copy(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.copy(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Copies this file to the target path. Fails if the target already exists.
 
 
-===== fun Path.copy_replace(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.copy_replace(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Copies this file to the target path, replacing an existing target.
 
 
-===== fun Path.create_directories(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.create_directories(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Creates a directory and any missing parent directories at this path, returning the created path.
 
 
-===== fun Path.create_directory(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.create_directory(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Creates a single directory at this path and returns the created path.
 
 
-===== fun Path.create_file(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.create_file(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Creates a new empty file at this path and returns the created path.
 
 
-===== fun Path.delete(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][bool]]
+===== fun Path.delete(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;bool&#93;&#93;
 
 Deletes the file or empty directory at this path and returns true when something was deleted.
 
 
-===== fun Path.exists(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+===== fun Path.exists(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Returns true when this path exists.
 
@@ -114,12 +114,12 @@ Returns true when this path exists.
 Returns true for absolute, home-rooted, and temp-rooted paths.
 
 
-===== fun Path.is_directory(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+===== fun Path.is_directory(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Returns true when this path exists and is a directory.
 
 
-===== fun Path.is_file(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][bool]
+===== fun Path.is_file(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;bool&#93;
 
 Returns true when this path exists and is a regular file.
 
@@ -129,17 +129,17 @@ Returns true when this path exists and is a regular file.
 Returns true when the path has a root but no child segments.
 
 
-===== fun Path.list_entries(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:#type-Path[Path]]]]
+===== fun Path.list_entries(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-Path[Path]&#93;&#93;&#93;
 
 Lists direct child entries of this directory.
 
 
-===== fun Path.move(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.move(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Moves this file or directory to the target path. Fails if the target already exists.
 
 
-===== fun Path.move_replace(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-Path[Path]]]
+===== fun Path.move_replace(target: xref:#type-Path[Path]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-Path[Path]&#93;&#93;
 
 Moves this file or directory to the target path, replacing an existing target.
 
@@ -166,7 +166,7 @@ from_string("src/./main/../test").normalize()
 Produces the relative path `src/test`.
 
 
-===== fun Path.parent(): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Path[Path]]
+===== fun Path.parent(): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Path[Path]&#93;
 
 Returns the parent path, or `None` when this path has no parent segment.
 
@@ -177,37 +177,37 @@ from_string("docs/api/json.md").parent()
 Returns `Some` containing `docs/api`.
 
 
-===== fun Path.read_bytes(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][byte]]]
+===== fun Path.read_bytes(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;&#93;
 
 Reads the entire file at this path as bytes.
 
 
-===== fun Path.read_lines(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]]]
+===== fun Path.read_lines(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;&#93;
 
 Reads all lines from the file at this path as UTF-8 text.
 
 
-===== fun Path.read_text(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+===== fun Path.read_text(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Reads the entire file at this path as UTF-8 text.
 
 
-===== fun Path.size(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/io/ByteSize.adoc#type-byte_count[byte_count]]]
+===== fun Path.size(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/io/ByteSize.adoc#type-byte_count[byte_count]&#93;&#93;
 
 Returns the size of this file in bytes.
 
 
-===== fun Path.write_bytes(bytes: xref:../../capy/collection/List.adoc#type-List[List][byte]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][byte]]]
+===== fun Path.write_bytes(bytes: xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;byte&#93;&#93;&#93;
 
 Writes bytes to this path, replacing existing content, and returns the consumed bytes.
 
 
-===== fun Path.write_lines(lines: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]]]
+===== fun Path.write_lines(lines: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;&#93;
 
 Writes UTF-8 lines to this path, replacing existing content, and returns the consumed lines.
 
 
-===== fun Path.write_text(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+===== fun Path.write_text(text: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Writes UTF-8 text to this path, replacing existing content, and returns the consumed text.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Effect.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Effect.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun delay(thunk: ()=>T): xref:#type-Effect[Effect][T]
+=== fun delay(thunk: ()=>T): xref:#type-Effect[Effect]&#91;T&#93;
 
 Defers a thunk until the effect is executed.
 
@@ -10,7 +10,7 @@ Use this for computations that should not happen while the effect is being
 constructed.
 
 
-=== fun pure(value: T): xref:#type-Effect[Effect][T]
+=== fun pure(value: T): xref:#type-Effect[Effect]&#91;T&#93;
 
 Wraps a pure value in an effect.
 
@@ -38,17 +38,17 @@ let program =
 
 ==== Functions
 
-===== fun Effect[T].`|*`(flatmap: T=>Effect[Y]): xref:#type-Effect[Effect][Y]
+===== fun Effect[T].`|*`(flatmap: T=>Effect[Y]): xref:#type-Effect[Effect]&#91;Y&#93;
 
 Operator alias for `flat_map`.
 
 
-===== fun Effect[T].`|`(map: T=>Y): xref:#type-Effect[Effect][Y]
+===== fun Effect[T].`|`(map: T=>Y): xref:#type-Effect[Effect]&#91;Y&#93;
 
 Operator alias for `map`.
 
 
-===== fun Effect[T].flat_map(flatmap: T=>Effect[Y]): xref:#type-Effect[Effect][Y]
+===== fun Effect[T].flat_map(flatmap: T=>Effect[Y]): xref:#type-Effect[Effect]&#91;Y&#93;
 
 Sequences this effect and then returns the effect produced by `flatmap`.
 
@@ -60,7 +60,7 @@ read_text(path).flat_map(result =>
 ```
 
 
-===== fun Effect[T].map(map: T=>Y): xref:#type-Effect[Effect][Y]
+===== fun Effect[T].map(map: T=>Y): xref:#type-Effect[Effect]&#91;Y&#93;
 
 Transforms the produced value without executing the effect immediately.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Either.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Either.adoc
@@ -12,8 +12,8 @@ the primary success branch.
 
 ==== Variants
 
-* xref:#type-Left[Left][L, R]
-* xref:#type-Right[Right][L, R]
+* xref:#type-Left[Left]&#91;L, R&#93;
+* xref:#type-Right[Right]&#91;L, R&#93;
 
 ==== Functions
 
@@ -22,22 +22,22 @@ the primary success branch.
 Reduces this value by applying the function for the current branch.
 
 
-===== fun Either[L,R].flat_map_left(map: L=>Either[Y,R]): xref:#type-Either[Either][Y, R]
+===== fun Either[L,R].flat_map_left(map: L=>Either[Y,R]): xref:#type-Either[Either]&#91;Y, R&#93;
 
 Transforms the `Left` value into another `Either`.
 
 
-===== fun Either[L,R].flat_map_right(map: R=>Either[L,Y]): xref:#type-Either[Either][L, Y]
+===== fun Either[L,R].flat_map_right(map: R=>Either[L,Y]): xref:#type-Either[Either]&#91;L, Y&#93;
 
 Transforms the `Right` value into another `Either`.
 
 
-===== fun Either[L,R].map_left(map: L=>Y): xref:#type-Either[Either][Y, R]
+===== fun Either[L,R].map_left(map: L=>Y): xref:#type-Either[Either]&#91;Y, R&#93;
 
 Transforms the `Left` value and leaves `Right` unchanged.
 
 
-===== fun Either[L,R].map_right(map: R=>Y): xref:#type-Either[Either][L, Y]
+===== fun Either[L,R].map_right(map: R=>Y): xref:#type-Either[Either]&#91;L, Y&#93;
 
 Transforms the `Right` value and leaves `Left` unchanged.
 
@@ -47,12 +47,12 @@ Transforms the `Right` value and leaves `Left` unchanged.
 Reduces this value by applying the function for the current branch.
 
 
-===== fun Either[L,R].swap(): xref:#type-Either[Either][R, L]
+===== fun Either[L,R].swap(): xref:#type-Either[Either]&#91;R, L&#93;
 
 Swaps `Left` and `Right`.
 
 
-===== fun Either[L,R].to_result(left_to_message: L=>String): xref:../../capy/lang/Result.adoc#type-Result[Result][R]
+===== fun Either[L,R].to_result(left_to_message: L=>String): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;R&#93;
 
 Converts this `Either` into a string-error `Result`.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Math.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Math.adoc
@@ -51,7 +51,7 @@ Result has the same sign as divisor `b` (or is zero).
 Returns the greater of two integers.
 
 
-=== fun max(values: xref:../../capy/collection/List.adoc#type-List[List][int]): xref:../../capy/lang/Option.adoc#type-Option[Option][int]
+=== fun max(values: xref:../../capy/collection/List.adoc#type-List[List]&#91;int&#93;): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
 
 Returns the greatest integer in `values`.
 
@@ -63,7 +63,7 @@ Returns `None` when the List is empty.
 Returns the greater of two long integers.
 
 
-=== fun max(values: xref:../../capy/collection/List.adoc#type-List[List][long]): xref:../../capy/lang/Option.adoc#type-Option[Option][long]
+=== fun max(values: xref:../../capy/collection/List.adoc#type-List[List]&#91;long&#93;): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;long&#93;
 
 Returns the greatest long integer in `values`.
 
@@ -75,7 +75,7 @@ Returns `None` when the List is empty.
 Returns the smaller of two integers.
 
 
-=== fun min(values: xref:../../capy/collection/List.adoc#type-List[List][int]): xref:../../capy/lang/Option.adoc#type-Option[Option][int]
+=== fun min(values: xref:../../capy/collection/List.adoc#type-List[List]&#91;int&#93;): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
 
 Returns the smallest integer in `values`.
 
@@ -87,7 +87,7 @@ Returns `None` when the List is empty.
 Returns the smaller of two long integers.
 
 
-=== fun min(values: xref:../../capy/collection/List.adoc#type-List[List][long]): xref:../../capy/lang/Option.adoc#type-Option[Option][long]
+=== fun min(values: xref:../../capy/collection/List.adoc#type-List[List]&#91;long&#93;): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;long&#93;
 
 Returns the smallest long integer in `values`.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Option.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Option.adoc
@@ -22,18 +22,18 @@ The result is `Some { value: "Ada!" }`. Mapping `None` returns `None`.
 ==== Variants
 
 * xref:#type-None[None]
-* xref:#type-Some[Some][T]
+* xref:#type-Some[Some]&#91;T&#93;
 
 ==== Functions
 
-===== fun Option[T].`|*`(flatmap: T=>Option[Y]): xref:#type-Option[Option][Y]
+===== fun Option[T].`|*`(flatmap: T=>Option[Y]): xref:#type-Option[Option]&#91;Y&#93;
 
 Applies `flatmap` to a present value; equivalent to `this.flat_map(flatmap)`.
 
 Use this when the mapping function already returns an `Option`.
 
 
-===== fun Option[T].`|`(map: T=>Y): xref:#type-Option[Option][Y]
+===== fun Option[T].`|`(map: T=>Y): xref:#type-Option[Option]&#91;Y&#93;
 
 Transforms a present value using `map`; equivalent to `this.map(map)`.
 
@@ -41,7 +41,7 @@ Example: `Some { value: 2 } | value => value * 2` returns
 `Some { value: 4 }`.
 
 
-===== fun Option[T].flat_map(flatmap: T=>Option[Y]): xref:#type-Option[Option][Y]
+===== fun Option[T].flat_map(flatmap: T=>Option[Y]): xref:#type-Option[Option]&#91;Y&#93;
 
 Applies `flatmap` to a present value, or returns None when empty.
 
@@ -52,7 +52,7 @@ Some { value: "capy" }.flat_map(text => text[0])
 The outer option stays empty if the original value is `None`.
 
 
-===== fun Option[T].map(map: T=>Y): xref:#type-Option[Option][Y]
+===== fun Option[T].map(map: T=>Y): xref:#type-Option[Option]&#91;Y&#93;
 
 Transforms a present value using `map`, or returns None when empty.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Primitives.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Primitives.adoc
@@ -6,31 +6,31 @@
 
 
 
-=== fun safe_long_to_int(value: long): xref:../../capy/lang/Result.adoc#type-Result[Result][int]
+=== fun safe_long_to_int(value: long): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;int&#93;
 
 
 
-=== fun to_bool(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][bool]
+=== fun to_bool(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;bool&#93;
 
 Parses this String as a bool.
 
 
-=== fun to_double(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][double]
+=== fun to_double(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;double&#93;
 
 Parses this String as a double.
 
 
-=== fun to_float(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][float]
+=== fun to_float(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;float&#93;
 
 Parses this String as a float.
 
 
-=== fun to_int(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][int]
+=== fun to_int(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;int&#93;
 
 Parses this String as an int.
 
 
-=== fun to_long(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][long]
+=== fun to_long(s: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;long&#93;
 
 Parses this String as a long.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Random.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Random.adoc
@@ -28,52 +28,52 @@ Immutable random generator state.
 
 ==== Functions
 
-===== fun seed.random_bool(): xref:#type-RandomResult[RandomResult][bool]
+===== fun seed.random_bool(): xref:#type-RandomResult[RandomResult]&#91;bool&#93;
 
 Returns a random `bool` and the next seed.
 
 
-===== fun seed.random_bools(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons][bool]
+===== fun seed.random_bools(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons]&#91;bool&#93;
 
 Returns an infinite sequence of random `bool` values.
 
 
-===== fun seed.random_double(): xref:#type-RandomResult[RandomResult][double]
+===== fun seed.random_double(): xref:#type-RandomResult[RandomResult]&#91;double&#93;
 
 Returns a random `double` in `[0.0, 1.0]` and the next seed.
 
 
-===== fun seed.random_doubles(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons][double]
+===== fun seed.random_doubles(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons]&#91;double&#93;
 
 Returns an infinite sequence of random `double` values in `[0.0, 1.0]`.
 
 
-===== fun seed.random_float(): xref:#type-RandomResult[RandomResult][float]
+===== fun seed.random_float(): xref:#type-RandomResult[RandomResult]&#91;float&#93;
 
 Returns a random `float` in `[0.0f, 1.0f]` and the next seed.
 
 
-===== fun seed.random_floats(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons][float]
+===== fun seed.random_floats(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons]&#91;float&#93;
 
 Returns an infinite sequence of random `float` values in `[0.0f, 1.0f]`.
 
 
-===== fun seed.random_int(): xref:#type-RandomResult[RandomResult][int]
+===== fun seed.random_int(): xref:#type-RandomResult[RandomResult]&#91;int&#93;
 
 Returns a random `int` and the next seed.
 
 
-===== fun seed.random_ints(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons][int]
+===== fun seed.random_ints(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons]&#91;int&#93;
 
 Returns an infinite sequence of random `int` values.
 
 
-===== fun seed.random_long(): xref:#type-RandomResult[RandomResult][long]
+===== fun seed.random_long(): xref:#type-RandomResult[RandomResult]&#91;long&#93;
 
 Returns a random `long` and the next seed.
 
 
-===== fun seed.random_longs(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons][long]
+===== fun seed.random_longs(): xref:../../capy/collection/Seq.adoc#type-Cons[Cons]&#91;long&#93;
 
 Returns an infinite sequence of random `long` values.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Regex.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Regex.adoc
@@ -27,14 +27,14 @@ Single regex match.
 
 ==== Functions
 
-===== fun Match.group(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
+===== fun Match.group(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Returns the capture group at `idx`.
 
 Current matches expose the full match at index `0`.
 
 
-===== fun Match.groups(): xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]]
+===== fun Match.groups(): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Returns all capture groups for this match.
 
@@ -59,7 +59,7 @@ digits.matches("123")
 
 ==== Functions
 
-===== fun Regex.`/>`(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]
+===== fun Regex.`/>`(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Operator alias for `split`.
 
@@ -80,22 +80,22 @@ Example:
 Returns `a#b#`.
 
 
-===== fun Regex.`~`(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Match[Match]]
+===== fun Regex.`~`(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Match[Match]&#93;
 
 Operator alias for `find`.
 
 
-===== fun Regex.`~~`(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][xref:#type-Match[Match]]
+===== fun Regex.`~~`(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;xref:#type-Match[Match]&#93;
 
 Operator alias for `find_all`.
 
 
-===== fun Regex.find(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Match[Match]]
+===== fun Regex.find(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Match[Match]&#93;
 
 Returns the first match, or `None` when no match exists.
 
 
-===== fun Regex.find_all(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][xref:#type-Match[Match]]
+===== fun Regex.find_all(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;xref:#type-Match[Match]&#93;
 
 Returns all matches as a lazy sequence.
 
@@ -125,7 +125,7 @@ redact_digits("room 42")
 Returns `room #`.
 
 
-===== fun Regex.split(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]
+===== fun Regex.split(input: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 Splits `input` around this regex pattern.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/Result.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/Result.adoc
@@ -12,7 +12,7 @@ Creates a generic Error with kind `capy.error`.
 Creates an Error with an explicit source location.
 
 
-=== fun error_full(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String], details: xref:../../capy/lang/Option.adoc#type-Option[Option][data], location: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-SourceLocation[SourceLocation]], stack_trace: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-StackFrame[StackFrame]], raw_stack: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]], cause: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Error[Error]], suppressed: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-Error[Error]]): xref:#type-Error[Error]
+=== fun error_full(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String], details: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;data&#93;, location: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-SourceLocation[SourceLocation]&#93;, stack_trace: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-StackFrame[StackFrame]&#93;, raw_stack: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;, cause: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Error[Error]&#93;, suppressed: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-Error[Error]&#93;): xref:#type-Error[Error]
 
 Creates an Error with all structured fields supplied by the caller.
 
@@ -27,22 +27,22 @@ Creates an Error with a stable kind and no structured details.
 Creates an Error with a stable kind and structured details.
 
 
-=== fun fail(message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Result[Result][T]
+=== fun fail(message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Result[Result]&#91;T&#93;
 
 Returns a failed Result with a generic Error.
 
 
-=== fun fail_error(error: xref:#type-Error[Error]): xref:#type-Result[Result][T]
+=== fun fail_error(error: xref:#type-Error[Error]): xref:#type-Result[Result]&#91;T&#93;
 
 Returns a failed Result from an existing Error.
 
 
-=== fun fail_kind(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Result[Result][T]
+=== fun fail_kind(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-Result[Result]&#91;T&#93;
 
 Returns a failed Result with a stable error kind.
 
 
-=== fun fail_with(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String], details: data): xref:#type-Result[Result][T]
+=== fun fail_with(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String], details: data): xref:#type-Result[Result]&#91;T&#93;
 
 Returns a failed Result with structured error details.
 
@@ -58,14 +58,14 @@ Structured recoverable failure value.
 
 ==== Fields
 
-* `cause`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Error[Error]]
-* `details`: xref:../../capy/lang/Option.adoc#type-Option[Option][data]
+* `cause`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Error[Error]&#93;
+* `details`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;data&#93;
 * `kind`: xref:../../capy/lang/String.adoc#type-String[String]
-* `location`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-SourceLocation[SourceLocation]]
+* `location`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-SourceLocation[SourceLocation]&#93;
 * `message`: xref:../../capy/lang/String.adoc#type-String[String]
-* `raw_stack`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
-* `stack_trace`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-StackFrame[StackFrame]]
-* `suppressed`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-Error[Error]]
+* `raw_stack`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
+* `stack_trace`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-StackFrame[StackFrame]&#93;
+* `suppressed`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-Error[Error]&#93;
 
 ==== Functions
 
@@ -119,12 +119,12 @@ Returns a copy of this Error with another message.
 Returns a copy of this Error with another raw backend stack.
 
 
-===== fun Error.with_stack_trace(stack_trace: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-StackFrame[StackFrame]]): xref:#type-Error[Error]
+===== fun Error.with_stack_trace(stack_trace: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-StackFrame[StackFrame]&#93;): xref:#type-Error[Error]
 
 Returns a copy of this Error with another stack trace.
 
 
-===== fun Error.with_suppressed(suppressed: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-Error[Error]]): xref:#type-Error[Error]
+===== fun Error.with_suppressed(suppressed: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-Error[Error]&#93;): xref:#type-Error[Error]
 
 Returns a copy of this Error with another suppressed error list.
 
@@ -141,21 +141,21 @@ exceptions.
 ==== Variants
 
 * xref:#type-Error[Error]
-* xref:#type-Success[Success][T]
+* xref:#type-Success[Success]&#91;T&#93;
 
 ==== Functions
 
-===== fun Result[T].`|*`(flatmap: T=>Result[Y]): xref:#type-Result[Result][Y]
+===== fun Result[T].`|*`(flatmap: T=>Result[Y]): xref:#type-Result[Result]&#91;Y&#93;
 
 Applies `flatmap` to a successful value; equivalent to `this.flat_map(flatmap)`.
 
 
-===== fun Result[T].`|>`(reduce: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][T=>R, Error=>R]): R
+===== fun Result[T].`|>`(reduce: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;T=>R, Error=>R&#93;): R
 
 Reduces a Result by applying the first function to Success or the second function to Error.
 
 
-===== fun Result[T].`|`(map: T=>Y): xref:#type-Result[Result][Y]
+===== fun Result[T].`|`(map: T=>Y): xref:#type-Result[Result]&#91;Y&#93;
 
 Transforms a successful value using `map`; equivalent to `this.map(map)`.
 
@@ -165,22 +165,22 @@ Transforms a successful value using `map`; equivalent to `this.map(map)`.
 Returns the error message, or an empty string when this Result is successful.
 
 
-===== fun Result[T].flat_map(flatmap: T=>Result[Y]): xref:#type-Result[Result][Y]
+===== fun Result[T].flat_map(flatmap: T=>Result[Y]): xref:#type-Result[Result]&#91;Y&#93;
 
 Applies `flatmap` to a successful value, or propagates an Error unchanged.
 
 
-===== fun Result[T].map(map: T=>Y): xref:#type-Result[Result][Y]
+===== fun Result[T].map(map: T=>Y): xref:#type-Result[Result]&#91;Y&#93;
 
 Transforms a successful value using `map`, or propagates an Error unchanged.
 
 
-===== fun Result[T].map_error(map: Error=>Error): xref:#type-Result[Result][T]
+===== fun Result[T].map_error(map: Error=>Error): xref:#type-Result[Result]&#91;T&#93;
 
 Maps an Error while preserving successful values.
 
 
-===== fun Result[T].or(r: xref:#type-Result[Result][T]): xref:#type-Result[Result][T]
+===== fun Result[T].or(r: xref:#type-Result[Result]&#91;T&#93;): xref:#type-Result[Result]&#91;T&#93;
 
 Returns this Result when successful, or `r` when this Result is an Error.
 
@@ -195,7 +195,7 @@ Returns the successful value, or `v` when this Result is an Error.
 Recovers an Error into a plain value.
 
 
-===== fun Result[T].recover_result(recover: Error=>Result[T]): xref:#type-Result[Result][T]
+===== fun Result[T].recover_result(recover: Error=>Result[T]): xref:#type-Result[Result]&#91;T&#93;
 
 Recovers an Error into another Result.
 
@@ -217,9 +217,9 @@ Optional source location attached to an Error.
 
 ==== Fields
 
-* `column`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
-* `end_column`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
-* `end_line`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
+* `column`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
+* `end_column`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
+* `end_line`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
 * `file`: xref:../../capy/lang/String.adoc#type-String[String]
 * `line`: int
 
@@ -231,17 +231,17 @@ Portable backend stack frame attached to an Error.
 ==== Fields
 
 * `backend`: xref:../../capy/lang/String.adoc#type-String[String]
-* `column`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
-* `end_column`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
-* `end_line`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
-* `file`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
-* `function`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
-* `line`: xref:../../capy/lang/Option.adoc#type-Option[Option][int]
-* `module`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
+* `column`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
+* `end_column`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
+* `end_line`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
+* `file`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
+* `function`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
+* `line`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;int&#93;
+* `module`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 * `native`: bool
 * `raw`: xref:../../capy/lang/String.adoc#type-String[String]
-* `source_line`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
-* `type_name`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
+* `source_line`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
+* `type_name`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 [[type-Success]]
 === data Success[T]

--- a/docs/capy-docs/SNAPSHOT/capy/lang/String.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/String.adoc
@@ -20,12 +20,12 @@ Returns this String with `value` appended.
 Returns true when this String contains the given substring.
 
 
-===== fun String.`|*`(map: String=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun String.`|*`(map: String=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` to each character and concatenates the resulting lists.
 
 
-===== fun String.`|-`(predicate: String=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][xref:#type-String[String]]
+===== fun String.`|-`(predicate: String=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;xref:#type-String[String]&#93;
 
 Returns a sequence containing only characters that satisfy `predicate`.
 
@@ -35,7 +35,7 @@ Returns a sequence containing only characters that satisfy `predicate`.
 Combines all characters from left to right.
 
 
-===== fun String.`|`(map: String=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun String.`|`(map: String=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each character using `map`.
 
@@ -64,7 +64,7 @@ Returns true when at least one character satisfies `predicate`.
 Returns true when at least one character and index pair satisfies `predicate`.
 
 
-===== fun String.chars(): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][xref:#type-char[char]]
+===== fun String.chars(): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;xref:#type-char[char]&#93;
 
 Returns this String's characters as a finite lazy sequence.
 
@@ -86,17 +86,17 @@ Returns true when this String contains the given substring.
 Returns true when this String ends with the given substring.
 
 
-===== fun String.filter(predicate: String=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][xref:#type-String[String]]
+===== fun String.filter(predicate: String=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;xref:#type-String[String]&#93;
 
 Returns a sequence containing only characters that satisfy `predicate`.
 
 
-===== fun String.flat_map(map: String=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun String.flat_map(map: String=>List[Y]): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Applies `map` to each character and concatenates the resulting lists.
 
 
-===== fun String.get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-char[char]]
+===== fun String.get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-char[char]&#93;
 
 Returns the character at idx as a String using the same bounds and negative-index rules as string[idx].
 
@@ -106,7 +106,7 @@ Returns the character at idx as a String using the same bounds and negative-inde
 Returns the substring in the half-open range [from, to) using negative-index rules.
 
 
-===== fun String.index_of(part: xref:#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/collection/CollectionTypes.adoc#type-index[index]]
+===== fun String.index_of(part: xref:#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/collection/CollectionTypes.adoc#type-index[index]&#93;
 
 Returns the first zero-based index where `part` occurs.
 
@@ -125,14 +125,14 @@ Trim whitespace is space, tab, newline, carriage return, or form feed.
 Returns true when this String has no characters.
 
 
-===== fun String.last_index_of(part: xref:#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/collection/CollectionTypes.adoc#type-index[index]]
+===== fun String.last_index_of(part: xref:#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/collection/CollectionTypes.adoc#type-index[index]&#93;
 
 Returns the last zero-based index where `part` occurs.
 
 Empty `part` matches at this String's size. Missing `part` returns None.
 
 
-===== fun String.map(map: String=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][Y]
+===== fun String.map(map: String=>Y): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;Y&#93;
 
 Transforms each character using `map`.
 
@@ -147,7 +147,7 @@ Returns this String with `value` appended.
 Combines all characters from left to right.
 
 
-===== fun String.reject(predicate: String=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq][xref:#type-String[String]]
+===== fun String.reject(predicate: String=>bool): xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;xref:#type-String[String]&#93;
 
 Returns a sequence without characters that satisfy `predicate`.
 

--- a/docs/capy-docs/SNAPSHOT/capy/lang/System.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/lang/System.adoc
@@ -2,14 +2,14 @@
 
 == Functions
 
-=== fun current_millis(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][long]
+=== fun current_millis(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;long&#93;
 
 Returns an effect that reads the current system time in milliseconds since the Unix epoch.
 
 The value is captured when the effect is run.
 
 
-=== fun nano_time(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][long]
+=== fun nano_time(): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;long&#93;
 
 Returns an effect that reads the current monotonic JVM time in nanoseconds.
 

--- a/docs/capy-docs/SNAPSHOT/capy/meta_prog/Reflection.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/meta_prog/Reflection.adoc
@@ -66,7 +66,7 @@ Reflected annotation with package metadata and argument values.
 
 ==== Fields
 
-* `arguments`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationArgumentInfo[AnnotationArgumentInfo]]
+* `arguments`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationArgumentInfo[AnnotationArgumentInfo]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 * `pkg`: xref:#type-PackageInfo[PackageInfo]
 
@@ -188,7 +188,7 @@ Data declaration metadata without runtime field values.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 * `pkg`: xref:#type-PackageInfo[PackageInfo]
 
@@ -199,8 +199,8 @@ Runtime data value metadata, including constructor name and field values.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
-* `fields`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-FieldValueInfo[FieldValueInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
+* `fields`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-FieldValueInfo[FieldValueInfo]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 * `pkg`: xref:#type-PackageInfo[PackageInfo]
 
@@ -220,7 +220,7 @@ Field declaration metadata.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 * `type`: xref:#type-AnyInfo[AnyInfo]
 
@@ -231,7 +231,7 @@ Field metadata plus the runtime value stored in a reflected data instance.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 * `type`: xref:#type-AnyInfo[AnyInfo]
 * `value`: any
@@ -243,7 +243,7 @@ Function type metadata.
 
 ==== Fields
 
-* `params`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnyInfo[AnyInfo]]
+* `params`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnyInfo[AnyInfo]&#93;
 * `return_type`: xref:#type-AnyInfo[AnyInfo]
 
 [[type-InterfaceInfo]]
@@ -253,9 +253,9 @@ Interface metadata.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
-* `methods`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-MethodInfo[MethodInfo]]
-* `parents`: xref:../../capy/collection/Set.adoc#type-Set[Set][xref:#type-AnyInfo[AnyInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
+* `methods`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-MethodInfo[MethodInfo]&#93;
+* `parents`: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;xref:#type-AnyInfo[AnyInfo]&#93;
 
 [[type-ListInfo]]
 === data ListInfo
@@ -273,9 +273,9 @@ Method metadata.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
-* `params`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-FieldInfo[FieldInfo]]
+* `params`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-FieldInfo[FieldInfo]&#93;
 * `pkg`: xref:#type-PackageInfo[PackageInfo]
 * `return_type`: xref:#type-AnyInfo[AnyInfo]
 
@@ -286,11 +286,11 @@ Object metadata.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
-* `fields`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-FieldInfo[FieldInfo]]
-* `methods`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-MethodInfo[MethodInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
+* `fields`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-FieldInfo[FieldInfo]&#93;
+* `methods`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-MethodInfo[MethodInfo]&#93;
 * `open`: bool
-* `parents`: xref:../../capy/collection/Set.adoc#type-Set[Set][xref:#type-AnyInfo[AnyInfo]]
+* `parents`: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;xref:#type-AnyInfo[AnyInfo]&#93;
 
 [[type-PackageInfo]]
 === data PackageInfo
@@ -318,9 +318,9 @@ Trait metadata.
 
 ==== Fields
 
-* `annotations`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnnotationInfo[AnnotationInfo]]
-* `methods`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-MethodInfo[MethodInfo]]
-* `parents`: xref:../../capy/collection/Set.adoc#type-Set[Set][xref:#type-AnyInfo[AnyInfo]]
+* `annotations`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnnotationInfo[AnnotationInfo]&#93;
+* `methods`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-MethodInfo[MethodInfo]&#93;
+* `parents`: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;xref:#type-AnyInfo[AnyInfo]&#93;
 
 [[type-TupleInfo]]
 === data TupleInfo
@@ -329,5 +329,5 @@ Tuple type metadata.
 
 ==== Fields
 
-* `elements`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-AnyInfo[AnyInfo]]
+* `elements`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-AnyInfo[AnyInfo]&#93;
 

--- a/docs/capy-docs/SNAPSHOT/capy/serialization/Json.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/serialization/Json.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun deserialize(json: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-JsonObject[JsonObject]]
+=== fun deserialize(json: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-JsonObject[JsonObject]&#93;
 
 Parses a JSON object string into a `JsonObject`.
 
@@ -14,7 +14,7 @@ Returns `Success` with `JsonString` and `JsonBool` field values. Invalid JSON
 returns `Error` with a parser message.
 
 
-=== fun deserialize(dict: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][any]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-JsonObject[JsonObject]]
+=== fun deserialize(dict: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;any&#93;): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-JsonObject[JsonObject]&#93;
 
 Converts a Capy dictionary of supported values into a JSON object.
 
@@ -33,7 +33,7 @@ need a custom data declaration. Supported values are strings, numeric
 primitives, nested dictionaries, and existing `Json` values.
 
 
-=== fun deserialize_typed(json: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-TypedJsonData[TypedJsonData]]
+=== fun deserialize_typed(json: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-TypedJsonData[TypedJsonData]&#93;
 
 Parses a JSON string produced by `serialize_typed` into typed JSON metadata.
 
@@ -75,7 +75,7 @@ The envelope field is `$capybaraTypedJson`, which separates typed data,
 object, array, and primitive value nodes from ordinary user JSON objects.
 
 
-=== fun to_json(obj: data): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-JsonObject[JsonObject]]
+=== fun to_json(obj: data): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-JsonObject[JsonObject]&#93;
 
 Converts a Capy data value into a plain JSON object.
 
@@ -108,7 +108,7 @@ If any field cannot be represented as JSON, the result is `Error` with the
 failing field name in the message.
 
 
-=== fun to_typed_json(obj: data): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-TypedJsonData[TypedJsonData]]
+=== fun to_typed_json(obj: data): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-TypedJsonData[TypedJsonData]&#93;
 
 Converts a Capy data value into typed JSON metadata.
 
@@ -158,7 +158,7 @@ JSON array represented as an ordered list of JSON values.
 
 ==== Fields
 
-* `value`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-Json[Json]]
+* `value`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-Json[Json]&#93;
 
 ==== Functions
 
@@ -172,7 +172,7 @@ Returns an array with values from both arrays.
 Returns an array with one value appended.
 
 
-===== fun JsonArray.get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Json[Json]]
+===== fun JsonArray.get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Json[Json]&#93;
 
 Returns the value at `idx`, or `None` when the index is outside the array.
 
@@ -227,7 +227,7 @@ JSON object represented as a dictionary of JSON values keyed by strings.
 
 ==== Fields
 
-* `value`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][xref:#type-Json[Json]]
+* `value`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;xref:#type-Json[Json]&#93;
 
 ==== Functions
 
@@ -239,7 +239,7 @@ When both objects contain the same key, the value from `other` replaces the
 value from `this`.
 
 
-===== fun JsonObject.`+`(other: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple][xref:../../capy/lang/String.adoc#type-String[String], xref:#type-Json[Json]]): xref:#type-JsonObject[JsonObject]
+===== fun JsonObject.`+`(other: xref:../../capy/collection/Tuple.adoc#type-Tuple[Tuple]&#91;xref:../../capy/lang/String.adoc#type-String[String], xref:#type-Json[Json]&#93;): xref:#type-JsonObject[JsonObject]
 
 Returns an object with one entry added or replaced.
 
@@ -251,7 +251,7 @@ JsonObject { value: { "name": JsonString { value: "Ada" } } }
 The resulting object has both `name` and `active` fields.
 
 
-===== fun JsonObject.get(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Json[Json]]
+===== fun JsonObject.get(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Json[Json]&#93;
 
 Returns the JSON value for `key`, or `None` when the field is missing.
 
@@ -290,7 +290,7 @@ JSON array value wrapper.
 
 ==== Functions
 
-===== fun JsonValueArray.get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Json[Json]]
+===== fun JsonValueArray.get(idx: xref:../../capy/collection/CollectionTypes.adoc#type-index[index]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Json[Json]&#93;
 
 
 
@@ -305,7 +305,7 @@ JSON object value wrapper.
 
 ==== Functions
 
-===== fun JsonValueObject.get(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-Json[Json]]
+===== fun JsonValueObject.get(key: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-Json[Json]&#93;
 
 
 
@@ -337,7 +337,7 @@ The `kind` field records the source collection family, such as `List` or
 ==== Fields
 
 * `kind`: xref:../../capy/lang/String.adoc#type-String[String]
-* `value`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TypedJson[TypedJson]]
+* `value`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TypedJson[TypedJson]&#93;
 
 [[type-TypedJsonBool]]
 === data TypedJsonBool
@@ -367,7 +367,7 @@ Typed Capy data value with constructor name, package metadata, and typed fields.
 
 ==== Fields
 
-* `fields`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][xref:#type-TypedJson[TypedJson]]
+* `fields`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;xref:#type-TypedJson[TypedJson]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 * `pkg`: xref:#type-TypedJsonPackage[TypedJsonPackage]
 
@@ -419,7 +419,7 @@ Typed object node used for dictionary-like values.
 
 ==== Fields
 
-* `value`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][xref:#type-TypedJson[TypedJson]]
+* `value`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;xref:#type-TypedJson[TypedJson]&#93;
 
 [[type-TypedJsonPackage]]
 === data TypedJsonPackage

--- a/docs/capy-docs/SNAPSHOT/capy/test/Assert.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/test/Assert.adoc
@@ -2,7 +2,7 @@
 
 == Functions
 
-=== fun assert_all(asserts: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-Assert[Assert]]): xref:#type-Assert[Assert]
+=== fun assert_all(asserts: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-Assert[Assert]&#93;): xref:#type-Assert[Assert]
 
 Combines several assertion chains into one `Assert`.
 
@@ -73,29 +73,29 @@ Starts a bool assertion chain.
 
 
 
-=== fun assert_that(value: xref:../../capy/collection/List.adoc#type-List[List][T]): xref:#type-ListAssert[ListAssert][T]
+=== fun assert_that(value: xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;): xref:#type-ListAssert[ListAssert]&#91;T&#93;
 
 Starts a list assertion chain.
 
 
-=== fun assert_that(value: xref:../../capy/collection/Set.adoc#type-Set[Set][T]): xref:#type-SetAssert[SetAssert][T]
+=== fun assert_that(value: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;T&#93;): xref:#type-SetAssert[SetAssert]&#91;T&#93;
 
 
 
-=== fun assert_that(value: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][T]): xref:#type-DictAssert[DictAssert][T]
+=== fun assert_that(value: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;T&#93;): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 
 
-=== fun assert_that(value: xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]): xref:#type-SeqAssert[SeqAssert][T]
+=== fun assert_that(value: xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;): xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
 
 
 
-=== fun assert_that(value: xref:../../capy/lang/Option.adoc#type-Option[Option][T]): xref:#type-OptionAssert[OptionAssert]
+=== fun assert_that(value: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;): xref:#type-OptionAssert[OptionAssert]
 
 Starts an option assertion chain.
 
 
-=== fun assert_that(value: xref:../../capy/lang/Result.adoc#type-Result[Result][T]): xref:#type-ResultAssert[ResultAssert]
+=== fun assert_that(value: xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;T&#93;): xref:#type-ResultAssert[ResultAssert]
 
 Starts a result assertion chain.
 
@@ -144,18 +144,18 @@ assert_all([
 * xref:#type-DataAssert[DataAssert]
 * xref:#type-DateAssert[DateAssert]
 * xref:#type-DateTimeAssert[DateTimeAssert]
-* xref:#type-DictAssert[DictAssert][T]
+* xref:#type-DictAssert[DictAssert]&#91;T&#93;
 * xref:#type-DoubleAssert[DoubleAssert]
 * xref:#type-DurationAssert[DurationAssert]
 * xref:#type-FloatAssert[FloatAssert]
 * xref:#type-IntAssert[IntAssert]
 * xref:#type-IntervalAssert[IntervalAssert]
-* xref:#type-ListAssert[ListAssert][T]
+* xref:#type-ListAssert[ListAssert]&#91;T&#93;
 * xref:#type-LongAssert[LongAssert]
-* xref:#type-OptionAssert[OptionAssert][T]
-* xref:#type-ResultAssert[ResultAssert][T]
-* xref:#type-SeqAssert[SeqAssert][T]
-* xref:#type-SetAssert[SetAssert][T]
+* xref:#type-OptionAssert[OptionAssert]&#91;T&#93;
+* xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
+* xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
+* xref:#type-SetAssert[SetAssert]&#91;T&#93;
 * xref:#type-StringAssert[StringAssert]
 * xref:#type-TimeAssert[TimeAssert]
 
@@ -327,32 +327,32 @@ Adds an assertion that the bool is true.
 ==== Fields
 
 * `assertions`: List[()=>Assertion]
-* `value`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][T]
+* `value`: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;T&#93;
 
 ==== Functions
 
-===== fun DictAssert[T].contains_key(other: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-DictAssert[DictAssert][T]
+===== fun DictAssert[T].contains_key(other: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 Adds an assertion that the dict contains `other` as a key.
 
 
-===== fun DictAssert[T].contains_value(other: T): xref:#type-DictAssert[DictAssert][T]
+===== fun DictAssert[T].contains_value(other: T): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 
 
-===== fun DictAssert[T].does_not_contain_key(other: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-DictAssert[DictAssert][T]
+===== fun DictAssert[T].does_not_contain_key(other: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 
 
-===== fun DictAssert[T].has_size(other: int): xref:#type-DictAssert[DictAssert][T]
+===== fun DictAssert[T].has_size(other: int): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 
 
-===== fun DictAssert[T].is_empty(): xref:#type-DictAssert[DictAssert][T]
+===== fun DictAssert[T].is_empty(): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 
 
-===== fun DictAssert[T].is_equal_to(other: xref:../../capy/collection/Dict.adoc#type-Dict[Dict][T]): xref:#type-DictAssert[DictAssert][T]
+===== fun DictAssert[T].is_equal_to(other: xref:../../capy/collection/Dict.adoc#type-Dict[Dict]&#91;T&#93;): xref:#type-DictAssert[DictAssert]&#91;T&#93;
 
 
 
@@ -572,29 +572,29 @@ Adds an int equality assertion to the chain.
 ==== Fields
 
 * `assertions`: List[()=>Assertion]
-* `value`: xref:../../capy/collection/List.adoc#type-List[List][T]
+* `value`: xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;
 
 ==== Functions
 
-===== fun ListAssert[T].contains(other: T): xref:#type-ListAssert[ListAssert][T]
+===== fun ListAssert[T].contains(other: T): xref:#type-ListAssert[ListAssert]&#91;T&#93;
 
 Adds an assertion that the list contains `other`.
 
 
-===== fun ListAssert[T].does_not_contain(other: T): xref:#type-ListAssert[ListAssert][T]
+===== fun ListAssert[T].does_not_contain(other: T): xref:#type-ListAssert[ListAssert]&#91;T&#93;
 
 
 
-===== fun ListAssert[T].has_size(other: int): xref:#type-ListAssert[ListAssert][T]
+===== fun ListAssert[T].has_size(other: int): xref:#type-ListAssert[ListAssert]&#91;T&#93;
 
 Adds an assertion that the list size equals `other`.
 
 
-===== fun ListAssert[T].is_empty(): xref:#type-ListAssert[ListAssert][T]
+===== fun ListAssert[T].is_empty(): xref:#type-ListAssert[ListAssert]&#91;T&#93;
 
 
 
-===== fun ListAssert[T].is_equal_to(other: xref:../../capy/collection/List.adoc#type-List[List][T]): xref:#type-ListAssert[ListAssert][T]
+===== fun ListAssert[T].is_equal_to(other: xref:../../capy/collection/List.adoc#type-List[List]&#91;T&#93;): xref:#type-ListAssert[ListAssert]&#91;T&#93;
 
 
 
@@ -648,21 +648,21 @@ Adds an assertion that the list size equals `other`.
 ==== Fields
 
 * `assertions`: List[()=>Assertion]
-* `value`: xref:../../capy/lang/Option.adoc#type-Option[Option][T]
+* `value`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;
 
 ==== Functions
 
-===== fun OptionAssert[T].contains(other: T): xref:#type-OptionAssert[OptionAssert][T]
+===== fun OptionAssert[T].contains(other: T): xref:#type-OptionAssert[OptionAssert]&#91;T&#93;
 
 Adds an assertion that the option is `Some` with `other`.
 
 
-===== fun OptionAssert[T].is_empty(): xref:#type-OptionAssert[OptionAssert][T]
+===== fun OptionAssert[T].is_empty(): xref:#type-OptionAssert[OptionAssert]&#91;T&#93;
 
 Adds an assertion that the option is `None`.
 
 
-===== fun OptionAssert[T].is_equal_to(other: xref:../../capy/lang/Option.adoc#type-Option[Option][T]): xref:#type-OptionAssert[OptionAssert][T]
+===== fun OptionAssert[T].is_equal_to(other: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;T&#93;): xref:#type-OptionAssert[OptionAssert]&#91;T&#93;
 
 
 
@@ -673,21 +673,21 @@ Adds an assertion that the option is `None`.
 ==== Fields
 
 * `assertions`: List[()=>Assertion]
-* `value`: xref:../../capy/lang/Result.adoc#type-Result[Result][T]
+* `value`: xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;T&#93;
 
 ==== Functions
 
-===== fun ResultAssert[T].fails(): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].fails(): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Error`.
 
 
-===== fun ResultAssert[T].fails(message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].fails(message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Error` with the expected message.
 
 
-===== fun ResultAssert[T].fails(assert: Error=>Assert): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].fails(assert: Error=>Assert): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Error`, then runs nested assertions
 against the structured error value.
@@ -700,38 +700,38 @@ assert_that(load_user()).fails(error =>
 ```
 
 
-===== fun ResultAssert[T].fails_with_kind(kind: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].fails_with_kind(kind: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Error` with the expected stable kind.
 
 
-===== fun ResultAssert[T].fails_with_kind(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].fails_with_kind(kind: xref:../../capy/lang/String.adoc#type-String[String], message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Error` with the expected stable kind and message.
 
 
-===== fun ResultAssert[T].fails_with_message_containing(message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].fails_with_message_containing(message: xref:../../capy/lang/String.adoc#type-String[String]): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Error` with a message containing `message`.
 
 
-===== fun ResultAssert[T].is_equal_to(other: xref:../../capy/lang/Result.adoc#type-Result[Result][T]): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].is_equal_to(other: xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;T&#93;): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 
 
-===== fun ResultAssert[T].succeeds(): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].succeeds(): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Success`.
 
 
-===== fun ResultAssert[T].succeeds(other: T): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].succeeds(other: T): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Success` containing `other`.
 
 Example: `assert_that("42".to_int()).succeeds(42)`.
 
 
-===== fun ResultAssert[T].succeeds(assert: T=>Assert): xref:#type-ResultAssert[ResultAssert][T]
+===== fun ResultAssert[T].succeeds(assert: T=>Assert): xref:#type-ResultAssert[ResultAssert]&#91;T&#93;
 
 Adds an assertion that the result is `Success`, then runs nested assertions
 against the success value.
@@ -751,27 +751,27 @@ assert_that(load_user()).succeeds(user =>
 ==== Fields
 
 * `assertions`: List[()=>Assertion]
-* `value`: xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]
+* `value`: xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;
 
 ==== Functions
 
-===== fun SeqAssert[T].contains(other: T): xref:#type-SeqAssert[SeqAssert][T]
+===== fun SeqAssert[T].contains(other: T): xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
 
 
 
-===== fun SeqAssert[T].does_not_contain(other: T): xref:#type-SeqAssert[SeqAssert][T]
+===== fun SeqAssert[T].does_not_contain(other: T): xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
 
 
 
-===== fun SeqAssert[T].has_size(other: int): xref:#type-SeqAssert[SeqAssert][T]
+===== fun SeqAssert[T].has_size(other: int): xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
 
 
 
-===== fun SeqAssert[T].is_empty(): xref:#type-SeqAssert[SeqAssert][T]
+===== fun SeqAssert[T].is_empty(): xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
 
 
 
-===== fun SeqAssert[T].is_equal_to(other: xref:../../capy/collection/Seq.adoc#type-Seq[Seq][T]): xref:#type-SeqAssert[SeqAssert][T]
+===== fun SeqAssert[T].is_equal_to(other: xref:../../capy/collection/Seq.adoc#type-Seq[Seq]&#91;T&#93;): xref:#type-SeqAssert[SeqAssert]&#91;T&#93;
 
 
 
@@ -782,27 +782,27 @@ assert_that(load_user()).succeeds(user =>
 ==== Fields
 
 * `assertions`: List[()=>Assertion]
-* `value`: xref:../../capy/collection/Set.adoc#type-Set[Set][T]
+* `value`: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;T&#93;
 
 ==== Functions
 
-===== fun SetAssert[T].contains(other: T): xref:#type-SetAssert[SetAssert][T]
+===== fun SetAssert[T].contains(other: T): xref:#type-SetAssert[SetAssert]&#91;T&#93;
 
 
 
-===== fun SetAssert[T].does_not_contain(other: T): xref:#type-SetAssert[SetAssert][T]
+===== fun SetAssert[T].does_not_contain(other: T): xref:#type-SetAssert[SetAssert]&#91;T&#93;
 
 
 
-===== fun SetAssert[T].has_size(other: int): xref:#type-SetAssert[SetAssert][T]
+===== fun SetAssert[T].has_size(other: int): xref:#type-SetAssert[SetAssert]&#91;T&#93;
 
 
 
-===== fun SetAssert[T].is_empty(): xref:#type-SetAssert[SetAssert][T]
+===== fun SetAssert[T].is_empty(): xref:#type-SetAssert[SetAssert]&#91;T&#93;
 
 
 
-===== fun SetAssert[T].is_equal_to(other: xref:../../capy/collection/Set.adoc#type-Set[Set][T]): xref:#type-SetAssert[SetAssert][T]
+===== fun SetAssert[T].is_equal_to(other: xref:../../capy/collection/Set.adoc#type-Set[Set]&#91;T&#93;): xref:#type-SetAssert[SetAssert]&#91;T&#93;
 
 
 
@@ -855,7 +855,7 @@ Adds an assertion that the string starts with `other`.
 
 
 
-===== fun TimeAssert.has_offset_minutes(other: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/date_time/Time.adoc#type-offset_minutes[offset_minutes]]): xref:#type-TimeAssert[TimeAssert]
+===== fun TimeAssert.has_offset_minutes(other: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/date_time/Time.adoc#type-offset_minutes[offset_minutes]&#93;): xref:#type-TimeAssert[TimeAssert]
 
 
 

--- a/docs/capy-docs/SNAPSHOT/capy/test/CapyTest.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/test/CapyTest.adoc
@@ -2,15 +2,15 @@
 
 == Functions
 
-=== fun ctrf_report(test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/String.adoc#type-String[String]
+=== fun ctrf_report(test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/String.adoc#type-String[String]
 
 
 
-=== fun failure_summary(test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/String.adoc#type-String[String]
+=== fun failure_summary(test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/String.adoc#type-String[String]
 
 
 
-=== fun jest_report(test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/String.adoc#type-String[String]
+=== fun jest_report(test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/String.adoc#type-String[String]
 
 
 
@@ -18,7 +18,7 @@
 
 
 
-=== fun run_tests(rtype: xref:#type-ReportType[ReportType], test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestOutput[TestOutput]]
+=== fun run_tests(rtype: xref:#type-ReportType[ReportType], test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestOutput[TestOutput]&#93;
 
 Generates report outputs in memory from already executed test files.
 
@@ -46,13 +46,13 @@ let outputs = run_tests(JUNIT, [reported_suite])
 Use the overload with `output_dir` to write report files.
 
 
-=== fun run_tests(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-TestRun[TestRun]]]
+=== fun run_tests(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-TestRun[TestRun]&#93;&#93;
 
 Runs test files, writes reports under `output_dir`, and returns the written
 output summary.
 
 
-=== fun run_tests(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], log_type: xref:#type-LogType[LogType], test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-TestRun[TestRun]]]
+=== fun run_tests(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], log_type: xref:#type-LogType[LogType], test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-TestRun[TestRun]&#93;&#93;
 
 Runs test files with the requested report type and logging mode.
 
@@ -68,12 +68,12 @@ run_tests(JUNIT, from_string("build/test-results"), LOG, [suite])
 `TEAM_CITY` emits service messages while tests execute.
 
 
-=== fun run_tests_and_print_summary(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-TestRun[TestRun]]]
+=== fun run_tests_and_print_summary(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-TestRun[TestRun]&#93;&#93;
 
 Runs tests, writes reports, and prints a failure summary.
 
 
-=== fun run_tests_and_print_summary(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], log_type: xref:#type-LogType[LogType], test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-TestRun[TestRun]]]
+=== fun run_tests_and_print_summary(rtype: xref:#type-ReportType[ReportType], output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], log_type: xref:#type-LogType[LogType], test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-TestRun[TestRun]&#93;&#93;
 
 Runs tests with logging, writes reports, and prints a failure summary.
 
@@ -82,7 +82,7 @@ Runs tests with logging, writes reports, and prints a failure summary.
 
 
 
-=== fun team_city_messages(test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]
+=== fun team_city_messages(test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 
 
@@ -94,7 +94,7 @@ The supplier is evaluated by the runner, so expensive or failing assertions
 should stay inside the lambda.
 
 
-=== fun test_file(file_name: xref:../../capy/lang/String.adoc#type-String[String], test_cases: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestCase[TestCase]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:#type-TestFile[TestFile]]
+=== fun test_file(file_name: xref:../../capy/lang/String.adoc#type-String[String], test_cases: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestCase[TestCase]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:#type-TestFile[TestFile]&#93;
 
 Builds a test file from already constructed test cases.
 
@@ -109,7 +109,7 @@ test_file("/capy/lang/StringTest.cfun", [
 The timestamp is captured from `now()` when the effect runs.
 
 
-=== fun test_file(file_name: xref:../../capy/lang/String.adoc#type-String[String], test_cases: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:#type-TestCase[TestCase]]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:#type-TestFile[TestFile]]
+=== fun test_file(file_name: xref:../../capy/lang/String.adoc#type-String[String], test_cases: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:#type-TestCase[TestCase]&#93;&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:#type-TestFile[TestFile]&#93;
 
 Builds a test file from effectful test cases.
 
@@ -117,18 +117,18 @@ Use this overload when test cases need setup effects before they can be
 added to the suite.
 
 
-=== fun test_log_lines(test_files: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestFile[TestFile]]): xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/lang/String.adoc#type-String[String]]
+=== fun test_log_lines(test_files: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestFile[TestFile]&#93;): xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 
 
-=== fun write_test_outputs(output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], test_outputs: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestOutput[TestOutput]]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/io/Path.adoc#type-Path[Path]]]]
+=== fun write_test_outputs(output_dir: xref:../../capy/io/Path.adoc#type-Path[Path], test_outputs: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestOutput[TestOutput]&#93;): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;&#93;&#93;
 
 Writes every test output under the given output directory and returns normalized relative paths.
 
 Existing files that already have the same content are left untouched.
 
 
-=== fun write_text_if_changed(path: xref:../../capy/io/Path.adoc#type-Path[Path], content: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect][xref:../../capy/lang/Result.adoc#type-Result[Result][xref:../../capy/lang/String.adoc#type-String[String]]]
+=== fun write_text_if_changed(path: xref:../../capy/io/Path.adoc#type-Path[Path], content: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Effect.adoc#type-Effect[Effect]&#91;xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;&#93;
 
 Writes text only when the target file content is different.
 
@@ -199,11 +199,11 @@ Failed test execution with assertion message and assertion type.
 [[type-JUnitReport]]
 === data JUnitReport
 
-See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml)
+See: https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml[Complete JUnit XML example]
 
 ==== Fields
 
-* `suites`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-JUnitTestSuite[JUnitTestSuite]]
+* `suites`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-JUnitTestSuite[JUnitTestSuite]&#93;
 
 [[type-JUnitTestCase]]
 === data JUnitTestCase
@@ -219,7 +219,7 @@ line        (not implemented) Source code line number of the start of this test 
 
 * `assertions`: int
 * `classname`: xref:../../capy/lang/String.adoc#type-String[String]
-* `failure`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:#type-JUnitFailure[JUnitFailure]]
+* `failure`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:#type-JUnitFailure[JUnitFailure]&#93;
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
 
 [[type-JUnitTestSuite]]
@@ -237,7 +237,7 @@ timestamp   Date and time of when the test run was executed (in ISO 8601 format)
 ==== Fields
 
 * `assertions`: int
-* `cases`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-JUnitTestCase[JUnitTestCase]]
+* `cases`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-JUnitTestCase[JUnitTestCase]&#93;
 * `error`: int
 * `failures`: int
 * `name`: xref:../../capy/lang/String.adoc#type-String[String]
@@ -326,7 +326,7 @@ Test suite source file with test cases and a run timestamp.
 ==== Fields
 
 * `file_name`: xref:../../capy/lang/String.adoc#type-String[String]
-* `test_cases`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestCase[TestCase]]
+* `test_cases`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestCase[TestCase]&#93;
 * `timestamp_millis`: long
 
 [[type-TestOutput]]
@@ -359,6 +359,6 @@ Result of writing a test run to disk.
 
 * `failed`: bool
 * `failure_summary`: xref:../../capy/lang/String.adoc#type-String[String]
-* `outputs`: xref:../../capy/collection/List.adoc#type-List[List][xref:#type-TestOutput[TestOutput]]
-* `written_files`: xref:../../capy/collection/List.adoc#type-List[List][xref:../../capy/io/Path.adoc#type-Path[Path]]
+* `outputs`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:#type-TestOutput[TestOutput]&#93;
+* `written_files`: xref:../../capy/collection/List.adoc#type-List[List]&#91;xref:../../capy/io/Path.adoc#type-Path[Path]&#93;
 

--- a/docs/capy-docs/SNAPSHOT/capy/util/SemVer.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/util/SemVer.adoc
@@ -2,9 +2,9 @@
 
 == Functions
 
-=== fun parse_semver(version: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-SemVer[SemVer]]
+=== fun parse_semver(version: xref:../../capy/lang/String.adoc#type-String[String]): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-SemVer[SemVer]&#93;
 
-[Backus–Naur Form Grammar for Valid SemVer Versions](https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions)
+https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions[Backus–Naur Form Grammar for Valid SemVer Versions]
 
 ```
 <valid semver> ::= <version core>
@@ -14,7 +14,7 @@
 ```
 
 
-=== fun sem_ver(major_value: int, minor_value: int, patch_value: int, pre_release: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]], build_metadata: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]): xref:../../capy/lang/Result.adoc#type-Result[Result][xref:#type-SemVer[SemVer]]
+=== fun sem_ver(major_value: int, minor_value: int, patch_value: int, pre_release: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;, build_metadata: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;): xref:../../capy/lang/Result.adoc#type-Result[Result]&#91;xref:#type-SemVer[SemVer]&#93;
 
 Creates a semantic version after validating the numeric components.
 
@@ -37,11 +37,11 @@ Full specification: https://semver.org/
 
 ==== Fields
 
-* `build_metadata`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
+* `build_metadata`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 * `major`: xref:#type-major[major]
 * `minor`: xref:#type-minor[minor]
 * `patch`: xref:#type-patch[patch]
-* `pre_release`: xref:../../capy/lang/Option.adoc#type-Option[Option][xref:../../capy/lang/String.adoc#type-String[String]]
+* `pre_release`: xref:../../capy/lang/Option.adoc#type-Option[Option]&#91;xref:../../capy/lang/String.adoc#type-String[String]&#93;
 
 ==== Functions
 


### PR DESCRIPTION
## Summary
- render generated AsciiDoc generic type delimiters as `&#91;` / `&#93;` so adjacent xref macros do not get parsed incorrectly and rendered docs still show normal brackets
- keep links for both the generic type and generic arguments, e.g. `Result[SemVer]`
- translate inline Markdown external links in doc comments, e.g. `[Spec](https://example.com)` to `https://example.com[Spec]`
- update docs command integration coverage for linked generic type output and documentation link conversion
- regenerate `docs/capy-docs/SNAPSHOT` so tracked SemVer docs contain the fixed link output

## Validation
- `./gradlew :capy:integrationTest --tests dev.capylang.cli.CapyDocsCommandIntegrationTest --no-daemon`
- `./gradlew :capy:assemble --no-daemon`
- `java -jar capy/build/libs/capy-0.4.0-SNAPSHOT.jar docs -i lib/capybara-lib/src/main/capybara -o build/capy-docs`
- `java -jar capy/build/libs/capy-0.4.0-SNAPSHOT.jar docs -i lib/capybara-lib/src/main/capybara -o docs/capy-docs/SNAPSHOT`
- checked `build/capy-docs/capy/util/SemVer.adoc` and `docs/capy-docs/SNAPSHOT/capy/util/SemVer.adoc` for generic `Result[SemVer]` links without backslash escapes and AsciiDoc external link output
- scanned generated docs for backslash-escaped generic delimiters and Markdown-style external links
