### PR TITLE
fix(#311): skip tests in release build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,8 +156,8 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Build and check project
-        run: ./gradlew clean check assemble --no-daemon
+      - name: Build project
+        run: ./gradlew clean assemble --no-daemon
 
       - name: Build and collect Linux artifacts
         shell: bash


### PR DESCRIPTION
Fixes #311.

## What changed
- Changed the Linux release artifact build step from `clean check assemble` to `clean assemble`.
- Kept Windows on the same build-only command, so `build-linux` and `build-windows` no longer run unit or e2e tests.

## Why
The release artifact jobs should build/package Java and native artifacts only. Unit and e2e coverage stays in the dedicated check workflow instead of being repeated during platform artifact builds.

## Validation
- Parsed `.github/workflows/release.yml` with `python3`/PyYAML.
- `git diff --check` completed.
- No Gradle tests run for this change.