### PR TITLE
fix(#302): normalize Windows Capybara source paths

### DIFF
--- a/capy/src/main/capybara/dev/capylang/cli/Capy.cfun
+++ b/capy/src/main/capybara/dev/capylang/cli/Capy.cfun
@@ -1512,7 +1512,54 @@ private fun relative_to(base: Path, path: Path): Path =
     cli_relative_to(base, path)
 
 private fun cli_relative_to(base: Path, path: Path): Path =
-    from_string(cli_path_segments_to_string(cli_drop_prefix_segments(base.normalize().segments, path.normalize().segments)))
+    Path {
+        root: PathRoot.RELATIVE,
+        prefix: None {},
+        segments: cli_drop_prefix_segments(cli_path_compare_segments(base), cli_path_compare_segments(path))
+    }
+
+private fun cli_path_compare_segments(path: Path): List[String] =
+    cli_drop_windows_drive_segment(cli_split_path_segments(path.normalize().segments))
+
+private fun cli_split_path_segments(segments: List[String]): List[String] =
+    match segments[0] with
+    case None -> []
+    case Some { segment } -> cli_split_path_segment(segment, "", []) + cli_split_path_segments(segments[1:])
+
+private fun cli_split_path_segment(segment: String, current: String, acc: List[String]): List[String] =
+    match segment[0] with
+    case None -> if current.is_empty() then acc else acc + current
+    case Some { value } ->
+        if cli_path_separator(value)
+        then
+            if current.is_empty()
+            then cli_split_path_segment(segment[1, segment.size()], "", acc)
+            else cli_split_path_segment(segment[1, segment.size()], "", acc + current)
+        else cli_split_path_segment(segment[1, segment.size()], current + value, acc)
+
+private fun cli_drop_windows_drive_segment(segments: List[String]): List[String] =
+    match segments[0] with
+    case None -> []
+    case Some { segment } -> if cli_windows_drive_segment(segment) then segments[1:] else segments
+
+private fun cli_windows_drive_segment(segment: String): bool =
+    match segment[0] with
+    case Some { drive } -> {
+        match segment[1] with
+        case Some { ':' } -> {
+            match segment[2] with
+            case None -> cli_valid_windows_drive_letter(drive)
+            case _ -> false
+        }
+        case _ -> false
+    }
+    case _ -> false
+
+private fun cli_valid_windows_drive_letter(value: String): bool =
+    value.size() == 1 & ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" ? value)
+
+private fun cli_path_separator(value: String): bool =
+    value == '/' | value == '\\'
 
 private fun cli_drop_prefix_segments(prefix: List[String], segments: List[String]): List[String] =
     if cli_segments_have_prefix(prefix, segments)
@@ -1552,7 +1599,11 @@ private fun cli_path_to_string(path: Path): String =
     let body = cli_path_segments_to_string(normalized.segments)
     match normalized.root with
     case RELATIVE -> if body.is_empty() then "." else body
-    case ABSOLUTE -> "/" + body
+    case ABSOLUTE -> {
+        match normalized.prefix with
+        case None -> "/" + body
+        case Some { prefix } -> prefix + body
+    }
     case HOME -> if body.is_empty() then "~" else "~/" + body
 
 private fun write_compilation_output(output_dir: Path, program: CompiledProgram): Effect[Result[String]] =

--- a/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/Path.cfun
@@ -18,6 +18,19 @@ from /capy/meta_prog/Recursive import { Recursive }
 /// paths start at the platform temporary directory.
 enum PathRoot { RELATIVE, ABSOLUTE, HOME, TEMP }
 
+/// Single ASCII drive letter for Windows drive-rooted paths.
+type windows_drive_letter -> String with constructor {
+    if value.size() == 1 & ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" ? value)
+    then Success { value.to_upper_case() }
+    else Error { kind: "capy.io.path.invalid_drive_letter", message: "windows_drive_letter must be a single ASCII letter, was `" + value + "`" }
+}
+
+private data WindowsUncRoot { prefix: String, body_start: int }
+
+/// Returns the native root prefix for this Windows drive, e.g. `D:\`.
+fun windows_drive_letter.native_prefix(): String =
+    this.value + ":\\"
+
 /// Portable path value split into a root and path segments.
 ///
 /// Build paths with `from_string` or the `/` operator instead of manually
@@ -42,6 +55,9 @@ data Path {
 /// from_string("/var/log/../tmp/app.log")
 /// ```
 /// Produces an absolute path with segments `["var", "tmp", "app.log"]`.
+/// Windows drive-rooted paths such as `D:\work\app`, and UNC paths such as
+/// `\\server\share\app`, are represented as absolute paths with native root
+/// prefixes.
 fun from_string(path_string: String): Path =
     @Recursive
     fun segments(value: String, current: String, acc: List[String]): List[String] =
@@ -51,7 +67,7 @@ fun from_string(path_string: String): Path =
             then acc
             else acc + current
         case Some { c } ->
-            if c == '/'
+            if path_separator(c)
             then
                 if current == ""
                 then segments(value[1, value.size()], "", acc)
@@ -59,25 +75,110 @@ fun from_string(path_string: String): Path =
             else
                 segments(value[1, value.size()], current + c, acc)
     ---
-    let value =
-        if path_string.starts_with('/')
-        then path_string[1, path_string.size()]
-        else if path_string.starts_with('~')
-        then
-            match path_string[1] with
-            case Some { '/' } -> path_string[2, path_string.size()]
-            case _ -> path_string[1, path_string.size()]
-        else path_string
     Path {
-        root:
-            if path_string.starts_with('/')
-            then PathRoot.ABSOLUTE
-            else if path_string.starts_with('~')
-            then PathRoot.HOME
-            else PathRoot.RELATIVE,
-        prefix: None {},
-        segments: segments(value, "", [])
+        root: path_root(path_string),
+        prefix: path_prefix(path_string),
+        segments: segments(path_body(path_string), "", [])
     }.normalize()
+
+private fun path_root(path_string: String): PathRoot =
+    if windows_unc_absolute_path(path_string) | windows_drive_absolute_path(path_string) | path_string.starts_with('/') | path_string.starts_with('\\')
+    then PathRoot.ABSOLUTE
+    else if path_string.starts_with('~')
+    then PathRoot.HOME
+    else PathRoot.RELATIVE
+
+private fun path_prefix(path_string: String): Option[String] =
+    match windows_unc_root(path_string) with
+    case Some { unc_root } -> Some { unc_root.prefix }
+    case None -> path_windows_drive_letter(path_string).map(drive => drive.native_prefix())
+
+private fun path_body(path_string: String): String =
+    if windows_drive_absolute_path(path_string)
+    then path_string[3, path_string.size()]
+    else
+        match windows_unc_root(path_string) with
+        case Some { unc_root } -> path_string[unc_root.body_start, path_string.size()]
+        case None ->
+            if path_string.starts_with('/') | path_string.starts_with('\\')
+            then path_string[1, path_string.size()]
+            else if path_string.starts_with('~')
+            then
+                match path_string[1] with
+                case Some { separator } ->
+                    if path_separator(separator)
+                    then path_string[2, path_string.size()]
+                    else path_string[1, path_string.size()]
+                case None -> ""
+            else path_string
+
+private fun windows_unc_absolute_path(path_string: String): bool =
+    match windows_unc_root(path_string) with
+    case Some _ -> true
+    case None -> false
+
+private fun windows_unc_root(path_string: String): Option[WindowsUncRoot] =
+    match path_string[0] with
+    case Some { first } -> {
+        match path_string[1] with
+        case Some { second } ->
+            if first == '\\' & second == '\\'
+            then windows_unc_server(path_string, 2, "")
+            else None {}
+        case None -> None {}
+    }
+    case None -> None {}
+
+private fun windows_unc_server(path_string: String, idx: int, server: String): Option[WindowsUncRoot] =
+    match path_string[idx] with
+    case Some { value } ->
+        if path_separator(value)
+        then
+            if server.is_empty()
+            then None {}
+            else windows_unc_share(path_string, idx + 1, server, "")
+        else windows_unc_server(path_string, idx + 1, server + value)
+    case None -> None {}
+
+private fun windows_unc_share(path_string: String, idx: int, server: String, share: String): Option[WindowsUncRoot] =
+    match path_string[idx] with
+    case Some { value } ->
+        if path_separator(value)
+        then windows_unc_root_from_parts(server, share, idx + 1)
+        else windows_unc_share(path_string, idx + 1, server, share + value)
+    case None -> windows_unc_root_from_parts(server, share, idx)
+
+private fun windows_unc_root_from_parts(server: String, share: String, body_start: int): Option[WindowsUncRoot] =
+    if share.is_empty()
+    then None {}
+    else Some { WindowsUncRoot { prefix: "\\\\" + server + "\\" + share + "\\", body_start: body_start } }
+
+private fun windows_drive_absolute_path(path_string: String): bool =
+    match path_windows_drive_letter(path_string) with
+    case Some _ -> true
+    case None -> false
+
+private fun path_windows_drive_letter(path_string: String): Option[windows_drive_letter] =
+    match path_string[0] with
+    case Some { drive } -> {
+        match path_string[1] with
+        case Some { ':' } -> {
+            match path_string[2] with
+            case Some { separator } ->
+                if path_separator(separator)
+                then
+                    match windows_drive_letter { drive } with
+                    case Success { drive_letter } -> Some { drive_letter }
+                    case Error _ -> None {}
+                else None {}
+            case _ -> None {}
+        }
+        case _ -> None {}
+    }
+    case _ -> None {}
+
+private fun path_separator(value: String): bool =
+    value == '/' | value == '\\'
 
 /// Returns a new path with `segment` appended.
 ///

--- a/lib/capybara-lib/src/test/capybara/capy/io/PathTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/io/PathTest.cfun
@@ -13,6 +13,9 @@ fun tests(): Effect[TestFile] =
         path_methods_create_list_and_delete_files_and_directories().map(assertion => test("path methods create list and delete files and directories", () => assertion)),
         path_methods_copy_move_and_replace_files().map(assertion => test("path methods copy move and replace files", () => assertion)),
         path_methods_forward_io_failures().map(assertion => test("path methods forward IO failures", () => assertion)),
+        test("should parse Windows drive letters", () => should_parse_windows_drive_letters()),
+        test("should parse Windows absolute paths", () => should_parse_windows_absolute_paths()),
+        test("should parse Windows UNC absolute paths", () => should_parse_windows_unc_absolute_paths()),
     ])
 
 fun path_methods_read_write_append_text_lines_and_bytes(): Effect[Assert] =
