### PR TITLE
fix(#311): fix release 0.7 artifact builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,8 +156,8 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Build and check project
-        run: ./gradlew clean check assemble --no-daemon
+      - name: Build project
+        run: ./gradlew clean assemble --no-daemon
 
       - name: Build and collect Linux artifacts
         shell: bash
@@ -166,7 +166,7 @@ jobs:
           VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
           cp "capy/build/libs/capy-${VERSION}.jar" "dist/capyc-${VERSION}.jar"
-          native-image --no-fallback -o "dist/capyc-${VERSION}-linux-x64" -jar "capy/build/libs/capy-${VERSION}.jar"
+          native-image --no-fallback -H:Path=dist -H:Name="capyc-${VERSION}-linux-x64" -jar "capy/build/libs/capy-${VERSION}.jar"
           tar -czf "dist/capyc-${VERSION}-linux-x64.tar.gz" -C dist "capyc-${VERSION}-linux-x64"
 
       - name: Upload Linux artifacts
@@ -208,15 +208,15 @@ jobs:
         with:
           cache-disabled: false
 
-      - name: Build and check project
-        run: .\gradlew.bat clean check assemble --no-daemon
+      - name: Build project
+        run: .\gradlew.bat clean assemble --no-daemon
 
       - name: Build and collect Windows artifacts
         shell: pwsh
         run: |
           $version = "${{ needs.release-metadata.outputs.release_version }}"
           New-Item -ItemType Directory -Path dist -Force | Out-Null
-          native-image.cmd --no-fallback -o "dist/capyc-$version-windows-x64" -jar "capy/build/libs/capy-$version.jar"
+          native-image.cmd --no-fallback "-H:Path=dist" "-H:Name=capyc-$version-windows-x64" -jar "capy/build/libs/capy-$version.jar"
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes #311.

## What changed
- Change `build-linux` and `build-windows` release artifact jobs to `clean assemble` so they do not run unit/e2e/backend test tasks.
- Use explicit GraalVM native-image output path/name via `-H:Path=dist` and `-H:Name=...` for Linux and Windows artifacts.

## Why
`release/0.7.x` was created from master with the old release workflow. Running Release as-is would hit the same failures seen on earlier release branches.

## Validation
- Parsed `.github/workflows/release.yml` with `python3`/PyYAML.
- `git diff --check -- .github/workflows/release.yml`.
- No local UT/e2e or Gradle tests run.