### PR TITLE
fix(#311): use checked Windows release build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,15 @@ permissions:
 
 jobs:
   build-check:
+    name: build-check (${{ matrix.os }})
     if: ${{ github.event_name != 'push' || !startsWith(github.ref_name, 'merge-back/') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
 
     steps:
       - name: Checkout
@@ -54,16 +61,22 @@ jobs:
           cache-disabled: false
 
       - name: Make Gradle wrapper executable
+        if: runner.os != 'Windows'
         run: chmod +x gradlew
 
-      - name: Run Gradle check
+      - name: Run Gradle check on Linux
+        if: runner.os != 'Windows'
         run: ./gradlew clean check --no-daemon
+
+      - name: Run Gradle check on Windows
+        if: runner.os == 'Windows'
+        run: .\gradlew.bat clean check --no-daemon
 
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-check-test-reports
+          name: build-check-test-reports-${{ matrix.os }}
           path: |
             **/build/reports/tests/**
             **/build/test-results/**/*.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,21 +217,29 @@ jobs:
         with:
           cache-disabled: false
 
-      - name: Build Windows native CLI
-        run: .\gradlew.bat :capy:nativeCompile --no-daemon
+      - name: Build and check Windows distribution
+        run: .\gradlew.bat clean check assemble --no-daemon
 
-      - name: Collect Windows artifacts
+      - name: Build Windows native CLI
         shell: pwsh
         run: |
           $version = "${{ needs.release-metadata.outputs.release_version }}"
           New-Item -ItemType Directory -Path dist -Force | Out-Null
-          Copy-Item "capy/build/native/nativeCompile/capyc-$version.exe" "dist/capyc-$version-windows-x64.exe"
+          $jar = "capy/build/libs/capy-$version.jar"
+          if (-not (Test-Path $jar)) {
+            Write-Error "Expected CLI jar was not produced: $jar"
+          }
+          native-image --no-fallback -jar $jar "dist/capyc-$version-windows-x64"
+          $exe = "dist/capyc-$version-windows-x64.exe"
+          if (-not (Test-Path $exe)) {
+            Write-Error "Expected Windows native executable was not produced: $exe"
+          }
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-windows
-          path: dist/*
+          path: dist/*.exe
           if-no-files-found: error
 
   publish-release:


### PR DESCRIPTION
Fixes #311.

## What changed
- Run Build & Check on both Ubuntu and Windows.
- Run the Windows release job through `clean check assemble` before packaging.
- Build the Windows native executable with GraalVM `native-image` directly from the assembled CLI jar.
- Upload only the uniquely named Windows `.exe`, avoiding collisions with Linux distribution archives when release artifacts are merged.

## Why
The Release workflow failed on `release/0.4.x` because Windows does not register the Gradle `:capy:nativeCompile` task for `:capy`, but the release still needs a GraalVM native image. Running the regular check workflow on Windows should catch this class of issue earlier.

## Validation
- `git diff --check HEAD~1 HEAD -- .github/workflows/check.yml .github/workflows/release.yml`
- Parsed both changed workflow YAML files with Python/PyYAML.
