### PR TITLE
fix(#311): sync release workflow artifact builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,8 +156,8 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Build and check project
-        run: ./gradlew clean check assemble --no-daemon
+      - name: Build project
+        run: ./gradlew clean assemble --no-daemon
 
       - name: Build and collect Linux artifacts
         shell: bash
@@ -166,7 +166,8 @@ jobs:
           VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
           cp "capy/build/libs/capy-${VERSION}.jar" "dist/capyc-${VERSION}.jar"
-          native-image --no-fallback -o "dist/capyc-${VERSION}-linux-x64" -jar "capy/build/libs/capy-${VERSION}.jar"
+          native-image --no-fallback -H:Path=dist -jar "capy/build/libs/capy-${VERSION}.jar"
+          mv "dist/capy-${VERSION}" "dist/capyc-${VERSION}-linux-x64"
           tar -czf "dist/capyc-${VERSION}-linux-x64.tar.gz" -C dist "capyc-${VERSION}-linux-x64"
 
       - name: Upload Linux artifacts
@@ -208,15 +209,16 @@ jobs:
         with:
           cache-disabled: false
 
-      - name: Build and check project
-        run: .\gradlew.bat clean check assemble --no-daemon
+      - name: Build project
+        run: .\gradlew.bat clean assemble --no-daemon
 
       - name: Build and collect Windows artifacts
         shell: pwsh
         run: |
           $version = "${{ needs.release-metadata.outputs.release_version }}"
           New-Item -ItemType Directory -Path dist -Force | Out-Null
-          native-image.cmd --no-fallback -o "dist/capyc-$version-windows-x64" -jar "capy/build/libs/capy-$version.jar"
+          native-image.cmd --no-fallback "-H:Path=dist" -jar "capy/build/libs/capy-$version.jar"
+          Move-Item -Path "dist/capy-$version.exe" -Destination "dist/capyc-$version-windows-x64.exe" -Force
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- sync the release workflow artifact build fixes back to master
- keep platform release builds on clean assemble only
- rename GraalVM native-image outputs to the expected release asset names

## Verification
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml', encoding='utf-8'))"
- git diff --check -- .github/workflows/release.yml

Refs #311