### PR TITLE
[codex] Render performance README as backend matrix

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -10,7 +10,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 2s (2.3 s)<br>🟢 Δ-0s / -13% | 2s (2.088 s)<br>🟢 Δ-0s / -17% | 2s (1.916 s)<br>🟢 Δ-1s / -32% |
+| `compile` | 2s (2.3 s)<br>🟢 Δ-0s / -13% | 2s (2.088 s)<br>🟢 Δ-0s / -17% | 2s (1.916 s)<br>🟢 Δ-1s / -32% |
 | `gen java` | 2s (1.631 s)<br>🟢 Δ-1m 24s / -98% | 2s (1.575 s)<br>🟢 Δ-1m 23s / -98% | 2s (1.534 s)<br>🟢 Δ-1m 23s / -98% |
 | `gen python` | 1s (1.107 s)<br>🟢 Δ-1m 24s / -99% | 1s (1.061 s)<br>🟢 Δ-1m 22s / -99% | 1s (1.106 s)<br>🟢 Δ-1m 22s / -99% |
 | `gen js` | 1s (0.954 s)<br>🟢 Δ-1m 22s / -99% | 1s (0.98 s)<br>🟢 Δ-1m 21s / -99% | 1s (0.977 s)<br>🟢 Δ-1m 23s / -99% |
@@ -22,7 +22,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 3s (2.632 s)<br>🟢 Δ-0s / -0% | 3s (2.524 s)<br>🟢 Δ-0s / -10% | 3s (2.811 s)<br>🟢 Δ-0s / -5% |
+| `compile` | 3s (2.632 s)<br>🟢 Δ-0s / -0% | 3s (2.524 s)<br>🟢 Δ-0s / -10% | 3s (2.811 s)<br>🟢 Δ-0s / -5% |
 | `gen java` | 1m 26s (85.751 s)<br>🟡 Δ+5s / +6% | 1m 25s (84.972 s)<br>🟢 Δ-1s / -1% | 1m 25s (84.977 s)<br>🔵 Δ+1s / +1% |
 | `gen python` | 1m 25s (84.86 s)<br>🟡 Δ+5s / +6% | 1m 23s (83.485 s)<br>🔵 Δ+1s / +1% | 1m 23s (82.86 s)<br>🔵 Δ+1s / +1% |
 | `gen js` | 1m 23s (83.159 s)<br>🟡 Δ+3s / +4% | 1m 22s (82.276 s)<br>🔵 Δ+1s / +1% | 1m 24s (84.17 s)<br>🟡 Δ+3s / +4% |
@@ -34,7 +34,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 3s (2.638 s)<br>🟡 Δ+0s / +5% | 3s (2.789 s)<br>🔴 Δ+0s / +18% | 3s (2.955 s)<br>🔴 Δ+0s / +19% |
+| `compile` | 3s (2.638 s)<br>🟡 Δ+0s / +5% | 3s (2.789 s)<br>🔴 Δ+0s / +18% | 3s (2.955 s)<br>🔴 Δ+0s / +19% |
 | `gen java` | 1m 21s (80.621 s)<br>🟡 Δ+5s / +7% | 1m 26s (85.936 s)<br>🔴 Δ+10s / +13% | 1m 24s (83.967 s)<br>🔴 Δ+8s / +11% |
 | `gen python` | 1m 20s (79.758 s)<br>🟡 Δ+5s / +7% | 1m 22s (82.359 s)<br>🟡 Δ+7s / +10% | 1m 22s (82.067 s)<br>🟡 Δ+7s / +9% |
 | `gen js` | 1m 20s (79.849 s)<br>🟡 Δ+6s / +8% | 1m 21s (81.267 s)<br>🟡 Δ+7s / +9% | 1m 21s (81.2 s)<br>🟡 Δ+7s / +9% |
@@ -46,7 +46,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 3s (2.502 s)<br>🟢 Δ-0s / -4% | 2s (2.358 s)<br>🟡 Δ+0s / +9% | 2s (2.475 s)<br>🔵 Δ+0s / +2% |
+| `compile` | 3s (2.502 s)<br>🟢 Δ-0s / -4% | 2s (2.358 s)<br>🟡 Δ+0s / +9% | 2s (2.475 s)<br>🔵 Δ+0s / +2% |
 | `gen java` | 1m 16s (75.64 s)<br>🟡 Δ+2s / +3% | 1m 16s (76.009 s)<br>🟡 Δ+3s / +4% | 1m 16s (75.969 s)<br>🟡 Δ+2s / +3% |
 | `gen python` | 1m 14s (74.39 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.123 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.016 s)<br>🟡 Δ+3s / +5% |
 | `gen js` | 1m 14s (74.116 s)<br>🟡 Δ+2s / +3% | 1m 14s (74.306 s)<br>🟡 Δ+3s / +4% | 1m 14s (74.339 s)<br>🟡 Δ+3s / +4% |
@@ -58,7 +58,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 3s (2.6 s)<br>🔴 Δ+0s / +16% | 2s (2.168 s)<br>🟢 Δ-0s / -16% | 2s (2.429 s)<br>🟢 Δ-0s / -7% |
+| `compile` | 3s (2.6 s)<br>🔴 Δ+0s / +16% | 2s (2.168 s)<br>🟢 Δ-0s / -16% | 2s (2.429 s)<br>🟢 Δ-0s / -7% |
 | `gen java` | 1m 14s (73.735 s)<br>🟢 Δ-1m 47s / -59% | 1m 13s (73.204 s)<br>🟢 Δ-1m 49s / -60% | 1m 14s (73.651 s)<br>🟢 Δ-1m 46s / -59% |
 | `gen python` | 1m 12s (71.665 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.927 s)<br>🟢 Δ-1m 48s / -60% | 1m 12s (71.648 s)<br>🟢 Δ-1m 47s / -60% |
 | `gen js` | 1m 12s (71.723 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.662 s)<br>🟢 Δ-1m 46s / -60% | 1m 11s (71.306 s)<br>🟢 Δ-1m 46s / -60% |
