### PR TITLE
fix(#311): release runnable compilers for all backends

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,15 @@ jobs:
           github-token: ${{ github.token }}
           native-image-job-reports: "false"
 
-      - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          arch: x64
+          node-version: "22"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -161,22 +166,30 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Build project without tests
-        run: ./gradlew clean assemble --no-daemon
+      - name: Build and check project
+        run: ./gradlew clean check assemble --no-daemon
 
-      - name: Build Linux native CLI
-        run: ./gradlew :capy:nativeCompile --no-daemon
+      - name: Build JavaScript and Python compiler packages
+        run: ./gradlew :capy:packageJavaScriptCompiler :capy:packagePythonCompiler --no-daemon
 
-      - name: Collect Linux artifacts
+      - name: Smoke test JavaScript and Python compiler packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          capy/build/distributions/javascript-compiler/bin/capyc-js --version
+          capy/build/distributions/python-compiler/bin/capyc-py --version
+
+      - name: Build and collect Linux artifacts
         shell: bash
         run: |
           set -euo pipefail
           VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
-          find capy lib build-tool -path '*/build/libs/*.jar' -type f -exec cp {} dist/ \;
-          find capy -path '*/build/distributions/*' -type f -exec cp {} dist/ \;
-          cp "capy/build/native/nativeCompile/capyc-${VERSION}" "dist/capyc-${VERSION}-linux-x64"
-          tar -czf "dist/capyc-${VERSION}-linux-x64.tar.gz" -C "capy/build/native/nativeCompile" "capyc-${VERSION}"
+          cp "capy/build/libs/capy-${VERSION}.jar" "dist/capyc-${VERSION}.jar"
+          cp "capy/build/distributions/capyc-${VERSION}-javascript.zip" dist/
+          cp "capy/build/distributions/capyc-${VERSION}-python.zip" dist/
+          native-image --no-fallback -o "dist/capyc-${VERSION}-linux-x64" -jar "capy/build/libs/capy-${VERSION}.jar"
+          tar -czf "dist/capyc-${VERSION}-linux-x64.tar.gz" -C dist "capyc-${VERSION}-linux-x64"
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
@@ -217,15 +230,15 @@ jobs:
         with:
           cache-disabled: false
 
-      - name: Build Windows native CLI
-        run: .\gradlew.bat :capy:nativeCompile --no-daemon
+      - name: Build and check project
+        run: .\gradlew.bat clean check assemble --no-daemon
 
-      - name: Collect Windows artifacts
+      - name: Build and collect Windows artifacts
         shell: pwsh
         run: |
           $version = "${{ needs.release-metadata.outputs.release_version }}"
           New-Item -ItemType Directory -Path dist -Force | Out-Null
-          Copy-Item "capy/build/native/nativeCompile/capyc-$version.exe" "dist/capyc-$version-windows-x64.exe"
+          native-image.cmd --no-fallback -o "dist/capyc-$version-windows-x64" -jar "capy/build/libs/capy-$version.jar"
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4

--- a/capy/build.gradle
+++ b/capy/build.gradle
@@ -385,11 +385,17 @@ def capybaraPreparedMainSourceDir = layout.buildDirectory.dir('generated/sources
 def capybaraMainLinkedOutputDir = layout.buildDirectory.dir('generated/sources/capybara/linked/main')
 def capybaraMainPythonSourceDir = layout.projectDirectory.dir('src/main/py')
 def capybaraMainJavaScriptSourceDir = layout.projectDirectory.dir('src/main/js')
+def capybaraJavaScriptCompilerDistDir = layout.projectDirectory.dir('src/dist/javascript')
+def capybaraPythonCompilerDistDir = layout.projectDirectory.dir('src/dist/python')
+def capybaraLibGeneratedJavaScriptDir = project(':lib:capybara-lib').layout.buildDirectory.dir('generated/sources/capybara/js/test')
+def capybaraLibGeneratedPythonDir = project(':lib:capybara-lib').layout.buildDirectory.dir('generated/sources/capybara/python/test')
 def capybaraGeneratedCompilerPythonDir = layout.buildDirectory.dir('generated/sources/capybara/python/compiler')
 def capybaraLinkedCompilerPythonOutputDir = layout.buildDirectory.dir('generated/sources/capybara/linked-python/compiler')
 def capybaraGeneratedCompilerJavaScriptDir = layout.buildDirectory.dir('generated/sources/capybara/javascript/compiler')
 def capybaraRuntimeCompilerJavaScriptDir = layout.buildDirectory.dir('generated/sources/capybara/javascript-runtime/compiler')
 def capybaraLinkedCompilerJavaScriptOutputDir = layout.buildDirectory.dir('generated/sources/capybara/linked-javascript/compiler')
+def capybaraJavaScriptCompilerPackageDir = layout.buildDirectory.dir('distributions/javascript-compiler')
+def capybaraPythonCompilerPackageDir = layout.buildDirectory.dir('distributions/python-compiler')
 def pythonAntlrGrammarDir = layout.buildDirectory.dir('generated/sources/antlr/python-grammars')
 def pythonAntlrGeneratedDir = layout.buildDirectory.dir('generated/sources/antlr/python/main')
 def pythonAntlrRuntimeDir = layout.buildDirectory.dir('python/antlr4-runtime')
@@ -936,6 +942,104 @@ def prepareJavaScriptCompilerRuntime = tasks.register('prepareJavaScriptCompiler
         include 'dev/**'
     }
     into capybaraRuntimeCompilerJavaScriptDir
+}
+
+tasks.register('prepareJavaScriptCompilerPackage', Sync) {
+    description = 'Prepares a runnable JavaScript Capybara compiler distribution.'
+    group = capybaraTaskGroup
+    dependsOn prepareJavaScriptCompilerRuntime
+    dependsOn ':lib:capybara-lib:compileTestCapybaraJavaScriptDirect'
+    dependsOn tasks.named('generateJavaScriptAntlr')
+    dependsOn tasks.named('installJavaScriptAntlrRuntime')
+
+    from(capybaraLibGeneratedJavaScriptDir) {
+        include 'capy/**'
+        exclude 'capy/test/CapyTestRuntime.js'
+        exclude '**/*Test.js'
+        into 'lib/compiler'
+    }
+    from(capybaraRuntimeCompilerJavaScriptDir) {
+        into 'lib/compiler'
+    }
+    from(javascriptAntlrGeneratedDir) {
+        into 'lib/antlr'
+    }
+    from(javascriptAntlrRuntimeDir.map { new File(it.asFile, 'node_modules') }) {
+        into 'lib/node_modules'
+    }
+    from(capybaraJavaScriptCompilerDistDir)
+    into capybaraJavaScriptCompilerPackageDir
+
+    doLast {
+        def packageDir = capybaraJavaScriptCompilerPackageDir.get().asFile
+        new File(packageDir, 'bin/capyc-js').setExecutable(true, false)
+    }
+}
+
+tasks.register('packageJavaScriptCompiler') {
+    description = 'Packages the runnable JavaScript Capybara compiler distribution.'
+    group = capybaraTaskGroup
+    dependsOn tasks.named('prepareJavaScriptCompilerPackage')
+    inputs.dir(capybaraJavaScriptCompilerPackageDir)
+    outputs.file(layout.buildDirectory.file("distributions/capyc-${project.version}-javascript.zip"))
+
+    doLast {
+        def archiveFile = layout.buildDirectory.file("distributions/capyc-${project.version}-javascript.zip").get().asFile
+        archiveFile.parentFile.mkdirs()
+        archiveFile.delete()
+        ant.zip(destfile: archiveFile, basedir: capybaraJavaScriptCompilerPackageDir.get().asFile)
+    }
+}
+
+tasks.register('preparePythonCompilerPackage', Sync) {
+    description = 'Prepares a runnable Python Capybara compiler distribution.'
+    group = capybaraTaskGroup
+    dependsOn generatePythonCompiler
+    dependsOn ':lib:capybara-lib:compileTestCapybaraPythonDirect'
+    dependsOn tasks.named('generatePythonAntlr')
+    dependsOn tasks.named('installPythonAntlrRuntime')
+
+    from(capybaraLibGeneratedPythonDir) {
+        include 'capy/**'
+        exclude 'capy/test/CapyTestRuntime.py'
+        exclude '**/*Test.py'
+        into 'lib/compiler'
+    }
+    from(capybaraGeneratedCompilerPythonDir) {
+        into 'lib/compiler'
+    }
+    from(capybaraMainPythonSourceDir) {
+        include 'dev/**'
+        into 'lib/native'
+    }
+    from(pythonAntlrGeneratedDir) {
+        into 'lib/antlr'
+    }
+    from(pythonAntlrRuntimeDir) {
+        into 'lib/runtime'
+    }
+    from(capybaraPythonCompilerDistDir)
+    into capybaraPythonCompilerPackageDir
+
+    doLast {
+        def packageDir = capybaraPythonCompilerPackageDir.get().asFile
+        new File(packageDir, 'bin/capyc-py').setExecutable(true, false)
+    }
+}
+
+tasks.register('packagePythonCompiler') {
+    description = 'Packages the runnable Python Capybara compiler distribution.'
+    group = capybaraTaskGroup
+    dependsOn tasks.named('preparePythonCompilerPackage')
+    inputs.dir(capybaraPythonCompilerPackageDir)
+    outputs.file(layout.buildDirectory.file("distributions/capyc-${project.version}-python.zip"))
+
+    doLast {
+        def archiveFile = layout.buildDirectory.file("distributions/capyc-${project.version}-python.zip").get().asFile
+        archiveFile.parentFile.mkdirs()
+        archiveFile.delete()
+        ant.zip(destfile: archiveFile, basedir: capybaraPythonCompilerPackageDir.get().asFile)
+    }
 }
 
 tasks.register('pythonNativeParserSmoke', Exec) {

--- a/capy/src/dist/javascript/bin/capyc-js
+++ b/capy/src/dist/javascript/bin/capyc-js
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+APP_HOME="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+if [ "${NODE_PATH:-}" ]; then
+    NODE_PATH="$APP_HOME/lib/compiler:$APP_HOME/lib/antlr:$APP_HOME/lib/node_modules:$NODE_PATH"
+else
+    NODE_PATH="$APP_HOME/lib/compiler:$APP_HOME/lib/antlr:$APP_HOME/lib/node_modules"
+fi
+export NODE_PATH
+exec node "$APP_HOME/launcher/capyc-js.js" "$@"

--- a/capy/src/dist/javascript/bin/capyc-js.cmd
+++ b/capy/src/dist/javascript/bin/capyc-js.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+set "APP_HOME=%~dp0.."
+if defined NODE_PATH (
+  set "NODE_PATH=%APP_HOME%\lib\compiler;%APP_HOME%\lib\antlr;%APP_HOME%\lib\node_modules;%NODE_PATH%"
+) else (
+  set "NODE_PATH=%APP_HOME%\lib\compiler;%APP_HOME%\lib\antlr;%APP_HOME%\lib\node_modules"
+)
+node "%APP_HOME%\launcher\capyc-js.js" %*
+exit /b %ERRORLEVEL%

--- a/capy/src/dist/javascript/launcher/capyc-js.js
+++ b/capy/src/dist/javascript/launcher/capyc-js.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { main } = require('dev/capylang/cli/Capy.js');
+const { __capy_unsafe_run } = require('capy/test/CapyTestRuntime.js');
+
+function dataField(value, name, fallback) {
+    if (value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, name)) {
+        return value[name];
+    }
+    return fallback;
+}
+
+function exitCodeValue(value) {
+    const raw = dataField(value, 'value', value);
+    const numeric = Number(raw);
+    return Number.isInteger(numeric) ? numeric : 1;
+}
+
+function programExitCode(program) {
+    const result = __capy_unsafe_run(program);
+    const type = result && typeof result === 'object' ? String(result.__type || '') : '';
+    if (type === 'Failed' || type.endsWith('.Failed') || type.endsWith('/Failed')) {
+        return exitCodeValue(dataField(result, 'exit_code', dataField(result, 'exitCode', dataField(result, 'value', 1))));
+    }
+    return 0;
+}
+
+process.exitCode = programExitCode(main(process.argv.slice(2)));

--- a/capy/src/dist/python/bin/capyc-py
+++ b/capy/src/dist/python/bin/capyc-py
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+APP_HOME="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+if [ "${PYTHONPATH:-}" ]; then
+    PYTHONPATH="$APP_HOME/lib/compiler:$APP_HOME/lib/native:$APP_HOME/lib/antlr:$APP_HOME/lib/runtime:$PYTHONPATH"
+else
+    PYTHONPATH="$APP_HOME/lib/compiler:$APP_HOME/lib/native:$APP_HOME/lib/antlr:$APP_HOME/lib/runtime"
+fi
+export PYTHONPATH
+exec python3 "$APP_HOME/launcher/capyc-py.py" "$@"

--- a/capy/src/dist/python/bin/capyc-py.cmd
+++ b/capy/src/dist/python/bin/capyc-py.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+set "APP_HOME=%~dp0.."
+if defined PYTHONPATH (
+  set "PYTHONPATH=%APP_HOME%\lib\compiler;%APP_HOME%\lib\native;%APP_HOME%\lib\antlr;%APP_HOME%\lib\runtime;%PYTHONPATH%"
+) else (
+  set "PYTHONPATH=%APP_HOME%\lib\compiler;%APP_HOME%\lib\native;%APP_HOME%\lib\antlr;%APP_HOME%\lib\runtime"
+)
+python "%APP_HOME%\launcher\capyc-py.py" %*
+exit /b %ERRORLEVEL%

--- a/capy/src/dist/python/launcher/capyc-py.py
+++ b/capy/src/dist/python/launcher/capyc-py.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import sys
+
+from capy.test.CapyTestRuntime import _unsafe_run
+from dev.capylang.cli.Capy import main
+
+
+def data_field(value, name, fallback=None):
+    if isinstance(value, dict):
+        return value.get(name, fallback)
+    return getattr(value, name, fallback)
+
+
+def exit_code_value(value):
+    raw = data_field(value, "value", value)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 1
+
+
+def program_exit_code(program):
+    result = _unsafe_run(program)
+    result_type = str(data_field(result, "__type", ""))
+    if result_type == "Failed" or result_type.endswith(".Failed") or result_type.endswith("/Failed"):
+        return exit_code_value(data_field(result, "exit_code", data_field(result, "exitCode", data_field(result, "value", 1))))
+    return 0
+
+
+sys.exit(program_exit_code(main(sys.argv[1:])))

--- a/capy/src/integrationTest/java/dev/capylang/CompilationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/CompilationTest.java
@@ -148,6 +148,41 @@ class CompilationTest {
     }
 
     @Test
+    void shouldGenerateFlatPythonStringConcatenation() {
+        var source = """
+                fun pieces(a: String, b: String, c: String, d: String): String =
+                    a + "-" + b + "-" + c + "-" + d
+                """;
+        var program = compileProgram(List.of(rawModule("StringConcat", "/sample/app", source, SourceKind.FUNCTIONAL)));
+
+        var code = PythonGenerator.pythonGenerator(program).modules().stream()
+                .filter(module -> module.relativePath().equals("sample/app/StringConcat.py"))
+                .findFirst()
+                .orElseThrow()
+                .code();
+
+        assertThat(code).contains("return \"\".join([a, \"-\", b, \"-\", c, \"-\", d])");
+    }
+
+    @Test
+    void shouldGeneratePythonCollectionReduceOperator() {
+        var source = """
+                fun joined(values: List[String]): String =
+                    values |> "", (acc, value) => acc + value
+                """;
+        var program = compileProgram(List.of(rawModule("CollectionReduce", "/sample/app", source, SourceKind.FUNCTIONAL)));
+
+        var code = PythonGenerator.pythonGenerator(program).modules().stream()
+                .filter(module -> module.relativePath().equals("sample/app/CollectionReduce.py"))
+                .findFirst()
+                .orElseThrow()
+                .code();
+
+        assertThat(code).contains("__capy_reduce(");
+        assertThat(code).doesNotContain("|>");
+    }
+
+    @Test
     void shouldGenerateUnionParentFieldsInJavaDataDeclarations() {
         var source = """
                 union A { a: String } = B | C

--- a/capy/src/integrationTest/java/dev/capylang/compiler/CapybaraCompilerLibrariesIntegrationTest.java
+++ b/capy/src/integrationTest/java/dev/capylang/compiler/CapybaraCompilerLibrariesIntegrationTest.java
@@ -17,6 +17,50 @@ import static org.assertj.core.api.Assertions.fail;
 
 class CapybaraCompilerLibrariesIntegrationTest {
     @Test
+    void shouldCompileExplicitEnumValueImportsFromParsedModules() {
+        var enumSource = """
+                enum SourceKind {
+                    FUNCTIONAL,
+                    OBJECT_ORIENTED,
+                }
+                """;
+        var consumerSource = """
+                from /dev/capylang/compiler/parser/SourceKind import { FUNCTIONAL, OBJECT_ORIENTED }
+
+                fun functional(): SourceKind = FUNCTIONAL
+                fun object_oriented(): SourceKind = OBJECT_ORIENTED
+                """;
+
+        var program = compileProgram(List.of(
+                rawModule("SourceKind", "/dev/capylang/compiler/parser", enumSource),
+                rawModule("RawModuleFactory", "/dev/capylang/compiler/parser", consumerSource)
+        ), new LinkedHashSet<>());
+
+        assertThat(program.modules())
+                .extracting(CompiledModule::name)
+                .contains("SourceKind", "RawModuleFactory");
+    }
+
+    @Test
+    void shouldCompileStandardRecursiveFunctionAnnotationImport() {
+        var source = """
+                from /capy/meta_prog/Recursive import { Recursive }
+
+                @Recursive
+                fun sum(values: List[int], acc: int): int =
+                    match values[0] with
+                    case None -> acc
+                    case Some { value } -> sum(values[1:], acc + value)
+                """;
+
+        var program = compileProgram(List.of(rawModule("RecursiveUser", "/foo/app", source)), new LinkedHashSet<>());
+
+        assertThat(program.modules())
+                .extracting(CompiledModule::name)
+                .contains("RecursiveUser");
+    }
+
+    @Test
     void shouldGenerateJavaReferencingLibraryWithoutEmittingIt() {
         var librarySource = """
                 data Message { value: String }

--- a/capy/src/main/capybara/dev/capylang/generator/JavaScriptGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/JavaScriptGenerator.cfun
@@ -8831,7 +8831,7 @@ private fun java_script_identifier_part_char(char: String): bool =
 
 /// Checks whether a name is reserved in JavaScript source.
 private fun java_script_reserved_word(name: String): bool =
-    "|break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|function|if|import|in|instanceof|new|return|super|switch|this|throw|try|typeof|var|void|while|with|yield|let|static|enum|await|implements|package|protected|interface|private|public|null|true|false|" ? ("|" + name + "|")
+    "|break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|function|if|import|in|instanceof|new|return|super|switch|this|throw|try|typeof|var|void|while|with|yield|let|static|enum|await|implements|package|protected|interface|private|public|null|true|false|arguments|" ? ("|" + name + "|")
 
 /// Formats string as a JavaScript literal.
 private fun java_script_string_literal(value: String): String =

--- a/capy/src/main/capybara/dev/capylang/generator/PythonGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/PythonGenerator.cfun
@@ -1083,6 +1083,8 @@ private fun python_binary_expression_code(binary: CompiledBinaryExpression, env:
     let leftType = python_expression_type(binary.left, env, module, allModules)
     if python_result_reduce_operator_expression_with_left_type(binary, leftType)
     then python_result_reduce_operator_code(binary, env, module, allModules)
+    else if python_collection_reduce_operator_expression_with_left_type(binary, leftType)
+    then python_collection_reduce_operator_code(binary, leftType, env, module, allModules)
     else if python_async_pipe_expression_with_left_type(binary, leftType)
     then python_async_pipe_code(binary, env, module, allModules)
     else if python_result_pipe_expression_with_left_type(binary, leftType)
@@ -1095,15 +1097,10 @@ private fun python_binary_expression_code(binary: CompiledBinaryExpression, env:
     then python_collection_pipe_code(binary, env, module, allModules)
     else if python_regex_binary_expression_with_left_type(binary, leftType)
     then python_regex_binary_code(binary, env, module, allModules)
-    else if python_binary_extension_operator_expression_with_left_type(binary, leftType, module, allModules)
-    then python_binary_extension_operator_code_with_left_type(binary, leftType, env, module, allModules)
+    else if python_string_concat_expression(binary, leftType, env, module, allModules)
+    then python_string_concat_code(binary, env, module, allModules)
     else if python_set_binary_expression_with_left_type(binary, leftType)
     then python_set_binary_code(binary, env, module, allModules)
-    else if python_string_concat_expression(binary, leftType, env, module, allModules)
-    then "(" + python_expression_code(binary.left, env, module, allModules)
-        + " + "
-        + python_expression_code(binary.right, env, module, allModules)
-        + ")"
     else if binary.operator == ".nand."
     then "(~(" + python_expression_code(binary.left, env, module, allModules)
         + " & "
@@ -1121,18 +1118,39 @@ private fun python_binary_expression_code(binary: CompiledBinaryExpression, env:
         + ")"
     else match python_binary_runtime_helper(binary.operator) with
     case Some { helper } -> python_binary_runtime_call(helper, binary, env, module, allModules)
-    case None -> "(" + python_expression_code(binary.left, env, module, allModules)
-        + " " + binary.operator + " "
-        + python_expression_code(binary.right, env, module, allModules)
-        + ")"
+    case None ->
+        match python_find_binary_extension_operator_with_left_type(binary, leftType, module, allModules) with
+        case Some { function } -> python_binary_extension_operator_code(function, binary, env, module, allModules)
+        case None -> "(" + python_expression_code(binary.left, env, module, allModules)
+            + " " + binary.operator + " "
+            + python_expression_code(binary.right, env, module, allModules)
+            + ")"
 
 /// Checks whether an expression has the string concat expression shape.
 private fun python_string_concat_expression(binary: CompiledBinaryExpression, leftType: String, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): bool =
     if binary.operator == "+"
     then if leftType == python_string_type()
-        then python_expression_type(binary.right, env, module, allModules) == python_string_type()
+        then match binary.right with
+            case CompiledStringLiteral _ -> true
+            case _ -> python_expression_type(binary.right, env, module, allModules) == python_string_type()
         else false
     else false
+
+/// Emits Python code for a string concat expression.
+private fun python_string_concat_code(expression: CompiledExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    "\"\".join([" + python_string_concat_items_code(expression, env, module, allModules) + "])"
+
+/// Emits flat Python code for string concat expression items.
+private fun python_string_concat_items_code(expression: CompiledExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    match expression with
+    case CompiledBinaryExpression binary ->
+        let leftType = python_expression_type(binary.left, env, module, allModules)
+        if python_string_concat_expression(binary, leftType, env, module, allModules)
+        then python_string_concat_items_code(binary.left, env, module, allModules)
+            + ", "
+            + python_string_concat_items_code(binary.right, env, module, allModules)
+        else python_expression_code(expression, env, module, allModules)
+    case _ -> python_expression_code(expression, env, module, allModules)
 
 /// Checks whether an operator belongs to the binary extension operator expression with left type category.
 private fun python_binary_extension_operator_expression_with_left_type(binary: CompiledBinaryExpression, leftType: String, module: CompiledModule, allModules: List[CompiledModule]): bool =
@@ -1143,13 +1161,16 @@ private fun python_binary_extension_operator_expression_with_left_type(binary: C
 /// Computes the Python type for binary extension operator code with left.
 private fun python_binary_extension_operator_code_with_left_type(binary: CompiledBinaryExpression, leftType: String, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
     match python_find_binary_extension_operator_with_left_type(binary, leftType, module, allModules) with
-    case Some { function } ->
-        python_function_name(function)
-            + "("
-            + python_expression_code(binary.left, env, module, allModules)
-            + python_extension_method_argument_tail([binary.right], env, module, allModules)
-            + ")"
+    case Some { function } -> python_binary_extension_operator_code(function, binary, env, module, allModules)
     case None -> "__capy_unsupported('extension operator')"
+
+/// Emits Python code for binary extension operator.
+private fun python_binary_extension_operator_code(function: CompiledFunction, binary: CompiledBinaryExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    python_function_name(function)
+        + "("
+        + python_expression_code(binary.left, env, module, allModules)
+        + python_extension_method_argument_tail([binary.right], env, module, allModules)
+        + ")"
 
 /// Emits Python runtime support source for binary runtime call.
 private fun python_binary_runtime_call(name: String, binary: CompiledBinaryExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
@@ -1834,6 +1855,28 @@ private fun python_collection_reduce_method_callable_code(receiver: CompiledExpr
         + ", "
         + python_expression_code(reducer, env, module, allModules)
         + ")"
+
+/// Emits Python code for collection reduce operator.
+private fun python_collection_reduce_operator_code(binary: CompiledBinaryExpression, leftType: String, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    match binary.right with
+    case CompiledTupleLiteral literal ->
+        python_collection_reduce_method_code(
+            python_collection_reduce_operator_method_call(binary, literal.values),
+            leftType,
+            env,
+            module,
+            allModules
+        )
+    case _ -> "__capy_unsupported('collection reduce operator')"
+
+/// Converts a collection reduce operator expression into a reduce method call.
+private fun python_collection_reduce_operator_method_call(binary: CompiledBinaryExpression, arguments: List[CompiledExpression]): CompiledMethodCallExpression =
+    CompiledMethodCallExpression {
+        receiver: binary.left,
+        name: "reduce",
+        arguments: arguments,
+        location: binary.location
+    }
 
 /// Computes the Python name for reduce parameters from names.
 private fun python_reduce_parameters_from_names(accumulatorName: String, keyName: String, valueName: String): String =
@@ -3979,6 +4022,8 @@ private fun python_binary_expression_type(binary: CompiledBinaryExpression, env:
     let leftType = python_expression_type(binary.left, env, module, allModules)
     if python_result_reduce_operator_expression_with_left_type(binary, leftType)
     then python_result_reduce_operator_type(binary, env, module, allModules)
+    else if python_collection_reduce_operator_expression_with_left_type(binary, leftType)
+    then python_collection_reduce_operator_type(binary, env, module, allModules)
     else if python_async_pipe_expression_with_left_type(binary, leftType)
     then python_async_type()
     else if python_result_pipe_expression_with_left_type(binary, leftType)
@@ -3993,22 +4038,30 @@ private fun python_binary_expression_type(binary: CompiledBinaryExpression, env:
     then python_regex_binary_expression_type(binary.operator)
     else if python_set_binary_expression_with_left_type(binary, leftType)
     then python_set_binary_expression_type(binary)
-    else match python_find_binary_extension_operator_with_left_type(binary, leftType, module, allModules) with
+    else if binary.operator == "+" & leftType == python_string_type()
+    then python_string_type()
+    else if python_bool_binary_operator(binary.operator) | python_comparison_operator(binary.operator)
+    then python_bool_type()
+    else if python_numeric_binary_operator(binary.operator) | binary.operator == "+"
+    then python_numeric_or_string_binary_expression_type(binary, leftType, env, module, allModules)
+    else python_binary_extension_operator_type(binary, leftType, module, allModules)
+
+/// Infers the expression type for numeric or right-string binary.
+private fun python_numeric_or_string_binary_expression_type(binary: CompiledBinaryExpression, leftType: String, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    let rightType = python_expression_type(binary.right, env, module, allModules)
+    if binary.operator == "+" & rightType == python_string_type()
+    then python_string_type()
+    else if python_numeric_binary_operator(binary.operator)
+    then if python_numeric_type(leftType)
+        then if python_numeric_type(rightType) then python_promoted_numeric_type(leftType, rightType) else python_unknown_type()
+        else python_unknown_type()
+    else python_unknown_type()
+
+/// Infers the expression type for extension operator fallback.
+private fun python_binary_extension_operator_type(binary: CompiledBinaryExpression, leftType: String, module: CompiledModule, allModules: List[CompiledModule]): String =
+    match python_find_binary_extension_operator_with_left_type(binary, leftType, module, allModules) with
     case Some { function } -> function.returnType.name
-    case None ->
-        if python_bool_binary_operator(binary.operator) | python_comparison_operator(binary.operator)
-        then python_bool_type()
-        else if binary.operator == "+" & leftType == "String"
-        then python_string_type()
-        else
-            let rightType = python_expression_type(binary.right, env, module, allModules)
-            if binary.operator == "+" & rightType == "String"
-            then python_string_type()
-            else if python_numeric_binary_operator(binary.operator)
-            then if python_numeric_type(leftType)
-                then if python_numeric_type(rightType) then python_promoted_numeric_type(leftType, rightType) else python_unknown_type()
-                else python_unknown_type()
-            else python_unknown_type()
+    case None -> python_unknown_type()
 
 /// Checks whether an operator belongs to the binary operator category.
 private fun python_bool_binary_operator(operator: String): bool =
@@ -4204,18 +4257,48 @@ private fun python_collection_pipe_operator(operator: String): bool =
 
 /// Checks whether a type reference matches the collection pipe receiver type rule.
 private fun python_collection_pipe_receiver_type(type: String): bool =
-    type == python_unknown_type()
-        | type == python_list_type()
-        | type == python_set_type()
-        | type == python_string_type()
-        | type == python_seq_type()
-        | type == python_dict_type()
+    let baseType = python_type_unqualified_name(type)
+    baseType == python_unknown_type()
+        | baseType == python_list_type()
+        | baseType == python_set_type()
+        | baseType == python_string_type()
+        | baseType == python_seq_type()
+        | baseType == python_dict_type()
 
 /// Computes the Python type for collection pipe result.
 private fun python_collection_pipe_result_type(operator: String, leftType: String): String =
     if leftType == python_dict_type() & operator != "|*"
     then python_dict_type()
     else python_seq_type()
+
+/// Checks whether an operator belongs to the collection reduce operator expression with left type category.
+private fun python_collection_reduce_operator_expression_with_left_type(binary: CompiledBinaryExpression, leftType: String): bool =
+    binary.operator == "|>"
+        & python_collection_pipe_receiver_type(leftType)
+
+/// Checks whether collection reduce operator arguments are supported by the current backend.
+private fun python_collection_reduce_operator_arguments_shape(expression: CompiledExpression, leftType: String): bool =
+    match expression with
+    case CompiledTupleLiteral literal ->
+        if python_two_method_arguments(literal.values)
+        then match literal.values[1] with
+            case Some { reducer } -> python_collection_reduce_operator_reducer_shape(reducer, leftType)
+            case None -> false
+        else false
+    case _ -> false
+
+/// Checks whether collection reduce operator reducer is supported by the current backend.
+private fun python_collection_reduce_operator_reducer_shape(reducer: CompiledExpression, leftType: String): bool =
+    match reducer with
+    case CompiledLambdaExpression lambda -> python_collection_reduce_lambda_parameters_supported(lambda.parameters, leftType)
+    case CompiledFunctionReferenceExpression _ -> true
+    case _ -> false
+
+/// Computes the Python type for collection reduce operator.
+private fun python_collection_reduce_operator_type(binary: CompiledBinaryExpression, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    match binary.right with
+    case CompiledTupleLiteral literal -> python_first_method_argument_type(literal.values, env, module, allModules)
+    case _ -> python_unknown_type()
 
 /// Checks whether a type reference matches the result pipe expression with left type rule.
 private fun python_result_pipe_expression_with_left_type(binary: CompiledBinaryExpression, leftType: String): bool =
@@ -7753,6 +7836,8 @@ private fun python_binary_expression_gatherable(binary: CompiledBinaryExpression
     let leftType = python_expression_type(binary.left, env, module, allModules)
     if python_result_reduce_operator_expression_with_left_type(binary, leftType)
     then python_result_reduce_operator_gatherable(binary, env, module, allModules)
+    else if python_collection_reduce_operator_expression_with_left_type(binary, leftType)
+    then python_collection_reduce_operator_gatherable(binary, leftType, env, module, allModules)
     else if python_async_pipe_expression_with_left_type(binary, leftType)
     then python_async_pipe_gatherable(binary, env, module, allModules)
     else if python_result_pipe_expression_with_left_type(binary, leftType)
@@ -7809,6 +7894,13 @@ private fun python_result_reduce_operator_gatherable(binary: CompiledBinaryExpre
         if python_expression_gatherable(binary.left, env, module, allModules)
         then python_result_reduce_arguments_gatherable(binary.left, literal.values, env, module, allModules)
         else false
+    case _ -> false
+
+/// Checks whether collection reduce operator can be included in generated test gathering.
+private fun python_collection_reduce_operator_gatherable(binary: CompiledBinaryExpression, leftType: String, env: List[PythonBinding], module: CompiledModule, allModules: List[CompiledModule]): bool =
+    match binary.right with
+    case CompiledTupleLiteral literal ->
+        python_collection_reduce_method_gatherable(python_collection_reduce_operator_method_call(binary, literal.values), leftType, env, module, allModules)
     case _ -> false
 
 /// Checks whether option pipe can be included in generated test gathering.

--- a/capy/src/main/java/dev/capylang/compiler/NativeCompilerValidator.java
+++ b/capy/src/main/java/dev/capylang/compiler/NativeCompilerValidator.java
@@ -210,6 +210,10 @@ public final class NativeCompilerValidator {
                 validateNativeProvider(module, function, annotation, errors, nativeProviderKeys);
                 continue;
             }
+            if (isStandardRecursive(annotation, module)) {
+                validateStandardRecursive(module, annotation, errors);
+                continue;
+            }
             var declaration = availableAnnotations.get(unqualified(annotation.name()));
             if (declaration == null) {
                 if ("NativeProvider".equals(unqualified(annotation.name())) && !standardNativeProviderImported(module)) {
@@ -676,6 +680,26 @@ public final class NativeCompilerValidator {
                 || importsName(module.imports(), "NativeProvider", "NativeProvider");
     }
 
+    private boolean isStandardRecursive(FunctionAnnotationApplication annotation, ParsedModule module) {
+        return "Recursive".equals(unqualified(annotation.name())) && standardRecursiveImported(module);
+    }
+
+    private boolean standardRecursiveImported(ParsedModule module) {
+        return importsName(module.imports(), "/capy/meta_prog/Recursive", "Recursive")
+                || importsName(module.imports(), "capy/meta_prog/Recursive", "Recursive")
+                || importsName(module.imports(), "Recursive", "Recursive");
+    }
+
+    private void validateStandardRecursive(
+            ParsedModule module,
+            FunctionAnnotationApplication annotation,
+            List<CompilerError> errors
+    ) {
+        for (var argument : annotation.arguments()) {
+            errors.add(error(module, argument.location(), "Unknown annotation argument " + argument.name() + "."));
+        }
+    }
+
     private boolean importsName(List<ImportDeclaration> imports, String modulePath, String name) {
         var expected = normalizeImportModulePath(modulePath);
         for (var declaration : imports) {
@@ -960,19 +984,20 @@ public final class NativeCompilerValidator {
         private Set<String> parsedSymbols(ParsedModule module) {
             var symbols = new LinkedHashSet<String>();
             for (var definition : module.definitions()) {
-                var name = switch (definition) {
-                    case AnnotationDeclaration annotation -> annotation.name();
-                    case ConstantDefinition constant -> constant.constant().name();
-                    case DataDeclaration data -> data.name();
-                    case DeriverDeclaration deriver -> deriver.name();
-                    case EnumDeclaration enumDeclaration -> enumDeclaration.name();
-                    case FunctionDefinition function -> function.function().name();
-                    case PrimitiveBackedTypeDeclaration primitive -> primitive.name();
-                    case TypeDeclaration type -> type.name();
-                    default -> "";
-                };
-                if (!name.isBlank()) {
-                    symbols.add(name);
+                switch (definition) {
+                    case AnnotationDeclaration annotation -> symbols.add(annotation.name());
+                    case ConstantDefinition constant -> symbols.add(constant.constant().name());
+                    case DataDeclaration data -> symbols.add(data.name());
+                    case DeriverDeclaration deriver -> symbols.add(deriver.name());
+                    case EnumDeclaration enumDeclaration -> {
+                        symbols.add(enumDeclaration.name());
+                        enumDeclaration.values().forEach(value -> symbols.add(value.name()));
+                    }
+                    case FunctionDefinition function -> symbols.add(function.function().name());
+                    case PrimitiveBackedTypeDeclaration primitive -> symbols.add(primitive.name());
+                    case TypeDeclaration type -> symbols.add(type.name());
+                    default -> {
+                    }
                 }
             }
             module.objectOriented().interfaces().forEach(type -> symbols.add(type.name()));


### PR DESCRIPTION
Closes #311.

## What changed
- Release now publishes the Java runnable CLI jar.
- Linux and Windows release jobs build GraalVM native executables directly from the assembled jar.
- Linux release also builds runnable JavaScript and Python compiler ZIPs generated from `Capy.cfun`.
- Added launcher templates for the JS and Python compiler distributions.
- Fixed backend issues exposed by packaging the compiler itself: parsed enum value imports, stdlib `@Recursive`, JS `arguments` escaping, Python collection reduce lowering, and Python string-concat flattening.

## Impacted modules
- `.github/workflows/release.yml`
- `capy` Gradle packaging tasks
- compiler validator
- JavaScript/Python generators

## Validation
- `env GRADLE_USER_HOME=/tmp/capy-gradle-home ./gradlew --project-cache-dir /tmp/capy-gradle-project-cache :capy:packageJavaScriptCompiler :capy:packagePythonCompiler --no-daemon --no-configuration-cache`
- `capy/build/distributions/javascript-compiler/bin/capyc-js --version`
- `capy/build/distributions/python-compiler/bin/capyc-py --version`
- `env GRADLE_USER_HOME=/tmp/capy-gradle-home ./gradlew --project-cache-dir /tmp/capy-gradle-project-cache :capy:integrationTest --tests dev.capylang.CompilationTest.shouldGenerateFlatPythonStringConcatenation --tests dev.capylang.CompilationTest.shouldGeneratePythonCollectionReduceOperator --tests dev.capylang.compiler.CapybaraCompilerLibrariesIntegrationTest.shouldCompileExplicitEnumValueImportsFromParsedModules --tests dev.capylang.compiler.CapybaraCompilerLibrariesIntegrationTest.shouldCompileStandardRecursiveFunctionAnnotationImport --no-daemon`
- `env GRADLE_USER_HOME=/tmp/capy-gradle-home ./gradlew --project-cache-dir /tmp/capy-gradle-project-cache clean check assemble --no-daemon`