### PR TITLE
fix(#311): rename native release executables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,8 @@ jobs:
           VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
           cp "capy/build/libs/capy-${VERSION}.jar" "dist/capyc-${VERSION}.jar"
-          native-image --no-fallback -H:Path=dist -H:Name="capyc-${VERSION}-linux-x64" -jar "capy/build/libs/capy-${VERSION}.jar"
+          native-image --no-fallback -H:Path=dist -jar "capy/build/libs/capy-${VERSION}.jar"
+          mv "dist/capy-${VERSION}" "dist/capyc-${VERSION}-linux-x64"
           tar -czf "dist/capyc-${VERSION}-linux-x64.tar.gz" -C dist "capyc-${VERSION}-linux-x64"
 
       - name: Upload Linux artifacts
@@ -216,7 +217,8 @@ jobs:
         run: |
           $version = "${{ needs.release-metadata.outputs.release_version }}"
           New-Item -ItemType Directory -Path dist -Force | Out-Null
-          native-image.cmd --no-fallback "-H:Path=dist" "-H:Name=capyc-$version-windows-x64" -jar "capy/build/libs/capy-$version.jar"
+          native-image.cmd --no-fallback "-H:Path=dist" -jar "capy/build/libs/capy-$version.jar"
+          Move-Item -Path "dist/capy-$version.exe" -Destination "dist/capyc-$version-windows-x64.exe" -Force
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- rename GraalVM native-image outputs to the expected Capy release asset names
- keep release build jobs on clean assemble only

## Verification
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8'))"
- git diff --check -- .github/workflows/release.yml

Refs #311