@@ -70,7 +70,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 2s (2.25 s)<br>🟢 Δ-1s / -23% | 3s (2.58 s)<br>🟢 Δ-0s / -13% | 3s (2.623 s)<br>🟢 Δ-0s / -10% |
+| `compile` | 2s (2.25 s)<br>🟢 Δ-1s / -23% | 3s (2.58 s)<br>🟢 Δ-0s / -13% | 3s (2.623 s)<br>🟢 Δ-0s / -10% |
 | `gen java` | 3m 1s (181.223 s)<br>🔴 Δ+1m 36s / +114% | 3m 3s (182.672 s)<br>🔴 Δ+1m 37s / +112% | 3m 0s (179.667 s)<br>🔴 Δ+1m 36s / +114% |
 | `gen python` | 3m 1s (180.957 s)<br>🔴 Δ+1m 37s / +115% | 3m 0s (180.386 s)<br>🔴 Δ+1m 37s / +117% | 2m 59s (178.752 s)<br>🔴 Δ+1m 35s / +114% |
 | `gen js` | 3m 1s (180.961 s)<br>🔴 Δ+1m 37s / +117% | 2m 58s (177.961 s)<br>🔴 Δ+1m 36s / +116% | 2m 58s (177.787 s)<br>🔴 Δ+1m 35s / +114% |
@@ -80,7 +80,7 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 | Step | Java | Python | JS |
 | --- | ---: | ---: | ---: |
-| `compiler` | 3s (2.905 s)<br>no previous run | 3s (2.961 s)<br>no previous run | 3s (2.92 s)<br>no previous run |
+| `compile` | 3s (2.905 s)<br>no previous run | 3s (2.961 s)<br>no previous run | 3s (2.92 s)<br>no previous run |
 | `gen java` | 1m 25s (84.774 s)<br>no previous run | 1m 26s (86.139 s)<br>no previous run | 1m 24s (83.893 s)<br>no previous run |
 | `gen python` | 1m 24s (84.087 s)<br>no previous run | 1m 23s (82.978 s)<br>no previous run | 1m 23s (83.487 s)<br>no previous run |
 | `gen js` | 1m 24s (83.533 s)<br>no previous run | 1m 22s (82.319 s)<br>no previous run | 1m 23s (83.173 s)<br>no previous run |

--- a/performance/README.md
+++ b/performance/README.md
@@ -8,192 +8,80 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/77cb03c00cf8d3f7c75bd323c86960d4486186c3...80fbebde0415fd6945aab64cb05c29e5bfe3f2d3)
 
-### Java
-
-- `compile`: 2s (2.3 s) 🟢 Δ-0s / -13%
-- `generate java`: 2s (1.631 s) 🟢 Δ-1m 24s / -98%
-- `generate python`: 1s (1.107 s) 🟢 Δ-1m 24s / -99%
-- `generate js`: 1s (0.954 s) 🟢 Δ-1m 22s / -99%
-- `compile-test`: 11s (11.13 s) 🟢 Δ-5s / -33%
-
-### Python
-
-- `compile`: 2s (2.088 s) 🟢 Δ-0s / -17%
-- `generate java`: 2s (1.575 s) 🟢 Δ-1m 23s / -98%
-- `generate python`: 1s (1.061 s) 🟢 Δ-1m 22s / -99%
-- `generate js`: 1s (0.98 s) 🟢 Δ-1m 21s / -99%
-- `compile-test`: 11s (11.358 s) 🟢 Δ-6s / -33%
-
-### JS
-
-- `compile`: 2s (1.916 s) 🟢 Δ-1s / -32%
-- `generate java`: 2s (1.534 s) 🟢 Δ-1m 23s / -98%
-- `generate python`: 1s (1.106 s) 🟢 Δ-1m 22s / -99%
-- `generate js`: 1s (0.977 s) 🟢 Δ-1m 23s / -99%
-- `compile-test`: 11s (11.246 s) 🟢 Δ-6s / -35%
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 2s (2.3 s)<br>🟢 Δ-0s / -13% | 2s (2.088 s)<br>🟢 Δ-0s / -17% | 2s (1.916 s)<br>🟢 Δ-1s / -32% |
+| `gen java` | 2s (1.631 s)<br>🟢 Δ-1m 24s / -98% | 2s (1.575 s)<br>🟢 Δ-1m 23s / -98% | 2s (1.534 s)<br>🟢 Δ-1m 23s / -98% |
+| `gen python` | 1s (1.107 s)<br>🟢 Δ-1m 24s / -99% | 1s (1.061 s)<br>🟢 Δ-1m 22s / -99% | 1s (1.106 s)<br>🟢 Δ-1m 22s / -99% |
+| `gen js` | 1s (0.954 s)<br>🟢 Δ-1m 22s / -99% | 1s (0.98 s)<br>🟢 Δ-1m 21s / -99% | 1s (0.977 s)<br>🟢 Δ-1m 23s / -99% |
+| `test` | 11s (11.13 s)<br>🟢 Δ-5s / -33% | 11s (11.358 s)<br>🟢 Δ-6s / -33% | 11s (11.246 s)<br>🟢 Δ-6s / -35% |
 
 ## 2026-06-20 [77cb03c](https://github.com/magx2/Capybara/commit/77cb03c00cf8d3f7c75bd323c86960d4486186c3)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/4c4e64a6fd0d83eb5718527f4f3d9f57211323b6...77cb03c00cf8d3f7c75bd323c86960d4486186c3)
 
