### PR TITLE
feat(#304): add cfun system property access

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SystemPropertiesCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SystemPropertiesCapyTest.cfun
@@ -1,0 +1,66 @@
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+from /capy/lang/Effect import { * }
+from /capy/lang/System import { clear_system_property, nano_time, set_system_property, system_property }
+
+fun tests(): Effect[TestFile] =
+    test_file("/dev/capylang/test/SystemPropertiesCapyTest.cfun", [
+        set_system_property_stores_value_and_returns_previous().map(assertion => test("set_system_property stores value and returns previous", () => assertion)),
+        set_system_property_empty_name_returns_none().map(assertion => test("set_system_property empty name returns None", () => assertion)),
+        clear_system_property_removes_value_and_returns_previous().map(assertion => test("clear_system_property removes value and returns previous", () => assertion)),
+        clear_system_property_empty_name_returns_none().map(assertion => test("clear_system_property empty name returns None", () => assertion)),
+    ])
+
+fun set_system_property_stores_value_and_returns_previous(): Effect[Assert] =
+    let key <- unique_system_property_key()
+    let missing <- system_property(key)
+    let previous <- set_system_property(key, "first")
+    let first <- system_property(key)
+    let overwritten <- set_system_property(key, "second")
+    let second <- system_property(key)
+    assert_all([
+        assert_that(missing).is_empty(),
+        assert_that(previous).is_empty(),
+        assert_that(first).contains("first"),
+        assert_that(overwritten).contains("first"),
+        assert_that(second).contains("second"),
+    ])
+
+fun set_system_property_empty_name_returns_none(): Effect[Assert] =
+    let previous <- set_system_property("", "ignored")
+    let value <- system_property("")
+    assert_all([
+        assert_that(previous).is_empty(),
+        assert_that(value).is_empty(),
+    ])
+
+fun clear_system_property_removes_value_and_returns_previous(): Effect[Assert] =
+    let key <- unique_system_property_key()
+    let empty_key = key + ".empty"
+    let missing <- clear_system_property(key)
+    let previous <- set_system_property(key, "value")
+    let cleared <- clear_system_property(key)
+    let value <- system_property(key)
+    let cleared_again <- clear_system_property(key)
+    let empty_previous <- set_system_property(empty_key, "")
+    let empty_cleared <- clear_system_property(empty_key)
+    assert_all([
+        assert_that(missing).is_empty(),
+        assert_that(previous).is_empty(),
+        assert_that(cleared).contains("value"),
+        assert_that(value).is_empty(),
+        assert_that(cleared_again).is_empty(),
+        assert_that(empty_previous).is_empty(),
+        assert_that(empty_cleared).contains(""),
+    ])
+
+fun clear_system_property_empty_name_returns_none(): Effect[Assert] =
+    let previous <- clear_system_property("")
+    let value <- system_property("")
+    assert_all([
+        assert_that(previous).is_empty(),
+        assert_that(value).is_empty(),
+    ])
+
+private fun unique_system_property_key(): Effect[String] =
+    nano_time().map(value => "capybara.e2e.system.property." + value)

--- a/capy/src/main/capybara/dev/capylang/generator/JavaGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/JavaGenerator.cfun
@@ -565,13 +565,86 @@ private fun java_system_module_code(module: CompiledModule): String =
     + "    public static capy.lang.Effect<java.lang.Long> nanoTime() {" + newline()
     + "        return capy.lang.Effect.delay(() -> java.lang.System.nanoTime());" + newline()
     + "    }" + newline() + newline()
-    + "    public static capy.lang.Effect<java.lang.Long> current_millis__3_0() {" + newline()
-    + "        return currentMillis();" + newline()
+    + "    public static capy.lang.Effect<java.util.Optional<java.lang.String>> systemProperty(java.lang.String name) {" + newline()
+    + "        return capy.lang.Effect.delay(() -> {" + newline()
+    + "            if (name == null || name.isEmpty()) {" + newline()
+    + "                return java.util.Optional.empty();" + newline()
+    + "            }" + newline()
+    + "            try {" + newline()
+    + "                return java.util.Optional.ofNullable(java.lang.System.getProperty(name));" + newline()
+    + "            } catch (java.lang.IllegalArgumentException | java.lang.SecurityException e) {" + newline()
+    + "                return java.util.Optional.empty();" + newline()
+    + "            }" + newline()
+    + "        });" + newline()
     + "    }" + newline() + newline()
-    + "    public static capy.lang.Effect<java.lang.Long> nano_time__8_0() {" + newline()
-    + "        return nanoTime();" + newline()
-    + "    }" + newline()
+    + "    public static capy.lang.Effect<java.util.Optional<java.lang.String>> setSystemProperty(java.lang.String name, java.lang.String value) {" + newline()
+    + "        return capy.lang.Effect.delay(() -> {" + newline()
+    + "            if (name == null || name.isEmpty() || value == null) {" + newline()
+    + "                return java.util.Optional.empty();" + newline()
+    + "            }" + newline()
+    + "            try {" + newline()
+    + "                return java.util.Optional.ofNullable(java.lang.System.setProperty(name, value));" + newline()
+    + "            } catch (java.lang.IllegalArgumentException | java.lang.NullPointerException | java.lang.SecurityException e) {" + newline()
+    + "                return java.util.Optional.empty();" + newline()
+    + "            }" + newline()
+    + "        });" + newline()
+    + "    }" + newline() + newline()
+    + "    public static capy.lang.Effect<java.util.Optional<java.lang.String>> clearSystemProperty(java.lang.String name) {" + newline()
+    + "        return capy.lang.Effect.delay(() -> {" + newline()
+    + "            if (name == null || name.isEmpty()) {" + newline()
+    + "                return java.util.Optional.empty();" + newline()
+    + "            }" + newline()
+    + "            try {" + newline()
+    + "                return java.util.Optional.ofNullable(java.lang.System.clearProperty(name));" + newline()
+    + "            } catch (java.lang.IllegalArgumentException | java.lang.NullPointerException | java.lang.SecurityException e) {" + newline()
+    + "                return java.util.Optional.empty();" + newline()
+    + "            }" + newline()
+    + "        });" + newline()
+    + "    }" + newline() + newline()
+    + java_system_aliases(module.functions)
     + "}" + newline()
+
+/// Emits generated aliases for public System functions.
+private fun java_system_aliases(functions: List[CompiledFunction]): String =
+    match functions[0] with
+    case None -> ""
+    case Some { function } -> java_system_alias(function) + java_system_aliases(functions[1:])
+
+/// Emits a generated alias for a public System function.
+private fun java_system_alias(function: CompiledFunction): String =
+    if function.name == "current_millis"
+    then "    public static capy.lang.Effect<java.lang.Long> " + java_function_name(function) + "() {" + newline()
+        + "        return currentMillis();" + newline()
+        + "    }" + newline() + newline()
+    else if function.name == "nano_time"
+    then "    public static capy.lang.Effect<java.lang.Long> " + java_function_name(function) + "() {" + newline()
+        + "        return nanoTime();" + newline()
+        + "    }" + newline() + newline()
+    else if function.name == "system_property"
+    then "    public static capy.lang.Effect<java.util.Optional<java.lang.String>> " + java_function_name(function) + "(java.lang.String " + java_identifier(java_first_function_parameter_name(function)) + ") {" + newline()
+        + "        return systemProperty(" + java_identifier(java_first_function_parameter_name(function)) + ");" + newline()
+        + "    }" + newline() + newline()
+    else if function.name == "set_system_property"
+    then "    public static capy.lang.Effect<java.util.Optional<java.lang.String>> " + java_function_name(function) + "(java.lang.String " + java_identifier(java_first_function_parameter_name(function)) + ", java.lang.String " + java_identifier(java_second_function_parameter_name(function)) + ") {" + newline()
+        + "        return setSystemProperty(" + java_identifier(java_first_function_parameter_name(function)) + ", " + java_identifier(java_second_function_parameter_name(function)) + ");" + newline()
+        + "    }" + newline() + newline()
+    else if function.name == "clear_system_property"
+    then "    public static capy.lang.Effect<java.util.Optional<java.lang.String>> " + java_function_name(function) + "(java.lang.String " + java_identifier(java_first_function_parameter_name(function)) + ") {" + newline()
+        + "        return clearSystemProperty(" + java_identifier(java_first_function_parameter_name(function)) + ");" + newline()
+        + "    }" + newline() + newline()
+    else ""
+
+/// Returns the first function parameter name.
+private fun java_first_function_parameter_name(function: CompiledFunction): String =
+    match function.parameters[0] with
+    case None -> "value"
+    case Some { parameter } -> parameter.name
+
+/// Returns the second function parameter name.
+private fun java_second_function_parameter_name(function: CompiledFunction): String =
+    match function.parameters[1] with
+    case None -> "value"
+    case Some { parameter } -> parameter.name
 
 /// Emits private Java functional interfaces needed for higher-arity Capybara function values.
 private fun java_function_type_interfaces(): String =
@@ -3696,6 +3769,8 @@ private fun function_call_code(call: CompiledFunctionCallExpression, env: List[J
     then
         let valueType = if expectedType.name == "Effect" then first_type_argument(expectedType) else expression_type(argument(call.arguments, 0), env, module, allModules)
         "capy.lang.Effect.pure(" + expression_code(argument(call.arguments, 0), env, valueType, module, allModules) + ")"
+    else if stdlib_system_property_call(call, module)
+    then stdlib_system_property_call_code(call, env, module, allModules)
     else if stdlib_effect_function_call(call, module)
     then stdlib_effect_function_call_code(call.name)
     else if async_function_call(call, module)
@@ -8028,6 +8103,8 @@ private fun function_call_type(call: CompiledFunctionCallExpression, env: List[J
     then effect_type(expression_type(argument(call.arguments, 0), env, module, allModules))
     else if async_function_call(call, module)
     then async_function_call_type(call, env, module, allModules)
+    else if stdlib_system_property_call(call, module)
+    then stdlib_system_property_call_type()
     else if stdlib_effect_function_call(call, module)
     then stdlib_effect_function_call_type(call.name)
     else if result_error_function_call(call, module)
@@ -8741,6 +8818,54 @@ private fun delay_call_type(arguments: List[CompiledExpression], env: List[JavaB
         match expression with
         case CompiledLambdaExpression lambda -> effect_type(expression_type(lambda.body, lambda_env(lambda.parameters, env), module, allModules))
         case _ -> effect_type(object_type())
+
+/// Checks whether a function matches the standard-library system property call metadata.
+private fun stdlib_system_property_call(call: CompiledFunctionCallExpression, module: CompiledModule): bool =
+    if call.name == "system_property"
+    then one_method_argument(call.arguments)
+        & !function_defined(call.name, module.functions)
+        & system_member_imported("system_property", module.imports)
+    else if call.name == "set_system_property"
+    then two_method_arguments(call.arguments)
+        & !function_defined(call.name, module.functions)
+        & system_member_imported("set_system_property", module.imports)
+    else if call.name == "clear_system_property"
+    then one_method_argument(call.arguments)
+        & !function_defined(call.name, module.functions)
+        & system_member_imported("clear_system_property", module.imports)
+    else false
+
+/// Emits generated code for standard-library system property call.
+private fun stdlib_system_property_call_code(call: CompiledFunctionCallExpression, env: List[JavaBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    if call.name == "system_property"
+    then "capy.lang.System.systemProperty("
+            + expression_code(argument(call.arguments, 0), env, string_type(), module, allModules)
+            + ")"
+    else if call.name == "set_system_property"
+    then "capy.lang.System.setSystemProperty("
+            + expression_code(argument(call.arguments, 0), env, string_type(), module, allModules)
+            + ", "
+            + expression_code(argument(call.arguments, 1), env, string_type(), module, allModules)
+            + ")"
+    else "capy.lang.System.clearSystemProperty("
+            + expression_code(argument(call.arguments, 0), env, string_type(), module, allModules)
+            + ")"
+
+/// Computes the compiled type for standard-library system property call.
+private fun stdlib_system_property_call_type(): CompiledTypeReference =
+    effect_type(option_type(string_type()))
+
+/// Checks whether a standard-library system property call can be emitted by the Java backend.
+private fun stdlib_system_property_call_emittable(call: CompiledFunctionCallExpression, env: List[JavaBinding], module: CompiledModule, allModules: List[CompiledModule]): bool =
+    if call.name == "system_property"
+    then one_method_argument(call.arguments)
+        & typed_argument_emittable(argument(call.arguments, 0), string_type(), env, module, allModules)
+    else if call.name == "set_system_property"
+    then two_method_arguments(call.arguments)
+        & typed_argument_emittable(argument(call.arguments, 0), string_type(), env, module, allModules)
+        & typed_argument_emittable(argument(call.arguments, 1), string_type(), env, module, allModules)
+    else one_method_argument(call.arguments)
+        & typed_argument_emittable(argument(call.arguments, 0), string_type(), env, module, allModules)
 
 /// Checks whether a function matches the standard-library effect function call metadata.
 private fun stdlib_effect_function_call(call: CompiledFunctionCallExpression, module: CompiledModule): bool =
@@ -11400,6 +11525,8 @@ private fun function_call_emittable(call: CompiledFunctionCallExpression, env: L
             else false
     else if async_function_call(call, module)
     then async_function_call_emittable(call, env, module, allModules)
+    else if stdlib_system_property_call(call, module)
+    then stdlib_system_property_call_emittable(call, env, module, allModules)
     else if stdlib_effect_function_call(call, module)
     then true
     else if result_error_function_call(call, module)
@@ -11524,7 +11651,7 @@ private fun function_defined(name: String, functions: List[CompiledFunction]): b
     match functions[0] with
     case None -> false
     case Some { function } ->
-        if function.name == name & !compiled_constant(function)
+        if !java_skip_function(function) & function.name == name & !compiled_constant(function)
         then true
         else function_defined(name, functions[1:])
 

--- a/capy/src/main/capybara/dev/capylang/generator/JavaScriptGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/JavaScriptGenerator.cfun
@@ -61,7 +61,7 @@ private data JavaScriptObjectInterfaceSources { methodInfoStatements: String, pa
 /// Decoded object field schema metadata used while emitting object reflection metadata.
 private data JavaScriptObjectFieldSchema { name: String, typeName: String }
 
-const JAVA_SCRIPT_RUNTIME_SYMBOLS = "Effect, Async, pure, delay, print, println, print_error, println_error, assert_all, assert_that, test, test_file, reflection, digits, DEFAULT_FAILED_EXIT_CODE, __capy_current_millis, __capy_nano_time, __capy_clock_now, __capy_path_from_string, __capy_io_read_text, __capy_io_read_lines, __capy_io_read_bytes, __capy_io_write_text, __capy_io_write_lines, __capy_io_write_bytes, __capy_io_append_text, __capy_io_append_lines, __capy_io_append_bytes, __capy_io_exists, __capy_io_is_file, __capy_io_is_directory, __capy_io_size, __capy_io_create_file, __capy_io_create_directory, __capy_io_create_directories, __capy_io_list_entries, __capy_io_delete, __capy_io_copy, __capy_io_copy_replace, __capy_io_move, __capy_io_move_replace, __capy_add, __capy_sub, __capy_mul, __capy_div, __capy_mod, __capy_pow, __capy_truthy, __capy_contains, __capy_size, __capy_to_int, __capy_to_long, __capy_parse_int, __capy_parse_long, __capy_parse_double, __capy_parse_float, __capy_parse_bool, __capy_enum_parse, __capy_enum_name, __capy_char, __capy_to_string, __capy_string_trim, __capy_string_replace, __capy_string_starts_with, __capy_string_end_with, __capy_string_get, __capy_string_slice, __capy_regex_matches, __capy_regex_find, __capy_regex_find_all, __capy_regex_replace, __capy_regex_split, __capy_date_unix_date, __capy_time_midnight, __capy_date_time_unix_epoch, __capy_duration_zero, __capy_date_add_days, __capy_date_add_years_months, __capy_date_to_days_since_unix_epoch, __capy_date_to_iso_8601, __capy_time_add_seconds, __capy_time_to_seconds, __capy_time_to_iso_8601, __capy_date_time_plus, __capy_date_time_minus, __capy_date_time_timestamp, __capy_date_time_to_iso_8601, __capy_duration_to_iso_8601, __capy_duration_negate, __capy_duration_years, __capy_duration_months, __capy_duration_days, __capy_duration_hours, __capy_duration_minutes, __capy_duration_seconds, __capy_tuple, __capy_set, __capy_set_append, __capy_set_concat, __capy_set_remove, __capy_set_remove_all, __capy_set_subset, __capy_set_proper_subset, __capy_set_intersection, __capy_set_symmetric_difference, __capy_set_cartesian_product, __capy_set_power_set, __capy_index, __capy_slice, __capy_get_field, __capy_reduce, __capy_with, __capy_data_fields, __capy_as_list, to_seq, __capy_async_start, __capy_async_join, __capy_async_all, __capy_async_any, __capy_async_map, __capy_async_flat_map, __capy_seq_map, __capy_seq_filter, __capy_seq_flat_map, __capy_option_map, __capy_option_filter, __capy_option_flat_map, __capy_result_map, __capy_result_flat_map, __capy_result_reduce, __capy_constructor_result, __capy_constructor_pipeline, __capy_any, __capy_all, __capy_type_matches, __capy_match_binding, __capy_no_match, __capy_throw, __capy_try, __capy_unsupported, __capy_not_implemented, __capy_data, __capy_export, __capy_unsafe_run, __capy_deep_equal, __capy_native_provider"
+const JAVA_SCRIPT_RUNTIME_SYMBOLS = "Effect, Async, pure, delay, print, println, print_error, println_error, assert_all, assert_that, test, test_file, reflection, digits, DEFAULT_FAILED_EXIT_CODE, __capy_current_millis, __capy_nano_time, __capy_system_property, __capy_set_system_property, __capy_clear_system_property, __capy_clock_now, __capy_path_from_string, __capy_io_read_text, __capy_io_read_lines, __capy_io_read_bytes, __capy_io_write_text, __capy_io_write_lines, __capy_io_write_bytes, __capy_io_append_text, __capy_io_append_lines, __capy_io_append_bytes, __capy_io_exists, __capy_io_is_file, __capy_io_is_directory, __capy_io_size, __capy_io_create_file, __capy_io_create_directory, __capy_io_create_directories, __capy_io_list_entries, __capy_io_delete, __capy_io_copy, __capy_io_copy_replace, __capy_io_move, __capy_io_move_replace, __capy_add, __capy_sub, __capy_mul, __capy_div, __capy_mod, __capy_pow, __capy_truthy, __capy_contains, __capy_size, __capy_to_int, __capy_to_long, __capy_parse_int, __capy_parse_long, __capy_parse_double, __capy_parse_float, __capy_parse_bool, __capy_enum_parse, __capy_enum_name, __capy_char, __capy_to_string, __capy_string_trim, __capy_string_replace, __capy_string_starts_with, __capy_string_end_with, __capy_string_get, __capy_string_slice, __capy_regex_matches, __capy_regex_find, __capy_regex_find_all, __capy_regex_replace, __capy_regex_split, __capy_date_unix_date, __capy_time_midnight, __capy_date_time_unix_epoch, __capy_duration_zero, __capy_date_add_days, __capy_date_add_years_months, __capy_date_to_days_since_unix_epoch, __capy_date_to_iso_8601, __capy_time_add_seconds, __capy_time_to_seconds, __capy_time_to_iso_8601, __capy_date_time_plus, __capy_date_time_minus, __capy_date_time_timestamp, __capy_date_time_to_iso_8601, __capy_duration_to_iso_8601, __capy_duration_negate, __capy_duration_years, __capy_duration_months, __capy_duration_days, __capy_duration_hours, __capy_duration_minutes, __capy_duration_seconds, __capy_tuple, __capy_set, __capy_set_append, __capy_set_concat, __capy_set_remove, __capy_set_remove_all, __capy_set_subset, __capy_set_proper_subset, __capy_set_intersection, __capy_set_symmetric_difference, __capy_set_cartesian_product, __capy_set_power_set, __capy_index, __capy_slice, __capy_get_field, __capy_reduce, __capy_with, __capy_data_fields, __capy_as_list, to_seq, __capy_async_start, __capy_async_join, __capy_async_all, __capy_async_any, __capy_async_map, __capy_async_flat_map, __capy_seq_map, __capy_seq_filter, __capy_seq_flat_map, __capy_option_map, __capy_option_filter, __capy_option_flat_map, __capy_result_map, __capy_result_flat_map, __capy_result_reduce, __capy_constructor_result, __capy_constructor_pipeline, __capy_any, __capy_all, __capy_type_matches, __capy_match_binding, __capy_no_match, __capy_throw, __capy_try, __capy_unsupported, __capy_not_implemented, __capy_data, __capy_export, __capy_unsafe_run, __capy_deep_equal, __capy_native_provider"
 
 /// Passes an optional string through unchanged where JavaScript generator pipelines need a named adapter.
 private fun java_script_option_string_identity(value: /capy/lang/Option[String]): /capy/lang/Option[String] = value
@@ -159,6 +159,9 @@ private fun java_script_runtime_symbol_names(): List[String] =
         "DEFAULT_FAILED_EXIT_CODE",
         "__capy_current_millis",
         "__capy_nano_time",
+        "__capy_system_property",
+        "__capy_set_system_property",
+        "__capy_clear_system_property",
         "__capy_clock_now",
         "__capy_path_from_string",
         "__capy_io_read_text",
@@ -1480,9 +1483,26 @@ private fun java_script_function_body_expression(function: CompiledFunction, mod
     match nativeProviderScope.declarations.get(function.name) with
     case Some { declaration } -> java_script_native_provider_function_body(declaration, function.returnType, nativeProviderScope)
     case None ->
-        if java_script_async_native_function(function, module)
+        if java_script_system_property_native_function(function, module)
+        then java_script_system_property_native_function_body(function)
+        else if java_script_async_native_function(function, module)
         then java_script_async_native_function_body(function)
         else java_script_expression_code(function.body, java_script_function_bindings(function), module, allModules)
+
+/// Checks whether a function is a System native runtime wrapper.
+private fun java_script_system_property_native_function(function: CompiledFunction, module: CompiledModule): bool =
+    module.path == "capy/lang"
+        & module.name == "System"
+        & (function.name == "system_property" | function.name == "set_system_property" | function.name == "clear_system_property")
+        & java_script_native_function_body(function)
+
+/// Emits the System property native runtime wrapper body.
+private fun java_script_system_property_native_function_body(function: CompiledFunction): String =
+    if function.name == "system_property"
+    then "__capy_system_property(" + java_script_identifier(first_function_parameter_name(function)) + ")"
+    else if function.name == "set_system_property"
+    then "__capy_set_system_property(" + java_script_identifier(first_function_parameter_name(function)) + ", " + java_script_identifier(second_function_parameter_name(function)) + ")"
+    else "__capy_clear_system_property(" + java_script_identifier(first_function_parameter_name(function)) + ")"
 
 /// Checks whether a function is an Async native runtime wrapper.
 private fun java_script_async_native_function(function: CompiledFunction, module: CompiledModule): bool =
@@ -1498,6 +1518,12 @@ private fun java_script_async_native_function_body(function: CompiledFunction): 
 /// Returns the first function parameter name.
 private fun first_function_parameter_name(function: CompiledFunction): String =
     match function.parameters[0] with
+    case Some { parameter } -> parameter.name
+    case None -> "value"
+
+/// Returns the second function parameter name.
+private fun second_function_parameter_name(function: CompiledFunction): String =
+    match function.parameters[1] with
     case Some { parameter } -> parameter.name
     case None -> "value"
 
@@ -2443,6 +2469,8 @@ private fun java_script_function_call_code(call: CompiledFunctionCallExpression,
     then java_script_object_type_call_code(call.name, module, allModules)
     else if java_script_stdlib_parse_function_call(call, module)
     then java_script_stdlib_parse_function_call_code(call, env, module, allModules)
+    else if java_script_stdlib_system_property_call(call, module)
+    then java_script_stdlib_system_property_call_code(call, env, module, allModules)
     else if java_script_stdlib_effect_function_call(call, module)
     then java_script_stdlib_effect_function_call_code(call.name)
     else if java_script_oo_constructor_call(call.name, module, allModules)
@@ -4566,7 +4594,9 @@ private fun java_script_let_binding_type(binding: CompiledLetBinding, env: List[
 private fun java_script_effect_binding_payload_type(expression: CompiledExpression, env: List[JavaScriptBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
     match expression with
     case CompiledFunctionCallExpression call ->
-        if java_script_oo_constructor_call(call.name, module, allModules)
+        if java_script_stdlib_system_property_call(call, module)
+        then "Option"
+        else if java_script_oo_constructor_call(call.name, module, allModules)
         then java_script_oo_constructor_call_payload_type(call.name, module, allModules)
         else java_script_effect_payload_type_from_function_call(call.name, module, allModules)
     case CompiledMethodCallExpression call -> java_script_effect_payload_type_from_method_call(call, env, module, allModules)
@@ -4616,6 +4646,8 @@ private fun java_script_expression_type(expression: CompiledExpression, env: Lis
     case CompiledFunctionCallExpression call ->
         if java_script_stdlib_math_sqrt_call(call, module)
         then "float"
+        else if java_script_stdlib_system_property_call(call, module)
+        then "Effect"
         else java_script_function_call_expression_type(call.name, module, allModules)
     case CompiledMethodCallExpression call -> java_script_method_call_expression_type(call, env, module, allModules)
     case CompiledListLiteral _ -> "List"
@@ -5232,6 +5264,38 @@ private fun java_script_stdlib_effect_function_call(call: CompiledFunctionCallEx
     if call.arguments.is_empty()
     then java_script_stdlib_effect_function_call_by_name(call.name, module)
     else false
+
+/// Checks whether a function matches the standard-library system property call metadata.
+private fun java_script_stdlib_system_property_call(call: CompiledFunctionCallExpression, module: CompiledModule): bool =
+    if call.name == "system_property"
+    then java_script_one_method_argument(call.arguments)
+        & !java_script_local_function_exists(call.name, module.functions)
+        & java_script_system_member_imported("system_property", module.imports)
+    else if call.name == "set_system_property"
+    then java_script_two_method_arguments(call.arguments)
+        & !java_script_local_function_exists(call.name, module.functions)
+        & java_script_system_member_imported("set_system_property", module.imports)
+    else if call.name == "clear_system_property"
+    then java_script_one_method_argument(call.arguments)
+        & !java_script_local_function_exists(call.name, module.functions)
+        & java_script_system_member_imported("clear_system_property", module.imports)
+    else false
+
+/// Emits JavaScript code for standard-library system property call.
+private fun java_script_stdlib_system_property_call_code(call: CompiledFunctionCallExpression, env: List[JavaScriptBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    if call.name == "system_property"
+    then "__capy_system_property("
+            + java_script_first_method_argument_code(call.arguments, env, module, allModules)
+            + ")"
+    else if call.name == "set_system_property"
+    then "__capy_set_system_property("
+            + java_script_first_method_argument_code(call.arguments, env, module, allModules)
+            + ", "
+            + java_script_second_method_argument_code(call.arguments, env, module, allModules)
+            + ")"
+    else "__capy_clear_system_property("
+            + java_script_first_method_argument_code(call.arguments, env, module, allModules)
+            + ")"
 
 /// Checks whether a function matches the standard-library effect function call by name metadata.
 private fun java_script_stdlib_effect_function_call_by_name(name: String, module: CompiledModule): bool =
@@ -6366,6 +6430,10 @@ private fun java_script_effect_runtime_code(): String =
     + "function __capy_async_flat_map(asyncValue, mapper) { return new Async(() => { const mapped = __capy_unsafe_run(mapper(__capy_async_value(asyncValue))); if (__capy_data_is(mapped, 'Error')) throw new CapyAsyncResultFailure(mapped); if (__capy_data_is(mapped, 'Success')) return __capy_match_binding(mapped, 'value', 0); throw new CapyAsyncResultFailure(__capy_error_full('capy.lang.argument.invalid', 'Async.flat_map expected Result value', __capy_none(), __capy_none(), [], __capy_none(), __capy_none(), [])); }); }" + java_script_newline()
     + "function __capy_current_millis() { return Effect.delay(() => __capy_long(BigInt(Date.now()))); }" + java_script_newline()
     + "function __capy_nano_time() { return Effect.delay(() => __capy_long(process.hrtime.bigint())); }" + java_script_newline()
+    + "const __capy_system_properties = new Map();" + java_script_newline()
+    + "function __capy_system_property(name) { return Effect.delay(() => { if (name === undefined || name === null || name === '') return __capy_data('None', Object.fromEntries([])); if (__capy_system_properties.has(name)) return __capy_data('Some', { value: __capy_system_properties.get(name) }); return __capy_data('None', Object.fromEntries([])); }); }" + java_script_newline()
+    + "function __capy_set_system_property(name, value) { return Effect.delay(() => { if (name === undefined || name === null || name === '' || value === undefined || value === null) return __capy_data('None', Object.fromEntries([])); const previous = __capy_system_properties.has(name) ? __capy_data('Some', { value: __capy_system_properties.get(name) }) : __capy_data('None', Object.fromEntries([])); __capy_system_properties.set(name, value); return previous; }); }" + java_script_newline()
+    + "function __capy_clear_system_property(name) { return Effect.delay(() => { if (name === undefined || name === null || name === '') return __capy_data('None', Object.fromEntries([])); if (!__capy_system_properties.has(name)) return __capy_data('None', Object.fromEntries([])); const previous = __capy_system_properties.get(name); __capy_system_properties.delete(name); return __capy_data('Some', { value: previous }); }); }" + java_script_newline()
     + "function __capy_clock_now() { return Effect.delay(() => { const current = new Date(); return __capy_date_time(__capy_date(current.getUTCDate(), current.getUTCMonth() + 1, current.getUTCFullYear()), __capy_time(current.getUTCHours(), current.getUTCMinutes(), current.getUTCSeconds(), __capy_data('Some', { value: 0 }))); }); }" + java_script_newline()
     + "function __capy_console_value(value) { if (Array.isArray(value)) return String.fromCharCode(...value); return __capy_str(value); }" + java_script_newline()
     + "function print(value) { return Effect.delay(() => { process.stdout.write(__capy_console_value(value)); return value; }); }" + java_script_newline()
@@ -7193,6 +7261,8 @@ private fun java_script_function_call_gatherable(call: CompiledFunctionCallExpre
         then true
         else if java_script_oo_constructor_call(call.name, module, allModules)
         then true
+        else if java_script_stdlib_system_property_call(call, module)
+        then true
         else if java_script_stdlib_effect_function_call(call, module)
         then true
         else if java_script_stdlib_path_function_call(call, module)
@@ -7420,6 +7490,13 @@ private fun java_script_local_function_count_at_most(name: String, functions: Li
         if !java_script_skip_function(function) & function.name == name
         then 1 + java_script_local_function_count_at_most(name, functions[1:], limit - 1)
         else java_script_local_function_count_at_most(name, functions[1:], limit)
+
+/// Checks whether a local function with the given name was declared without running generation filters.
+private fun java_script_local_function_declared(name: String, functions: List[CompiledFunction]): bool =
+    match functions[0] with
+    case None -> false
+    case Some { function } ->
+        function.name == name | java_script_local_function_declared(name, functions[1:])
 
 /// Collects imported function exists visible to the current module.
 private fun java_script_imported_function_exists(name: String, imports: List[CompiledImportDeclaration], module: CompiledModule, allModules: List[CompiledModule]): bool =

--- a/capy/src/main/capybara/dev/capylang/generator/PythonGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/PythonGenerator.cfun
@@ -726,9 +726,26 @@ private fun python_function_body(function: CompiledFunction, env: List[PythonBin
     match nativeProviderScope.declarations.get(function.name) with
     case Some { declaration } -> python_native_provider_function_body(declaration, function.returnType, nativeProviderScope)
     case None ->
-        if python_async_native_function(function, module)
+        if python_system_property_native_function(function, module)
+        then "    return " + python_system_property_native_function_body(function) + python_newline()
+        else if python_async_native_function(function, module)
         then "    return " + python_async_native_function_body(function) + python_newline()
         else python_return_statement(function.body, env, module, allModules, "    ", function.returnType)
+
+/// Checks whether a function is a System native runtime wrapper.
+private fun python_system_property_native_function(function: CompiledFunction, module: CompiledModule): bool =
+    module.path == "capy/lang"
+        & module.name == "System"
+        & (function.name == "system_property" | function.name == "set_system_property" | function.name == "clear_system_property")
+        & python_native_placeholder_function(function)
+
+/// Emits the System property native runtime wrapper body.
+private fun python_system_property_native_function_body(function: CompiledFunction): String =
+    if function.name == "system_property"
+    then "__capy_system_property(" + python_identifier(python_first_function_parameter_name(function)) + ")"
+    else if function.name == "set_system_property"
+    then "__capy_set_system_property(" + python_identifier(python_first_function_parameter_name(function)) + ", " + python_identifier(python_second_function_parameter_name(function)) + ")"
+    else "__capy_clear_system_property(" + python_identifier(python_first_function_parameter_name(function)) + ")"
 
 /// Checks whether a function is an Async native runtime wrapper.
 private fun python_async_native_function(function: CompiledFunction, module: CompiledModule): bool =
@@ -744,6 +761,12 @@ private fun python_async_native_function_body(function: CompiledFunction): Strin
 /// Returns the first function parameter name.
 private fun python_first_function_parameter_name(function: CompiledFunction): String =
     match function.parameters[0] with
+    case Some { parameter } -> parameter.name
+    case None -> "value"
+
+/// Returns the second function parameter name.
+private fun python_second_function_parameter_name(function: CompiledFunction): String =
+    match function.parameters[1] with
     case Some { parameter } -> parameter.name
     case None -> "value"
 
@@ -1196,7 +1219,9 @@ private fun python_unary_expression_code(unary: CompiledUnaryExpression, env: Li
 
 /// Emits Python code for function call.
 private fun python_function_call_code(call: CompiledFunctionCallExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
-    if python_stdlib_effect_function_call(call, module)
+    if python_stdlib_system_property_call(call, module)
+    then python_stdlib_system_property_call_code(call, env, module, allModules)
+    else if python_stdlib_effect_function_call(call, module)
     then python_stdlib_effect_function_call_code(call.name)
     else if python_stdlib_parse_function_call(call, module)
     then python_stdlib_parse_function_call_code(call, env, module, allModules)
@@ -3365,7 +3390,9 @@ private fun python_user_defined_index_type(receiverType: String, module: Compile
 
 /// Infers the expression type for function call.
 private fun python_function_call_expression_type(call: CompiledFunctionCallExpression, module: CompiledModule, allModules: List[CompiledModule]): String =
-    if python_stdlib_effect_function_call(call, module)
+    if python_stdlib_system_property_call(call, module)
+    then python_effect_type()
+    else if python_stdlib_effect_function_call(call, module)
     then python_stdlib_effect_function_call_type(call.name)
     else if python_object_type_function_call(call, module, allModules)
     then python_object_type_function_call_type(call, module, allModules)
@@ -3439,6 +3466,38 @@ private fun python_stdlib_effect_function_call_by_name(name: String, module: Com
     else if name == "now"
     then !python_local_function_exists(name, module.functions) & python_clock_member_imported("now", module.imports)
     else false
+
+/// Checks whether a function matches the standard-library system property call metadata.
+private fun python_stdlib_system_property_call(call: CompiledFunctionCallExpression, module: CompiledModule): bool =
+    if call.name == "system_property"
+    then python_one_method_argument(call.arguments)
+        & !python_local_function_exists(call.name, module.functions)
+        & python_system_member_imported("system_property", module.imports)
+    else if call.name == "set_system_property"
+    then python_two_method_arguments(call.arguments)
+        & !python_local_function_exists(call.name, module.functions)
+        & python_system_member_imported("set_system_property", module.imports)
+    else if call.name == "clear_system_property"
+    then python_one_method_argument(call.arguments)
+        & !python_local_function_exists(call.name, module.functions)
+        & python_system_member_imported("clear_system_property", module.imports)
+    else false
+
+/// Emits Python code for standard-library system property call.
+private fun python_stdlib_system_property_call_code(call: CompiledFunctionCallExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    if call.name == "system_property"
+    then "__capy_system_property("
+            + python_first_method_argument_code(call.arguments, env, module, allModules)
+            + ")"
+    else if call.name == "set_system_property"
+    then "__capy_set_system_property("
+            + python_first_method_argument_code(call.arguments, env, module, allModules)
+            + ", "
+            + python_second_method_argument_code(call.arguments, env, module, allModules)
+            + ")"
+    else "__capy_clear_system_property("
+            + python_first_method_argument_code(call.arguments, env, module, allModules)
+            + ")"
 
 /// Emits Python code for standard-library effect function call.
 private fun python_stdlib_effect_function_call_code(name: String): String =
@@ -3749,7 +3808,9 @@ private fun python_effect_payload_type(expression: CompiledExpression, env: List
 
 /// Emits Python expression text for effect payload type from function call.
 private fun python_effect_payload_type_from_function_call(call: CompiledFunctionCallExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
-    if python_stdlib_effect_function_call(call, module)
+    if python_stdlib_system_property_call(call, module)
+    then python_option_type()
+    else if python_stdlib_effect_function_call(call, module)
     then python_stdlib_effect_payload_type(call.name)
     else match python_find_object_class_in_scope(call.name, module, allModules) with
     case Some { binding } -> python_object_type_name(binding.module, binding.objectClass.name)
@@ -5672,7 +5733,7 @@ private fun python_test_runtime_header_code(): String =
     + "import time" + python_newline()
     + "import traceback" + python_newline()
     + python_newline()
-    + "__all__ = ['Effect', 'Async', 'CapySet', 'pure', 'delay', 'print', 'println', 'print_error', 'println_error', 'DEFAULT_FAILED_EXIT_CODE', 'assert_all', 'assert_that', 'test', 'test_file', 'reflection', 'from_string', 'read_text', 'read_lines', 'read_bytes', 'write_text', 'write_lines', 'write_bytes', 'append_text', 'append_lines', 'append_bytes', 'exists', 'is_file', 'is_directory', 'size', 'create_file', 'create_directory', 'create_directories', 'list_entries', 'delete', 'copy', 'copy_replace', 'move', 'move_replace', 'digits', 'to_seq', '__capy_async_start', '__capy_async_join', '__capy_async_all', '__capy_async_any', '__capy_async_map', '__capy_async_flat_map', '__capy_current_millis', '__capy_nano_time', '__capy_clock_now', '_unsafe_run', '_capy_data_is', '_capy_data_value', '__capy_bind_value', '__capy_effect_bind_value', '__capy_long', '__capy_to_int', '__capy_to_long', '__capy_parse_int', '__capy_parse_long', '__capy_parse_double', '__capy_parse_float', '__capy_parse_bool', '__capy_enum_parse', '__capy_enum_name', '__capy_char', '__capy_to_string', '__capy_date_unix_date', '__capy_time_midnight', '__capy_date_time_unix_epoch', '__capy_duration_zero', '__capy_date_add_days', '__capy_date_add_years_months', '__capy_date_to_days_since_unix_epoch', '__capy_date_to_iso_8601', '__capy_time_add_seconds', '__capy_time_to_seconds', '__capy_time_to_iso_8601', '__capy_date_time_plus', '__capy_date_time_minus', '__capy_date_time_timestamp', '__capy_date_time_to_iso_8601', '__capy_duration_to_iso_8601', '__capy_duration_negate', '__capy_duration_years', '__capy_duration_months', '__capy_duration_days', '__capy_duration_hours', '__capy_duration_minutes', '__capy_duration_seconds', '__capy_set', '__capy_set_append', '__capy_set_concat', '__capy_set_remove', '__capy_set_remove_all', '__capy_set_subset', '__capy_set_proper_subset', '__capy_set_intersection', '__capy_set_symmetric_difference', '__capy_set_cartesian_product', '__capy_set_power_set', '__capy_deep_equal', '__capy_add', '__capy_sub', '__capy_mul', '__capy_div', '__capy_mod', '__capy_pow', '__capy_pow_int', '__capy_contains', '__capy_size', '__capy_is_empty', '__capy_string_trim', '__capy_string_replace', '__capy_string_starts_with', '__capy_string_end_with', '__capy_string_get', '__capy_string_slice', '__capy_regex_matches', '__capy_regex_find', '__capy_regex_find_all', '__capy_regex_replace', '__capy_regex_split', '__capy_index', '__capy_get_field', '__capy_reduce', '__capy_as_list', '__capy_seq_map', '__capy_seq_filter', '__capy_seq_reject', '__capy_seq_flat_map', '__capy_option_map', '__capy_option_filter', '__capy_option_flat_map', '__capy_option_reduce', '__capy_result_map', '__capy_result_flat_map', '__capy_result_or', '__capy_result_or_else', '__capy_result_reduce', '__capy_any', '__capy_all', '__capy_type_matches', '__capy_match_binding', '__capy_no_match', '__capy_throw', '__capy_try', '__capy_unsupported', '__capy_not_implemented', '__capy_reflection_annotations', '__capy_data', '__capy_with', '__capy_constructor_value', '__capy_constructor_result', '__capy_primitive_constructor_result', '__capy_constructor_pipeline']" + python_newline()
+    + "__all__ = ['Effect', 'Async', 'CapySet', 'pure', 'delay', 'print', 'println', 'print_error', 'println_error', 'DEFAULT_FAILED_EXIT_CODE', 'assert_all', 'assert_that', 'test', 'test_file', 'reflection', 'from_string', 'read_text', 'read_lines', 'read_bytes', 'write_text', 'write_lines', 'write_bytes', 'append_text', 'append_lines', 'append_bytes', 'exists', 'is_file', 'is_directory', 'size', 'create_file', 'create_directory', 'create_directories', 'list_entries', 'delete', 'copy', 'copy_replace', 'move', 'move_replace', 'digits', 'to_seq', '__capy_async_start', '__capy_async_join', '__capy_async_all', '__capy_async_any', '__capy_async_map', '__capy_async_flat_map', '__capy_current_millis', '__capy_nano_time', '__capy_system_property', '__capy_set_system_property', '__capy_clear_system_property', '__capy_clock_now', '_unsafe_run', '_capy_data_is', '_capy_data_value', '__capy_bind_value', '__capy_effect_bind_value', '__capy_long', '__capy_to_int', '__capy_to_long', '__capy_parse_int', '__capy_parse_long', '__capy_parse_double', '__capy_parse_float', '__capy_parse_bool', '__capy_enum_parse', '__capy_enum_name', '__capy_char', '__capy_to_string', '__capy_date_unix_date', '__capy_time_midnight', '__capy_date_time_unix_epoch', '__capy_duration_zero', '__capy_date_add_days', '__capy_date_add_years_months', '__capy_date_to_days_since_unix_epoch', '__capy_date_to_iso_8601', '__capy_time_add_seconds', '__capy_time_to_seconds', '__capy_time_to_iso_8601', '__capy_date_time_plus', '__capy_date_time_minus', '__capy_date_time_timestamp', '__capy_date_time_to_iso_8601', '__capy_duration_to_iso_8601', '__capy_duration_negate', '__capy_duration_years', '__capy_duration_months', '__capy_duration_days', '__capy_duration_hours', '__capy_duration_minutes', '__capy_duration_seconds', '__capy_set', '__capy_set_append', '__capy_set_concat', '__capy_set_remove', '__capy_set_remove_all', '__capy_set_subset', '__capy_set_proper_subset', '__capy_set_intersection', '__capy_set_symmetric_difference', '__capy_set_cartesian_product', '__capy_set_power_set', '__capy_deep_equal', '__capy_add', '__capy_sub', '__capy_mul', '__capy_div', '__capy_mod', '__capy_pow', '__capy_pow_int', '__capy_contains', '__capy_size', '__capy_is_empty', '__capy_string_trim', '__capy_string_replace', '__capy_string_starts_with', '__capy_string_end_with', '__capy_string_get', '__capy_string_slice', '__capy_regex_matches', '__capy_regex_find', '__capy_regex_find_all', '__capy_regex_replace', '__capy_regex_split', '__capy_index', '__capy_get_field', '__capy_reduce', '__capy_as_list', '__capy_seq_map', '__capy_seq_filter', '__capy_seq_reject', '__capy_seq_flat_map', '__capy_option_map', '__capy_option_filter', '__capy_option_flat_map', '__capy_option_reduce', '__capy_result_map', '__capy_result_flat_map', '__capy_result_or', '__capy_result_or_else', '__capy_result_reduce', '__capy_any', '__capy_all', '__capy_type_matches', '__capy_match_binding', '__capy_no_match', '__capy_throw', '__capy_try', '__capy_unsupported', '__capy_not_implemented', '__capy_reflection_annotations', '__capy_data', '__capy_with', '__capy_constructor_value', '__capy_constructor_result', '__capy_primitive_constructor_result', '__capy_constructor_pipeline']" + python_newline()
     + python_newline()
 
 /// Emits Python code for test runtime effect.
@@ -5790,6 +5851,38 @@ private fun python_test_runtime_effect_code(): String =
     + python_newline()
     + "def __capy_nano_time():" + python_newline()
     + "    return Effect.delay(lambda: __capy_long(time.monotonic_ns()))" + python_newline()
+    + python_newline()
+    + "__capy_system_properties = dict()" + python_newline()
+    + python_newline()
+    + "def __capy_system_property(name):" + python_newline()
+    + "    def __capy_read_system_property():" + python_newline()
+    + "        if name is None or name == '':" + python_newline()
+    + "            return __capy_data('None', dict())" + python_newline()
+    + "        if name in __capy_system_properties:" + python_newline()
+    + "            return __capy_data('Some', dict(value=__capy_system_properties[name]))" + python_newline()
+    + "        return __capy_data('None', dict())" + python_newline()
+    + "    return Effect.delay(__capy_read_system_property)" + python_newline()
+    + python_newline()
+    + "def __capy_set_system_property(name, value):" + python_newline()
+    + "    def __capy_write_system_property():" + python_newline()
+    + "        if name is None or name == '' or value is None:" + python_newline()
+    + "            return __capy_data('None', dict())" + python_newline()
+    + "        previous = __capy_system_properties.get(name)" + python_newline()
+    + "        __capy_system_properties[name] = value" + python_newline()
+    + "        if previous is None:" + python_newline()
+    + "            return __capy_data('None', dict())" + python_newline()
+    + "        return __capy_data('Some', dict(value=previous))" + python_newline()
+    + "    return Effect.delay(__capy_write_system_property)" + python_newline()
+    + python_newline()
+    + "def __capy_clear_system_property(name):" + python_newline()
+    + "    def __capy_clear_property():" + python_newline()
+    + "        if name is None or name == '':" + python_newline()
+    + "            return __capy_data('None', dict())" + python_newline()
+    + "        if name not in __capy_system_properties:" + python_newline()
+    + "            return __capy_data('None', dict())" + python_newline()
+    + "        previous = __capy_system_properties.pop(name)" + python_newline()
+    + "        return __capy_data('Some', dict(value=previous))" + python_newline()
+    + "    return Effect.delay(__capy_clear_property)" + python_newline()
     + python_newline()
     + "def __capy_clock_now():" + python_newline()
     + "    def __capy_run_clock_now():" + python_newline()
@@ -7765,7 +7858,9 @@ private fun python_unary_operator_gatherable(operator: String): bool =
 /// Checks whether function call can be included in generated test gathering.
 private fun python_function_call_gatherable(call: CompiledFunctionCallExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): bool =
     if python_expressions_gatherable(call.arguments, env, module, allModules)
-    then if python_stdlib_effect_function_call(call, module)
+    then if python_stdlib_system_property_call(call, module)
+        then true
+        else if python_stdlib_effect_function_call(call, module)
         then true
         else if python_runtime_function(call.name)
         then true
@@ -7986,6 +8081,13 @@ private fun python_local_function_count_at_most(name: String, functions: List[Co
         if !python_skip_function(function) & function.name == name
         then 1 + python_local_function_count_at_most(name, functions[1:], limit - 1)
         else python_local_function_count_at_most(name, functions[1:], limit)
+
+/// Checks whether a local function with the given name was declared without running generation filters.
+private fun python_local_function_declared(name: String, functions: List[CompiledFunction]): bool =
+    match functions[0] with
+    case None -> false
+    case Some { function } ->
+        function.name == name | python_local_function_declared(name, functions[1:])
 
 /// Collects imported function exists visible to the current module.
 private fun python_imported_function_exists(name: String, imports: List[CompiledImportDeclaration], module: CompiledModule, allModules: List[CompiledModule]): bool =

--- a/lib/capybara-lib/src/main/capybara/capy/lang/System.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/System.cfun
@@ -1,4 +1,5 @@
 from /capy/lang/Effect import { * }
+from /capy/lang/Option import { Option }
 
 /// Returns an effect that reads the current system time in milliseconds since the Unix epoch.
 ///
@@ -9,3 +10,18 @@ fun current_millis(): Effect[long] = <native>
 ///
 /// Use this for measuring elapsed durations, not for wall-clock timestamps.
 fun nano_time(): Effect[long] = <native>
+
+/// Returns an effect that reads a system property by name.
+///
+/// Missing, empty, or inaccessible properties return `None`.
+fun system_property(name: String): Effect[Option[String]] = <native>
+
+/// Returns an effect that sets a system property and returns its previous value.
+///
+/// Missing previous values, empty names, or inaccessible properties return `None`.
+fun set_system_property(name: String, value: String): Effect[Option[String]] = <native>
+
+/// Returns an effect that clears a system property and returns its previous value.
+///
+/// Missing previous values, empty names, or inaccessible properties return `None`.
+fun clear_system_property(name: String): Effect[Option[String]] = <native>

--- a/lib/capybara-lib/src/test/capybara/capy/lang/SystemTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/SystemTest.cfun
@@ -1,0 +1,70 @@
+from /capy/test/Assert import { * }
+from /capy/lang/Effect import { * }
+from /capy/lang/System import { clear_system_property, nano_time, set_system_property, system_property }
+from /capy/test/CapyTest import { * }
+
+fun tests(): Effect[TestFile] =
+    test_file("/capy/lang/SystemTest.cfun", [
+        system_property_empty_name_returns_none().map(assertion => test("system_property empty name returns None", () => assertion)),
+        set_system_property_round_trips_value().map(assertion => test("set_system_property stores value and returns previous value", () => assertion)),
+        set_system_property_empty_name_returns_none().map(assertion => test("set_system_property empty name returns None", () => assertion)),
+        clear_system_property_removes_value().map(assertion => test("clear_system_property removes value and returns previous value", () => assertion)),
+        clear_system_property_empty_name_returns_none().map(assertion => test("clear_system_property empty name returns None", () => assertion)),
+    ])
+
+fun system_property_empty_name_returns_none(): Effect[Assert] =
+    system_property("").map(option => assert_that(option).is_empty())
+
+fun set_system_property_round_trips_value(): Effect[Assert] =
+    let key <- unique_system_property_key()
+    let missing <- system_property(key)
+    let previous <- set_system_property(key, "first")
+    let first <- system_property(key)
+    let overwritten <- set_system_property(key, "second")
+    let second <- system_property(key)
+    assert_all([
+        assert_that(missing).is_empty(),
+        assert_that(previous).is_empty(),
+        assert_that(first).contains("first"),
+        assert_that(overwritten).contains("first"),
+        assert_that(second).contains("second"),
+    ])
+
+fun set_system_property_empty_name_returns_none(): Effect[Assert] =
+    let previous <- set_system_property("", "ignored")
+    let value <- system_property("")
+    assert_all([
+        assert_that(previous).is_empty(),
+        assert_that(value).is_empty(),
+    ])
+
+fun clear_system_property_removes_value(): Effect[Assert] =
+    let key <- unique_system_property_key()
+    let empty_key = key + ".empty"
+    let missing <- clear_system_property(key)
+    let previous <- set_system_property(key, "value")
+    let cleared <- clear_system_property(key)
+    let value <- system_property(key)
+    let cleared_again <- clear_system_property(key)
+    let empty_previous <- set_system_property(empty_key, "")
+    let empty_cleared <- clear_system_property(empty_key)
+    assert_all([
+        assert_that(missing).is_empty(),
+        assert_that(previous).is_empty(),
+        assert_that(cleared).contains("value"),
+        assert_that(value).is_empty(),
+        assert_that(cleared_again).is_empty(),
+        assert_that(empty_previous).is_empty(),
+        assert_that(empty_cleared).contains(""),
+    ])
+
+fun clear_system_property_empty_name_returns_none(): Effect[Assert] =
+    let previous <- clear_system_property("")
+    let value <- system_property("")
+    assert_all([
+        assert_that(previous).is_empty(),
+        assert_that(value).is_empty(),
+    ])
+
+private fun unique_system_property_key(): Effect[String] =
+    nano_time().map(value => "capybara.system.property.test." + value)


### PR DESCRIPTION
## Summary

- Add `/capy/lang/System.system_property(name: String): Effect[Option[String]]`, `/capy/lang/System.set_system_property(name: String, value: String): Effect[Option[String]]`, and `/capy/lang/System.clear_system_property(name: String): Effect[Option[String]]` for Capybara Functional.
- Keep the API effectful and `Option`-based: missing values, invalid empty property names, or inaccessible properties return `None`; setting and clearing return the previous value as `Some(previous)` when present.
- Generate Java runtime support from platform system properties, with JavaScript and Python runtime-backed property maps for portable generated tests.
- Add stdlib `.cfun` tests and focused e2e `.cfun` coverage for setting, reading, overwriting, clearing, empty-string values, repeated clear, and empty-name behavior.

Closes #304

## Impacted Modules

- `lib/capybara-lib`: public `capy/lang/System.cfun` API and tests.
- `capy`: Java, JavaScript, and Python generators plus cfun e2e source coverage.

## Example

```cfun
from /capy/lang/System import { clear_system_property, set_system_property, system_property }

fun main(): Effect[Option[String]] =
    let previous <- set_system_property("capy.example", "enabled")
    let value <- system_property("capy.example")
    clear_system_property("capy.example")
```

## Validation

- `git diff --check`
- `./gradlew :lib:capybara-lib:compileCapybara`
- `./gradlew :lib:capybara-lib:testCapybara`
- `./gradlew :capy:run --args="compile-generate javascript -i /mnt/d/repos/capy-family/Capybara3/lib/capybara-lib/src/main/capybara -o /mnt/d/repos/capy-family/Capybara3/build/tmp/system-properties-e2e/js --test-input /mnt/d/repos/capy-family/Capybara3/build/tmp/system-properties-e2e/src --test-output /mnt/d/repos/capy-family/Capybara3/build/tmp/system-properties-e2e/js --skip-java-lib"`
- `./gradlew :capy:run --args="compile-generate python -i /mnt/d/repos/capy-family/Capybara3/lib/capybara-lib/src/main/capybara -o /mnt/d/repos/capy-family/Capybara3/build/tmp/system-properties-e2e/py --test-input /mnt/d/repos/capy-family/Capybara3/build/tmp/system-properties-e2e/src --test-output /mnt/d/repos/capy-family/Capybara3/build/tmp/system-properties-e2e/py --skip-java-lib"`
- `node lib/capybara-lib/src/test/js/run-capybara-tests.js --generated-dir build/tmp/system-properties-e2e/js --output-dir build/tmp/system-properties-e2e/js-results --report-type JUNIT --log TC`
- `python3 lib/capybara-lib/src/test/py/run-capybara-tests.py --generated-dir build/tmp/system-properties-e2e/py --output-dir build/tmp/system-properties-e2e/py-results --report-type JUNIT --log TC`

## Notes

- The existing `CompilationTest.java` changes were removed; this PR no longer modifies that file.
- No grammar changes or new ADR are needed; this follows the existing effectful native stdlib function pattern.
