### PR TITLE
feat(#290): add SemVer precedence operators

### DIFF
--- a/docs/capy-docs/SNAPSHOT/capy/util/SemVer.adoc
+++ b/docs/capy-docs/SNAPSHOT/capy/util/SemVer.adoc
@@ -45,6 +45,38 @@ Full specification: https://semver.org/
 
 ==== Functions
 
+===== fun SemVer.`<=`(other: xref:#type-SemVer[SemVer]): bool
+
+Returns true when this SemVer version has the same or lower precedence than `other`.
+
+
+===== fun SemVer.`<`(other: xref:#type-SemVer[SemVer]): bool
+
+Returns true when this SemVer version has lower precedence than `other`.
+
+
+===== fun SemVer.`==`(other: xref:#type-SemVer[SemVer]): bool
+
+Returns true when this SemVer version has the same precedence as `other`.
+
+
+===== fun SemVer.`>=`(other: xref:#type-SemVer[SemVer]): bool
+
+Returns true when this SemVer version has the same or higher precedence than `other`.
+
+
+===== fun SemVer.`>`(other: xref:#type-SemVer[SemVer]): bool
+
+Returns true when this SemVer version has higher precedence than `other`.
+
+
+===== fun SemVer.compare(other: xref:#type-SemVer[SemVer]): xref:../../capy/lang/Ordering.adoc#type-Ordering[Ordering]
+
+Compares this SemVer version with `other` using Semantic Versioning precedence.
+
+Build metadata does not affect precedence.
+
+
 ===== fun SemVer.to_string(): xref:../../capy/lang/String.adoc#type-String[String]
 
 Generates a string representation of this SemVer version, e.g. `1.0.0`, `2.1.3-alpha`, `3.2.1+build.123`, `4.5.6-beta+exp.sha.5114f85`

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -1,4 +1,5 @@
 from /capy/lang/Option import { Option, Some, None }
+from /capy/lang/Ordering import { Ordering, LESS, EQUAL, GREATER }
 from /capy/lang/Result import {*}
 from /capy/lang/String import { * }
 from /capy/meta_prog/Recursive import { Recursive }
@@ -57,6 +58,110 @@ data SemVer {
     pre_release: Option[String],
     build_metadata: Option[String]
 }
+
+private data PreReleaseIdentifier { buffer: String, value: String }
+
+/// Returns true when this SemVer version has higher precedence than `other`.
+fun SemVer.`>`(other: SemVer): bool = this.compare(other) == GREATER
+
+/// Returns true when this SemVer version has the same or higher precedence than `other`.
+fun SemVer.`>=`(other: SemVer): bool = this.compare(other) != LESS
+
+/// Returns true when this SemVer version has lower precedence than `other`.
+fun SemVer.`<`(other: SemVer): bool = this.compare(other) == LESS
+
+/// Returns true when this SemVer version has the same or lower precedence than `other`.
+fun SemVer.`<=`(other: SemVer): bool = this.compare(other) != GREATER
+
+/// Returns true when this SemVer version has the same precedence as `other`.
+fun SemVer.`==`(other: SemVer): bool = this.compare(other) == EQUAL
+
+/// Compares this SemVer version with `other` using Semantic Versioning precedence.
+///
+/// Build metadata does not affect precedence.
+fun SemVer.compare(other: SemVer): Ordering =
+    match semver_compare_version_core(this, other) with
+    case EQUAL -> semver_compare_pre_release(this.pre_release, other.pre_release)
+    case order -> order
+
+private fun semver_compare_version_core(left: SemVer, right: SemVer): Ordering =
+    if left.major < right.major
+    then LESS
+    else if left.major > right.major
+        then GREATER
+        else if left.minor < right.minor
+            then LESS
+            else if left.minor > right.minor
+                then GREATER
+                else if left.patch < right.patch
+                    then LESS
+                    else if left.patch > right.patch
+                        then GREATER
+                        else EQUAL
+
+private fun semver_compare_pre_release(left: Option[String], right: Option[String]): Ordering =
+    match left with
+    case None ->
+        match right with
+        case None -> EQUAL
+        case Some -> GREATER
+    case Some { left_value } ->
+        match right with
+        case None -> LESS
+        case Some { right_value } -> semver_compare_pre_release_identifiers(left_value, right_value)
+
+@Recursive
+private fun semver_compare_pre_release_identifiers(left: String, right: String): Ordering =
+    let left_identifier = semver_take_pre_release_identifier(left, "")
+    let right_identifier = semver_take_pre_release_identifier(right, "")
+    match semver_compare_pre_release_identifier(left_identifier.value, right_identifier.value) with
+    case EQUAL ->
+        if left_identifier.buffer.is_empty() & right_identifier.buffer.is_empty()
+        then EQUAL
+        else if left_identifier.buffer.is_empty()
+            then LESS
+            else if right_identifier.buffer.is_empty()
+                then GREATER
+                else semver_compare_pre_release_identifiers(
+                    semver_drop_pre_release_separator(left_identifier.buffer),
+                    semver_drop_pre_release_separator(right_identifier.buffer)
+                )
+    case order -> order
+
+@Recursive
+private fun semver_take_pre_release_identifier(value: String, parsed: String): PreReleaseIdentifier =
+    match value[0] with
+    case None -> PreReleaseIdentifier { buffer: value, value: parsed }
+    case Some { char } when char == '.' -> PreReleaseIdentifier { buffer: value, value: parsed }
+    case Some { char } -> semver_take_pre_release_identifier(value[1, value.size()], parsed + char)
+
+private fun semver_drop_pre_release_separator(value: String): String =
+    match value[0] with
+    case Some { char } when char == '.' -> value[1, value.size()]
+    case _ -> value
+
+private fun semver_compare_pre_release_identifier(left: String, right: String): Ordering =
+    let left_numeric = semver_pre_release_identifier_is_numeric(left)
+    let right_numeric = semver_pre_release_identifier_is_numeric(right)
+    if left_numeric & right_numeric
+    then semver_compare_numeric_identifier(left, right)
+    else if left_numeric
+        then LESS
+        else if right_numeric
+            then GREATER
+            else left.compare(right)
+
+private fun semver_compare_numeric_identifier(left: String, right: String): Ordering =
+    if left.size() < right.size()
+    then LESS
+    else if left.size() > right.size()
+        then GREATER
+        else left.compare(right)
+
+private fun semver_pre_release_identifier_is_numeric(value: String): bool =
+    !value.is_empty() & value.all(char => match char with
+        case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' -> true
+        case _ -> false)
 
 /// Creates a semantic version after validating the numeric components.
 fun sem_ver(

--- a/lib/capybara-lib/src/test/capybara/capy/util/SemVerTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/util/SemVerTest.cfun
@@ -3,6 +3,7 @@ from /capy/lang/Effect import { * }
 from /capy/test/CapyTest import { * }
 from /capy/util/SemVer import { * }
 from /capy/lang/Option import { * }
+from /capy/lang/Ordering import { * }
 from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
@@ -51,6 +52,21 @@ fun tests(): Effect[TestFile] =
         test("sem_ver rejects negative minor", () => assert_that(sem_ver(0, -1, 0, None {}, None {})).fails("minor must be greater than or equal to 0")),
         test("sem_ver rejects negative patch", () => assert_that(sem_ver(0, 0, -1, None {}, None {})).fails("patch must be greater than or equal to 0")),
     ]
+    let comparison_test_cases = [
+        test("SemVer compares major components first", () => should_order_sem_ver("2.0.0", "1.999.999")),
+        test("SemVer compares minor components after equal majors", () => should_order_sem_ver("1.3.0", "1.2.999")),
+        test("SemVer compares patch components after equal major and minor components", () => should_order_sem_ver("1.2.4", "1.2.3")),
+        test("SemVer compares pre-release identifiers by SemVer precedence", () => assert_all([
+            should_order_sem_ver("1.0.0-alpha.1", "1.0.0-alpha"),
+            should_order_sem_ver("1.0.0-alpha.beta", "1.0.0-alpha.1"),
+            should_order_sem_ver("1.0.0-beta", "1.0.0-alpha.beta"),
+            should_order_sem_ver("1.0.0-beta.2", "1.0.0-beta"),
+            should_order_sem_ver("1.0.0-beta.11", "1.0.0-beta.2"),
+            should_order_sem_ver("1.0.0-rc.1", "1.0.0-beta.11"),
+            should_order_sem_ver("1.0.0", "1.0.0-rc.1"),
+        ])),
+        test("SemVer equality uses precedence and ignores build metadata", () => should_equal_sem_ver_precedence("1.2.3+build.1", "1.2.3+build.2")),
+    ]
 
     let failed_test_cases = ({
         "1" : "Unexpected end of version string!",
@@ -71,7 +87,7 @@ fun tests(): Effect[TestFile] =
         "1.2.3-asd+QĘT" : "Expected end of version string or `.` for next build identifier, but got `Ę`!", }
         .entries() | (sem_ver, expected_message) => test("should fail parsing {sem_ver}", () => should_fail_parse_with_message(sem_ver, expected_message))).as_list()
 
-    test_file("/capy/util/SemVer.cfun", component_test_cases + parse_test_cases + to_string_test_cases + failed_test_cases)
+    test_file("/capy/util/SemVer.cfun", component_test_cases + comparison_test_cases + parse_test_cases + to_string_test_cases + failed_test_cases)
 
 fun should_parse_sem_ver(str: String, expected: ExpectedSemVer) =
     assert_that(parse_semver(str)).succeeds(value => assert_all([
@@ -86,3 +102,37 @@ fun should_stringify_sem_ver(version: String) =
     assert_that(parse_semver(version)).succeeds(value => assert_that(value.to_string()).is_equal_to(version))
 
 fun should_fail_parse_with_message(sem_ver: String, expected_message: String) = assert_that(parse_semver(sem_ver)).fails(expected_message)
+
+fun should_order_sem_ver(greater: String, less: String): Assert =
+    assert_that(parse_semver(greater)).succeeds(greater_value =>
+        assert_that(parse_semver(less)).succeeds(less_value => assert_all([
+            assert_that(greater_value.compare(less_value)).is_equal_to(GREATER),
+            assert_that(less_value.compare(greater_value)).is_equal_to(LESS),
+            assert_that(greater_value > less_value).is_true(),
+            assert_that(greater_value >= less_value).is_true(),
+            assert_that(greater_value < less_value).is_false(),
+            assert_that(greater_value <= less_value).is_false(),
+            assert_that(greater_value == less_value).is_false(),
+            assert_that(less_value < greater_value).is_true(),
+            assert_that(less_value <= greater_value).is_true(),
+            assert_that(less_value > greater_value).is_false(),
+            assert_that(less_value >= greater_value).is_false(),
+            assert_that(less_value == greater_value).is_false(),
+        ])))
+
+fun should_equal_sem_ver_precedence(left: String, right: String): Assert =
+    assert_that(parse_semver(left)).succeeds(left_value =>
+        assert_that(parse_semver(right)).succeeds(right_value => assert_all([
+            assert_that(left_value.compare(right_value)).is_equal_to(EQUAL),
+            assert_that(right_value.compare(left_value)).is_equal_to(EQUAL),
+            assert_that(left_value == right_value).is_true(),
+            assert_that(right_value == left_value).is_true(),
+            assert_that(left_value >= right_value).is_true(),
+            assert_that(right_value >= left_value).is_true(),
+            assert_that(left_value <= right_value).is_true(),
+            assert_that(right_value <= left_value).is_true(),
+            assert_that(left_value > right_value).is_false(),
+            assert_that(right_value > left_value).is_false(),
+            assert_that(left_value < right_value).is_false(),
+            assert_that(right_value < left_value).is_false(),
+        ])))


### PR DESCRIPTION
## Summary
- Add `SemVer.compare(other: SemVer): Ordering` for Semantic Versioning precedence.
- Add `SemVer` operator functions for `>`, `>=`, `<`, `<=`, and `==` backed by `compare`.
- Compare versions using SemVer precedence: major, minor, patch, then pre-release identifiers; build metadata is ignored for precedence.
- Add SemVer comparison tests and regenerate the docs snapshot.

## Validation
- `./gradlew :lib:capybara-lib:testCapybara`
- `./gradlew :capy:run --args="docs -i /mnt/d/repos/capy-family/Capybara3/lib/capybara-lib/src/main/capybara -o /mnt/d/repos/capy-family/Capybara3/docs/capy-docs/SNAPSHOT"`

Closes #290