-### Java
-
-- `compile`: 3s (2.632 s) 🟢 Δ-0s / -0%
-- `generate java`: 1m 26s (85.751 s) 🟡 Δ+5s / +6%
-- `generate python`: 1m 25s (84.86 s) 🟡 Δ+5s / +6%
-- `generate js`: 1m 23s (83.159 s) 🟡 Δ+3s / +4%
-- `compile-test`: 17s (16.597 s) 🟢 Δ-1s / -4%
-
-### Python
-
-- `compile`: 3s (2.524 s) 🟢 Δ-0s / -10%
-- `generate java`: 1m 25s (84.972 s) 🟢 Δ-1s / -1%
-- `generate python`: 1m 23s (83.485 s) 🔵 Δ+1s / +1%
-- `generate js`: 1m 22s (82.276 s) 🔵 Δ+1s / +1%
-- `compile-test`: 17s (16.867 s) 🟢 Δ-1s / -6%
-
-### JS
-
-- `compile`: 3s (2.811 s) 🟢 Δ-0s / -5%
-- `generate java`: 1m 25s (84.977 s) 🔵 Δ+1s / +1%
-- `generate python`: 1m 23s (82.86 s) 🔵 Δ+1s / +1%
-- `generate js`: 1m 24s (84.17 s) 🟡 Δ+3s / +4%
-- `compile-test`: 17s (17.205 s) 🔵 Δ+0s / +0%
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 3s (2.632 s)<br>🟢 Δ-0s / -0% | 3s (2.524 s)<br>🟢 Δ-0s / -10% | 3s (2.811 s)<br>🟢 Δ-0s / -5% |
+| `gen java` | 1m 26s (85.751 s)<br>🟡 Δ+5s / +6% | 1m 25s (84.972 s)<br>🟢 Δ-1s / -1% | 1m 25s (84.977 s)<br>🔵 Δ+1s / +1% |
+| `gen python` | 1m 25s (84.86 s)<br>🟡 Δ+5s / +6% | 1m 23s (83.485 s)<br>🔵 Δ+1s / +1% | 1m 23s (82.86 s)<br>🔵 Δ+1s / +1% |
+| `gen js` | 1m 23s (83.159 s)<br>🟡 Δ+3s / +4% | 1m 22s (82.276 s)<br>🔵 Δ+1s / +1% | 1m 24s (84.17 s)<br>🟡 Δ+3s / +4% |
+| `test` | 17s (16.597 s)<br>🟢 Δ-1s / -4% | 17s (16.867 s)<br>🟢 Δ-1s / -6% | 17s (17.205 s)<br>🔵 Δ+0s / +0% |
 
 ## 2026-06-19 [4c4e64a](https://github.com/magx2/Capybara/commit/4c4e64a6fd0d83eb5718527f4f3d9f57211323b6)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/5d6201373d073065277f10e8a0b9a37c5c918bf0...4c4e64a6fd0d83eb5718527f4f3d9f57211323b6)
 
-### Java
-
-- `compile`: 3s (2.638 s) 🟡 Δ+0s / +5%
-- `generate java`: 1m 21s (80.621 s) 🟡 Δ+5s / +7%
-- `generate python`: 1m 20s (79.758 s) 🟡 Δ+5s / +7%
-- `generate js`: 1m 20s (79.849 s) 🟡 Δ+6s / +8%
-- `compile-test`: 17s (17.31 s) 🟡 Δ+1s / +6%
-
-### Python
-
-- `compile`: 3s (2.789 s) 🔴 Δ+0s / +18%
-- `generate java`: 1m 26s (85.936 s) 🔴 Δ+10s / +13%
-- `generate python`: 1m 22s (82.359 s) 🟡 Δ+7s / +10%
-- `generate js`: 1m 21s (81.267 s) 🟡 Δ+7s / +9%
-- `compile-test`: 18s (17.941 s) 🟡 Δ+1s / +8%
-
-### JS
-
-- `compile`: 3s (2.955 s) 🔴 Δ+0s / +19%
-- `generate java`: 1m 24s (83.967 s) 🔴 Δ+8s / +11%
-- `generate python`: 1m 22s (82.067 s) 🟡 Δ+7s / +9%
-- `generate js`: 1m 21s (81.2 s) 🟡 Δ+7s / +9%
-- `compile-test`: 17s (17.133 s) 🔵 Δ+0s / +1%
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 3s (2.638 s)<br>🟡 Δ+0s / +5% | 3s (2.789 s)<br>🔴 Δ+0s / +18% | 3s (2.955 s)<br>🔴 Δ+0s / +19% |
+| `gen java` | 1m 21s (80.621 s)<br>🟡 Δ+5s / +7% | 1m 26s (85.936 s)<br>🔴 Δ+10s / +13% | 1m 24s (83.967 s)<br>🔴 Δ+8s / +11% |
+| `gen python` | 1m 20s (79.758 s)<br>🟡 Δ+5s / +7% | 1m 22s (82.359 s)<br>🟡 Δ+7s / +10% | 1m 22s (82.067 s)<br>🟡 Δ+7s / +9% |
+| `gen js` | 1m 20s (79.849 s)<br>🟡 Δ+6s / +8% | 1m 21s (81.267 s)<br>🟡 Δ+7s / +9% | 1m 21s (81.2 s)<br>🟡 Δ+7s / +9% |
+| `test` | 17s (17.31 s)<br>🟡 Δ+1s / +6% | 18s (17.941 s)<br>🟡 Δ+1s / +8% | 17s (17.133 s)<br>🔵 Δ+0s / +1% |
 
 ## 2026-06-19 [5d62013](https://github.com/magx2/Capybara/commit/5d6201373d073065277f10e8a0b9a37c5c918bf0)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/349b20aa03c402bb010d856747a6bb5891e6ae4c...5d6201373d073065277f10e8a0b9a37c5c918bf0)
 
-### Java
-
-- `compile`: 3s (2.502 s) 🟢 Δ-0s / -4%
-- `generate java`: 1m 16s (75.64 s) 🟡 Δ+2s / +3%
-- `generate python`: 1m 14s (74.39 s) 🟡 Δ+3s / +4%
-- `generate js`: 1m 14s (74.116 s) 🟡 Δ+2s / +3%
-- `compile-test`: 16s (16.395 s) 🟡 Δ+0s / +2%
-
-### Python
-
-- `compile`: 2s (2.358 s) 🟡 Δ+0s / +9%
-- `generate java`: 1m 16s (76.009 s) 🟡 Δ+3s / +4%
-- `generate python`: 1m 15s (75.123 s) 🟡 Δ+3s / +4%
-- `generate js`: 1m 14s (74.306 s) 🟡 Δ+3s / +4%
-- `compile-test`: 17s (16.623 s) 🟡 Δ+0s / +2%
-
-### JS
-
-- `compile`: 2s (2.475 s) 🔵 Δ+0s / +2%
-- `generate java`: 1m 16s (75.969 s) 🟡 Δ+2s / +3%
-- `generate python`: 1m 15s (75.016 s) 🟡 Δ+3s / +5%
-- `generate js`: 1m 14s (74.339 s) 🟡 Δ+3s / +4%
-- `compile-test`: 17s (16.889 s) 🟡 Δ+1s / +4%
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 3s (2.502 s)<br>🟢 Δ-0s / -4% | 2s (2.358 s)<br>🟡 Δ+0s / +9% | 2s (2.475 s)<br>🔵 Δ+0s / +2% |
+| `gen java` | 1m 16s (75.64 s)<br>🟡 Δ+2s / +3% | 1m 16s (76.009 s)<br>🟡 Δ+3s / +4% | 1m 16s (75.969 s)<br>🟡 Δ+2s / +3% |
+| `gen python` | 1m 14s (74.39 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.123 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.016 s)<br>🟡 Δ+3s / +5% |
+| `gen js` | 1m 14s (74.116 s)<br>🟡 Δ+2s / +3% | 1m 14s (74.306 s)<br>🟡 Δ+3s / +4% | 1m 14s (74.339 s)<br>🟡 Δ+3s / +4% |
+| `test` | 16s (16.395 s)<br>🟡 Δ+0s / +2% | 17s (16.623 s)<br>🟡 Δ+0s / +2% | 17s (16.889 s)<br>🟡 Δ+1s / +4% |
 
 ## 2026-06-19 [349b20a](https://github.com/magx2/Capybara/commit/349b20aa03c402bb010d856747a6bb5891e6ae4c)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/f46942aa64ec07cf07baefcc59bb83d06d70421e...349b20aa03c402bb010d856747a6bb5891e6ae4c)
 