@@ -137,6 +140,32 @@ fun path_methods_forward_io_failures(): Effect[Assert] =
         assert_failed_message_contains(size_missing, "size failed"),
         assert_failed_message_contains(copy_missing, "copy failed"),
         assert_that(missing_exists).is_false(),
+    ])
+
+private fun should_parse_windows_absolute_paths(): Assert =
+    let path = from_string("D:\\repos\\capybara\\src\\main\\capybara")
+    assert_all([
+        assert_that(path.root).is_equal_to(PathRoot.ABSOLUTE),
+        assert_that(path.prefix).contains("D:\\"),
+        assert_that(path.segments).is_equal_to(["repos", "capybara", "src", "main", "capybara"]),
+    ])
+
+private fun should_parse_windows_unc_absolute_paths(): Assert =
+    let path = from_string("\\\\server\\share\\src\\main")
+    assert_all([
+        assert_that(path.root).is_equal_to(PathRoot.ABSOLUTE),
+        assert_that(path.prefix).contains("\\\\server\\share\\"),
+        assert_that(path.segments).is_equal_to(["src", "main"]),
+    ])
+
+private fun should_parse_windows_drive_letters(): Assert =
+    assert_all([
+        assert_that(windows_drive_letter { "D" }).succeeds(windows_drive_letter! { "D" }),
+        assert_that(windows_drive_letter { "z" }).succeeds(windows_drive_letter! { "Z" }),
+        assert_that(windows_drive_letter { "1" }).fails_with_kind("capy.io.path.invalid_drive_letter", "windows_drive_letter must be a single ASCII letter, was `1`"),
+        assert_that(windows_drive_letter { "" }).fails(),
+        assert_that(windows_drive_letter! { "d" }).is_equal_to(windows_drive_letter! { "D" }),
+        assert_that(windows_drive_letter! { "d" }.native_prefix()).is_equal_to("D:\\"),
     ])
 
 private fun unique_temp_path(name: String): Effect[Path] =


### PR DESCRIPTION
Fixes #302.

## What changed
- Parse Windows drive-rooted paths in `Path.from_string`, preserving the drive prefix and splitting backslash separators.
- Make CLI module path relativization compare normalized logical path segments when Windows paths arrive with embedded drive/separator text.
- Preserve native prefixes when stringifying absolute CLI paths and add a capybara-lib parser test for `D:\\...` paths.

## Impacted modules
- `capy`
- `lib/capybara-lib`

## Validation
- `cmd.exe /c "cd /d D:\\repos\\capy-family\\Capybara && gradlew.bat :lib:capybara-lib:compileTestCapybaraJavaScriptDirect --no-configuration-cache --stacktrace"`
- `cmd.exe /c "cd /d D:\\repos\\capy-family\\Capybara && gradlew.bat :lib:capybara-lib:testCapybara --no-configuration-cache --stacktrace"`