-### Java
-
-- `compile`: 3s (2.6 s) 🔴 Δ+0s / +16%
-- `generate java`: 1m 14s (73.735 s) 🟢 Δ-1m 47s / -59%
-- `generate python`: 1m 12s (71.665 s) 🟢 Δ-1m 49s / -60%
-- `generate js`: 1m 12s (71.723 s) 🟢 Δ-1m 49s / -60%
-- `compile-test`: 16s (16.01 s) 🟢 Δ-1s / -7%
-
-### Python
-
-- `compile`: 2s (2.168 s) 🟢 Δ-0s / -16%
-- `generate java`: 1m 13s (73.204 s) 🟢 Δ-1m 49s / -60%
-- `generate python`: 1m 12s (71.927 s) 🟢 Δ-1m 48s / -60%
-- `generate js`: 1m 12s (71.662 s) 🟢 Δ-1m 46s / -60%
-- `compile-test`: 16s (16.244 s) 🟢 Δ-0s / -2%
-
-### JS
-
-- `compile`: 2s (2.429 s) 🟢 Δ-0s / -7%
-- `generate java`: 1m 14s (73.651 s) 🟢 Δ-1m 46s / -59%
-- `generate python`: 1m 12s (71.648 s) 🟢 Δ-1m 47s / -60%
-- `generate js`: 1m 11s (71.306 s) 🟢 Δ-1m 46s / -60%
-- `compile-test`: 16s (16.273 s) 🟢 Δ-0s / -1%
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 3s (2.6 s)<br>🔴 Δ+0s / +16% | 2s (2.168 s)<br>🟢 Δ-0s / -16% | 2s (2.429 s)<br>🟢 Δ-0s / -7% |
+| `gen java` | 1m 14s (73.735 s)<br>🟢 Δ-1m 47s / -59% | 1m 13s (73.204 s)<br>🟢 Δ-1m 49s / -60% | 1m 14s (73.651 s)<br>🟢 Δ-1m 46s / -59% |
+| `gen python` | 1m 12s (71.665 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.927 s)<br>🟢 Δ-1m 48s / -60% | 1m 12s (71.648 s)<br>🟢 Δ-1m 47s / -60% |
+| `gen js` | 1m 12s (71.723 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.662 s)<br>🟢 Δ-1m 46s / -60% | 1m 11s (71.306 s)<br>🟢 Δ-1m 46s / -60% |
+| `test` | 16s (16.01 s)<br>🟢 Δ-1s / -7% | 16s (16.244 s)<br>🟢 Δ-0s / -2% | 16s (16.273 s)<br>🟢 Δ-0s / -1% |
 
 ## 2026-06-19 [f46942a](https://github.com/magx2/Capybara/commit/f46942aa64ec07cf07baefcc59bb83d06d70421e)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/176dd6b54b5660641e58da2187cc6ef623bf4d72...f46942aa64ec07cf07baefcc59bb83d06d70421e)
 
-### Java
-
-- `compile`: 2s (2.25 s) 🟢 Δ-1s / -23%
-- `generate java`: 3m 1s (181.223 s) 🔴 Δ+1m 36s / +114%
-- `generate python`: 3m 1s (180.957 s) 🔴 Δ+1m 37s / +115%
-- `generate js`: 3m 1s (180.961 s) 🔴 Δ+1m 37s / +117%
-- `compile-test`: 17s (17.155 s) 🟢 Δ-1s / -3%
-
-### Python
-
-- `compile`: 3s (2.58 s) 🟢 Δ-0s / -13%
-- `generate java`: 3m 3s (182.672 s) 🔴 Δ+1m 37s / +112%
-- `generate python`: 3m 0s (180.386 s) 🔴 Δ+1m 37s / +117%
-- `generate js`: 2m 58s (177.961 s) 🔴 Δ+1m 36s / +116%
-- `compile-test`: 17s (16.629 s) 🟢 Δ-1s / -5%
-
-### JS
-
-- `compile`: 3s (2.623 s) 🟢 Δ-0s / -10%
-- `generate java`: 3m 0s (179.667 s) 🔴 Δ+1m 36s / +114%
-- `generate python`: 2m 59s (178.752 s) 🔴 Δ+1m 35s / +114%
-- `generate js`: 2m 58s (177.787 s) 🔴 Δ+1m 35s / +114%
-- `compile-test`: 16s (16.419 s) 🟢 Δ-2s / -10%
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 2s (2.25 s)<br>🟢 Δ-1s / -23% | 3s (2.58 s)<br>🟢 Δ-0s / -13% | 3s (2.623 s)<br>🟢 Δ-0s / -10% |
+| `gen java` | 3m 1s (181.223 s)<br>🔴 Δ+1m 36s / +114% | 3m 3s (182.672 s)<br>🔴 Δ+1m 37s / +112% | 3m 0s (179.667 s)<br>🔴 Δ+1m 36s / +114% |
+| `gen python` | 3m 1s (180.957 s)<br>🔴 Δ+1m 37s / +115% | 3m 0s (180.386 s)<br>🔴 Δ+1m 37s / +117% | 2m 59s (178.752 s)<br>🔴 Δ+1m 35s / +114% |
+| `gen js` | 3m 1s (180.961 s)<br>🔴 Δ+1m 37s / +117% | 2m 58s (177.961 s)<br>🔴 Δ+1m 36s / +116% | 2m 58s (177.787 s)<br>🔴 Δ+1m 35s / +114% |
+| `test` | 17s (17.155 s)<br>🟢 Δ-1s / -3% | 17s (16.629 s)<br>🟢 Δ-1s / -5% | 16s (16.419 s)<br>🟢 Δ-2s / -10% |
 
 ## 2026-06-19 [176dd6b](https://github.com/magx2/Capybara/commit/176dd6b54b5660641e58da2187cc6ef623bf4d72)
 
-### Java
-
-- `compile`: 3s (2.905 s) no previous run
-- `generate java`: 1m 25s (84.774 s) no previous run
-- `generate python`: 1m 24s (84.087 s) no previous run
-- `generate js`: 1m 24s (83.533 s) no previous run
-- `compile-test`: 18s (17.732 s) no previous run
-
-### Python
-
-- `compile`: 3s (2.961 s) no previous run
-- `generate java`: 1m 26s (86.139 s) no previous run
-- `generate python`: 1m 23s (82.978 s) no previous run
-- `generate js`: 1m 22s (82.319 s) no previous run
-- `compile-test`: 18s (17.561 s) no previous run
-
-### JS
-
-- `compile`: 3s (2.92 s) no previous run
-- `generate java`: 1m 24s (83.893 s) no previous run
-- `generate python`: 1m 23s (83.487 s) no previous run
-- `generate js`: 1m 23s (83.173 s) no previous run
-- `compile-test`: 18s (18.314 s) no previous run
+| Step | Java | Python | JS |
+| --- | ---: | ---: | ---: |
+| `compiler` | 3s (2.905 s)<br>no previous run | 3s (2.961 s)<br>no previous run | 3s (2.92 s)<br>no previous run |
+| `gen java` | 1m 25s (84.774 s)<br>no previous run | 1m 26s (86.139 s)<br>no previous run | 1m 24s (83.893 s)<br>no previous run |
+| `gen python` | 1m 24s (84.087 s)<br>no previous run | 1m 23s (82.978 s)<br>no previous run | 1m 23s (83.487 s)<br>no previous run |
+| `gen js` | 1m 24s (83.533 s)<br>no previous run | 1m 22s (82.319 s)<br>no previous run | 1m 23s (83.173 s)<br>no previous run |
+| `test` | 18s (17.732 s)<br>no previous run | 18s (17.561 s)<br>no previous run | 18s (18.314 s)<br>no previous run |

--- a/performance/README.md
+++ b/performance/README.md
@@ -8,80 +8,66 @@ Legend: 🟢 faster, 🔵 roughly unchanged, 🟡 small regression, 🔴 regress
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/77cb03c00cf8d3f7c75bd323c86960d4486186c3...80fbebde0415fd6945aab64cb05c29e5bfe3f2d3)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 2s (2.3 s)<br>🟢 Δ-0s / -13% | 2s (2.088 s)<br>🟢 Δ-0s / -17% | 2s (1.916 s)<br>🟢 Δ-1s / -32% |
-| `gen java` | 2s (1.631 s)<br>🟢 Δ-1m 24s / -98% | 2s (1.575 s)<br>🟢 Δ-1m 23s / -98% | 2s (1.534 s)<br>🟢 Δ-1m 23s / -98% |
-| `gen python` | 1s (1.107 s)<br>🟢 Δ-1m 24s / -99% | 1s (1.061 s)<br>🟢 Δ-1m 22s / -99% | 1s (1.106 s)<br>🟢 Δ-1m 22s / -99% |
-| `gen js` | 1s (0.954 s)<br>🟢 Δ-1m 22s / -99% | 1s (0.98 s)<br>🟢 Δ-1m 21s / -99% | 1s (0.977 s)<br>🟢 Δ-1m 23s / -99% |
-| `test` | 11s (11.13 s)<br>🟢 Δ-5s / -33% | 11s (11.358 s)<br>🟢 Δ-6s / -33% | 11s (11.246 s)<br>🟢 Δ-6s / -35% |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 2s (2.3 s)<br>🟢 Δ-0s / -13% | 2s (1.631 s)<br>🟢 Δ-1m 24s / -98% | 1s (1.107 s)<br>🟢 Δ-1m 24s / -99% | 1s (0.954 s)<br>🟢 Δ-1m 22s / -99% | 11s (11.13 s)<br>🟢 Δ-5s / -33% |
+| `Python` | 2s (2.088 s)<br>🟢 Δ-0s / -17% | 2s (1.575 s)<br>🟢 Δ-1m 23s / -98% | 1s (1.061 s)<br>🟢 Δ-1m 22s / -99% | 1s (0.98 s)<br>🟢 Δ-1m 21s / -99% | 11s (11.358 s)<br>🟢 Δ-6s / -33% |
+| `JS` | 2s (1.916 s)<br>🟢 Δ-1s / -32% | 2s (1.534 s)<br>🟢 Δ-1m 23s / -98% | 1s (1.106 s)<br>🟢 Δ-1m 22s / -99% | 1s (0.977 s)<br>🟢 Δ-1m 23s / -99% | 11s (11.246 s)<br>🟢 Δ-6s / -35% |
 
 ## 2026-06-20 [77cb03c](https://github.com/magx2/Capybara/commit/77cb03c00cf8d3f7c75bd323c86960d4486186c3)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/4c4e64a6fd0d83eb5718527f4f3d9f57211323b6...77cb03c00cf8d3f7c75bd323c86960d4486186c3)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 3s (2.632 s)<br>🟢 Δ-0s / -0% | 3s (2.524 s)<br>🟢 Δ-0s / -10% | 3s (2.811 s)<br>🟢 Δ-0s / -5% |
-| `gen java` | 1m 26s (85.751 s)<br>🟡 Δ+5s / +6% | 1m 25s (84.972 s)<br>🟢 Δ-1s / -1% | 1m 25s (84.977 s)<br>🔵 Δ+1s / +1% |
-| `gen python` | 1m 25s (84.86 s)<br>🟡 Δ+5s / +6% | 1m 23s (83.485 s)<br>🔵 Δ+1s / +1% | 1m 23s (82.86 s)<br>🔵 Δ+1s / +1% |
-| `gen js` | 1m 23s (83.159 s)<br>🟡 Δ+3s / +4% | 1m 22s (82.276 s)<br>🔵 Δ+1s / +1% | 1m 24s (84.17 s)<br>🟡 Δ+3s / +4% |
-| `test` | 17s (16.597 s)<br>🟢 Δ-1s / -4% | 17s (16.867 s)<br>🟢 Δ-1s / -6% | 17s (17.205 s)<br>🔵 Δ+0s / +0% |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 3s (2.632 s)<br>🟢 Δ-0s / -0% | 1m 26s (85.751 s)<br>🟡 Δ+5s / +6% | 1m 25s (84.86 s)<br>🟡 Δ+5s / +6% | 1m 23s (83.159 s)<br>🟡 Δ+3s / +4% | 17s (16.597 s)<br>🟢 Δ-1s / -4% |
+| `Python` | 3s (2.524 s)<br>🟢 Δ-0s / -10% | 1m 25s (84.972 s)<br>🟢 Δ-1s / -1% | 1m 23s (83.485 s)<br>🔵 Δ+1s / +1% | 1m 22s (82.276 s)<br>🔵 Δ+1s / +1% | 17s (16.867 s)<br>🟢 Δ-1s / -6% |
+| `JS` | 3s (2.811 s)<br>🟢 Δ-0s / -5% | 1m 25s (84.977 s)<br>🔵 Δ+1s / +1% | 1m 23s (82.86 s)<br>🔵 Δ+1s / +1% | 1m 24s (84.17 s)<br>🟡 Δ+3s / +4% | 17s (17.205 s)<br>🔵 Δ+0s / +0% |
 
 ## 2026-06-19 [4c4e64a](https://github.com/magx2/Capybara/commit/4c4e64a6fd0d83eb5718527f4f3d9f57211323b6)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/5d6201373d073065277f10e8a0b9a37c5c918bf0...4c4e64a6fd0d83eb5718527f4f3d9f57211323b6)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 3s (2.638 s)<br>🟡 Δ+0s / +5% | 3s (2.789 s)<br>🔴 Δ+0s / +18% | 3s (2.955 s)<br>🔴 Δ+0s / +19% |
-| `gen java` | 1m 21s (80.621 s)<br>🟡 Δ+5s / +7% | 1m 26s (85.936 s)<br>🔴 Δ+10s / +13% | 1m 24s (83.967 s)<br>🔴 Δ+8s / +11% |
-| `gen python` | 1m 20s (79.758 s)<br>🟡 Δ+5s / +7% | 1m 22s (82.359 s)<br>🟡 Δ+7s / +10% | 1m 22s (82.067 s)<br>🟡 Δ+7s / +9% |
-| `gen js` | 1m 20s (79.849 s)<br>🟡 Δ+6s / +8% | 1m 21s (81.267 s)<br>🟡 Δ+7s / +9% | 1m 21s (81.2 s)<br>🟡 Δ+7s / +9% |
-| `test` | 17s (17.31 s)<br>🟡 Δ+1s / +6% | 18s (17.941 s)<br>🟡 Δ+1s / +8% | 17s (17.133 s)<br>🔵 Δ+0s / +1% |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 3s (2.638 s)<br>🟡 Δ+0s / +5% | 1m 21s (80.621 s)<br>🟡 Δ+5s / +7% | 1m 20s (79.758 s)<br>🟡 Δ+5s / +7% | 1m 20s (79.849 s)<br>🟡 Δ+6s / +8% | 17s (17.31 s)<br>🟡 Δ+1s / +6% |
+| `Python` | 3s (2.789 s)<br>🔴 Δ+0s / +18% | 1m 26s (85.936 s)<br>🔴 Δ+10s / +13% | 1m 22s (82.359 s)<br>🟡 Δ+7s / +10% | 1m 21s (81.267 s)<br>🟡 Δ+7s / +9% | 18s (17.941 s)<br>🟡 Δ+1s / +8% |
+| `JS` | 3s (2.955 s)<br>🔴 Δ+0s / +19% | 1m 24s (83.967 s)<br>🔴 Δ+8s / +11% | 1m 22s (82.067 s)<br>🟡 Δ+7s / +9% | 1m 21s (81.2 s)<br>🟡 Δ+7s / +9% | 17s (17.133 s)<br>🔵 Δ+0s / +1% |
 
 ## 2026-06-19 [5d62013](https://github.com/magx2/Capybara/commit/5d6201373d073065277f10e8a0b9a37c5c918bf0)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/349b20aa03c402bb010d856747a6bb5891e6ae4c...5d6201373d073065277f10e8a0b9a37c5c918bf0)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 3s (2.502 s)<br>🟢 Δ-0s / -4% | 2s (2.358 s)<br>🟡 Δ+0s / +9% | 2s (2.475 s)<br>🔵 Δ+0s / +2% |
-| `gen java` | 1m 16s (75.64 s)<br>🟡 Δ+2s / +3% | 1m 16s (76.009 s)<br>🟡 Δ+3s / +4% | 1m 16s (75.969 s)<br>🟡 Δ+2s / +3% |
-| `gen python` | 1m 14s (74.39 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.123 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.016 s)<br>🟡 Δ+3s / +5% |
-| `gen js` | 1m 14s (74.116 s)<br>🟡 Δ+2s / +3% | 1m 14s (74.306 s)<br>🟡 Δ+3s / +4% | 1m 14s (74.339 s)<br>🟡 Δ+3s / +4% |
-| `test` | 16s (16.395 s)<br>🟡 Δ+0s / +2% | 17s (16.623 s)<br>🟡 Δ+0s / +2% | 17s (16.889 s)<br>🟡 Δ+1s / +4% |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 3s (2.502 s)<br>🟢 Δ-0s / -4% | 1m 16s (75.64 s)<br>🟡 Δ+2s / +3% | 1m 14s (74.39 s)<br>🟡 Δ+3s / +4% | 1m 14s (74.116 s)<br>🟡 Δ+2s / +3% | 16s (16.395 s)<br>🟡 Δ+0s / +2% |
+| `Python` | 2s (2.358 s)<br>🟡 Δ+0s / +9% | 1m 16s (76.009 s)<br>🟡 Δ+3s / +4% | 1m 15s (75.123 s)<br>🟡 Δ+3s / +4% | 1m 14s (74.306 s)<br>🟡 Δ+3s / +4% | 17s (16.623 s)<br>🟡 Δ+0s / +2% |
+| `JS` | 2s (2.475 s)<br>🔵 Δ+0s / +2% | 1m 16s (75.969 s)<br>🟡 Δ+2s / +3% | 1m 15s (75.016 s)<br>🟡 Δ+3s / +5% | 1m 14s (74.339 s)<br>🟡 Δ+3s / +4% | 17s (16.889 s)<br>🟡 Δ+1s / +4% |
 
 ## 2026-06-19 [349b20a](https://github.com/magx2/Capybara/commit/349b20aa03c402bb010d856747a6bb5891e6ae4c)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/f46942aa64ec07cf07baefcc59bb83d06d70421e...349b20aa03c402bb010d856747a6bb5891e6ae4c)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 3s (2.6 s)<br>🔴 Δ+0s / +16% | 2s (2.168 s)<br>🟢 Δ-0s / -16% | 2s (2.429 s)<br>🟢 Δ-0s / -7% |
-| `gen java` | 1m 14s (73.735 s)<br>🟢 Δ-1m 47s / -59% | 1m 13s (73.204 s)<br>🟢 Δ-1m 49s / -60% | 1m 14s (73.651 s)<br>🟢 Δ-1m 46s / -59% |
-| `gen python` | 1m 12s (71.665 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.927 s)<br>🟢 Δ-1m 48s / -60% | 1m 12s (71.648 s)<br>🟢 Δ-1m 47s / -60% |
-| `gen js` | 1m 12s (71.723 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.662 s)<br>🟢 Δ-1m 46s / -60% | 1m 11s (71.306 s)<br>🟢 Δ-1m 46s / -60% |
-| `test` | 16s (16.01 s)<br>🟢 Δ-1s / -7% | 16s (16.244 s)<br>🟢 Δ-0s / -2% | 16s (16.273 s)<br>🟢 Δ-0s / -1% |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 3s (2.6 s)<br>🔴 Δ+0s / +16% | 1m 14s (73.735 s)<br>🟢 Δ-1m 47s / -59% | 1m 12s (71.665 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.723 s)<br>🟢 Δ-1m 49s / -60% | 16s (16.01 s)<br>🟢 Δ-1s / -7% |
+| `Python` | 2s (2.168 s)<br>🟢 Δ-0s / -16% | 1m 13s (73.204 s)<br>🟢 Δ-1m 49s / -60% | 1m 12s (71.927 s)<br>🟢 Δ-1m 48s / -60% | 1m 12s (71.662 s)<br>🟢 Δ-1m 46s / -60% | 16s (16.244 s)<br>🟢 Δ-0s / -2% |
+| `JS` | 2s (2.429 s)<br>🟢 Δ-0s / -7% | 1m 14s (73.651 s)<br>🟢 Δ-1m 46s / -59% | 1m 12s (71.648 s)<br>🟢 Δ-1m 47s / -60% | 1m 11s (71.306 s)<br>🟢 Δ-1m 46s / -60% | 16s (16.273 s)<br>🟢 Δ-0s / -1% |
 
 ## 2026-06-19 [f46942a](https://github.com/magx2/Capybara/commit/f46942aa64ec07cf07baefcc59bb83d06d70421e)
 
 [Changes since previous benchmark check](https://github.com/magx2/Capybara/compare/176dd6b54b5660641e58da2187cc6ef623bf4d72...f46942aa64ec07cf07baefcc59bb83d06d70421e)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 2s (2.25 s)<br>🟢 Δ-1s / -23% | 3s (2.58 s)<br>🟢 Δ-0s / -13% | 3s (2.623 s)<br>🟢 Δ-0s / -10% |
-| `gen java` | 3m 1s (181.223 s)<br>🔴 Δ+1m 36s / +114% | 3m 3s (182.672 s)<br>🔴 Δ+1m 37s / +112% | 3m 0s (179.667 s)<br>🔴 Δ+1m 36s / +114% |
-| `gen python` | 3m 1s (180.957 s)<br>🔴 Δ+1m 37s / +115% | 3m 0s (180.386 s)<br>🔴 Δ+1m 37s / +117% | 2m 59s (178.752 s)<br>🔴 Δ+1m 35s / +114% |
-| `gen js` | 3m 1s (180.961 s)<br>🔴 Δ+1m 37s / +117% | 2m 58s (177.961 s)<br>🔴 Δ+1m 36s / +116% | 2m 58s (177.787 s)<br>🔴 Δ+1m 35s / +114% |
-| `test` | 17s (17.155 s)<br>🟢 Δ-1s / -3% | 17s (16.629 s)<br>🟢 Δ-1s / -5% | 16s (16.419 s)<br>🟢 Δ-2s / -10% |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 2s (2.25 s)<br>🟢 Δ-1s / -23% | 3m 1s (181.223 s)<br>🔴 Δ+1m 36s / +114% | 3m 1s (180.957 s)<br>🔴 Δ+1m 37s / +115% | 3m 1s (180.961 s)<br>🔴 Δ+1m 37s / +117% | 17s (17.155 s)<br>🟢 Δ-1s / -3% |
+| `Python` | 3s (2.58 s)<br>🟢 Δ-0s / -13% | 3m 3s (182.672 s)<br>🔴 Δ+1m 37s / +112% | 3m 0s (180.386 s)<br>🔴 Δ+1m 37s / +117% | 2m 58s (177.961 s)<br>🔴 Δ+1m 36s / +116% | 17s (16.629 s)<br>🟢 Δ-1s / -5% |
+| `JS` | 3s (2.623 s)<br>🟢 Δ-0s / -10% | 3m 0s (179.667 s)<br>🔴 Δ+1m 36s / +114% | 2m 59s (178.752 s)<br>🔴 Δ+1m 35s / +114% | 2m 58s (177.787 s)<br>🔴 Δ+1m 35s / +114% | 16s (16.419 s)<br>🟢 Δ-2s / -10% |
 
 ## 2026-06-19 [176dd6b](https://github.com/magx2/Capybara/commit/176dd6b54b5660641e58da2187cc6ef623bf4d72)
 
-| Step | Java | Python | JS |
-| --- | ---: | ---: | ---: |
-| `compile` | 3s (2.905 s)<br>no previous run | 3s (2.961 s)<br>no previous run | 3s (2.92 s)<br>no previous run |
-| `gen java` | 1m 25s (84.774 s)<br>no previous run | 1m 26s (86.139 s)<br>no previous run | 1m 24s (83.893 s)<br>no previous run |
-| `gen python` | 1m 24s (84.087 s)<br>no previous run | 1m 23s (82.978 s)<br>no previous run | 1m 23s (83.487 s)<br>no previous run |
-| `gen js` | 1m 24s (83.533 s)<br>no previous run | 1m 22s (82.319 s)<br>no previous run | 1m 23s (83.173 s)<br>no previous run |
-| `test` | 18s (17.732 s)<br>no previous run | 18s (17.561 s)<br>no previous run | 18s (18.314 s)<br>no previous run |
+| Backend | compile | gen java | gen python | gen js | test |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `Java` | 3s (2.905 s)<br>no previous run | 1m 25s (84.774 s)<br>no previous run | 1m 24s (84.087 s)<br>no previous run | 1m 24s (83.533 s)<br>no previous run | 18s (17.732 s)<br>no previous run |
+| `Python` | 3s (2.961 s)<br>no previous run | 1m 26s (86.139 s)<br>no previous run | 1m 23s (82.978 s)<br>no previous run | 1m 22s (82.319 s)<br>no previous run | 18s (17.561 s)<br>no previous run |
+| `JS` | 3s (2.92 s)<br>no previous run | 1m 24s (83.893 s)<br>no previous run | 1m 23s (83.487 s)<br>no previous run | 1m 23s (83.173 s)<br>no previous run | 18s (18.314 s)<br>no previous run |

--- a/performance/scripts/render-readme
+++ b/performance/scripts/render-readme
@@ -135,16 +135,18 @@ else:
             lines.append("")
             lines.append(f"[Changes since previous benchmark check]({compare_url(previous_sha, short_sha)})")
         lines.append("")
-        lines.append("| Step | Java | Python | JS |")
-        lines.append("| --- | ---: | ---: | ---: |")
-        for step, step_title in steps:
+        step_headers = " | ".join(step_title for _, step_title in steps)
+        step_alignments = " | ".join("---:" for _ in steps)
+        lines.append(f"| Backend | {step_headers} |")
+        lines.append(f"| --- | {step_alignments} |")
+        for backend, backend_title in backends:
             cells = []
-            for backend, _ in backends:
+            for step, _ in steps:
                 metric = f"{backend}-{step}"
                 current = parse_seconds(row.get(metric))
                 previous = delta_by_index[index].get(metric)
                 cells.append(result_cell(current, previous))
-            lines.append(f"| `{step_title}` | {' | '.join(cells)} |")
+            lines.append(f"| `{backend_title}` | {' | '.join(cells)} |")
         lines.append("")
 
 readme_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")

--- a/performance/scripts/render-readme
+++ b/performance/scripts/render-readme
@@ -17,11 +17,11 @@ repository = sys.argv[4].strip("/")
 
 backends = [("java", "Java"), ("python", "Python"), ("js", "JS")]
 steps = [
-    ("compile", "compile"),
-    ("generate-java", "generate java"),
-    ("generate-python", "generate python"),
-    ("generate-js", "generate js"),
-    ("compile-test", "compile-test"),
+    ("compile", "compiler"),
+    ("generate-java", "gen java"),
+    ("generate-python", "gen python"),
+    ("generate-js", "gen js"),
+    ("compile-test", "test"),
 ]
 
 def parse_seconds(value):
@@ -89,6 +89,9 @@ def delta_text(current, previous):
     pct_sign = "+" if pct >= 0 else ""
     return f"{indicator} Δ{sign}{human_duration(abs(delta))} / {pct_sign}{pct:.0f}%"
 
+def result_cell(current, previous):
+    return f"{human_duration(current)} ({raw_seconds(current)} s)<br>{delta_text(current, previous)}"
+
 rows = []
 if csv_path.exists():
     with csv_path.open(newline="") as handle:
@@ -132,17 +135,17 @@ else:
             lines.append("")
             lines.append(f"[Changes since previous benchmark check]({compare_url(previous_sha, short_sha)})")
         lines.append("")
-        for backend, backend_title in backends:
-            lines.append(f"### {backend_title}")
-            lines.append("")
-            for step, step_title in steps:
+        lines.append("| Step | Java | Python | JS |")
+        lines.append("| --- | ---: | ---: | ---: |")
+        for step, step_title in steps:
+            cells = []
+            for backend, _ in backends:
                 metric = f"{backend}-{step}"
                 current = parse_seconds(row.get(metric))
                 previous = delta_by_index[index].get(metric)
-                lines.append(
-                    f"- `{step_title}`: {human_duration(current)} ({raw_seconds(current)} s) {delta_text(current, previous)}"
-                )
-            lines.append("")
+                cells.append(result_cell(current, previous))
+            lines.append(f"| `{step_title}` | {' | '.join(cells)} |")
+        lines.append("")
 
 readme_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 PY

--- a/performance/scripts/render-readme
+++ b/performance/scripts/render-readme
@@ -17,7 +17,7 @@ repository = sys.argv[4].strip("/")
 
 backends = [("java", "Java"), ("python", "Python"), ("js", "JS")]
 steps = [
-    ("compile", "compiler"),
+    ("compile", "compile"),
     ("generate-java", "gen java"),
     ("generate-python", "gen python"),
     ("generate-js", "gen js"),


### PR DESCRIPTION
## Summary
- Update `performance/scripts/render-readme` to render each benchmark run as a matrix instead of backend-specific bullet lists.
- Use backend rows (`Java`, `Python`, `JS`) and benchmark step columns (`compile`, `gen java`, `gen python`, `gen js`, `test`).
- Regenerate `performance/README.md` from the existing `results.csv`.

Fixes #313.

## Impacted modules
- `performance`

## Validation
- `performance/scripts/render-readme`
- `bash -n performance/scripts/render-readme`
- embedded Python compile check for the renderer heredoc
- `git diff --check -- performance/scripts/render-readme performance/README.md`
