### PR TITLE
[codex] Add COO Async e2e coverage

### DIFF
--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInterop.coo
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInterop.coo
@@ -1,0 +1,18 @@
+from /capy/lang/Async import { * }
+from /capy/lang/Effect import { * }
+from /capy/lang/Result import { * }
+
+class AsyncCalculator(seed: int) {
+    field seed: int = seed
+
+    def add(delta: int): int = this.seed + delta
+
+    def start_add(delta: int): Async[int] =
+        pure(this.seed + delta).start()
+
+    def join_add(delta: int): Effect[Result[int]] =
+        pure(this.seed + delta).start().join()
+
+    def joined_label(delta: int): Effect[Result[String]] =
+        pure("value:" + (this.seed + delta)).start().join()
+}

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInterop.coo
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInterop.coo
@@ -13,6 +13,9 @@ class AsyncCalculator(seed: int) {
     def join_add(delta: int): Effect[Result[int]] =
         pure(this.seed + delta).start().join()
 
+    def join_external(task: Async[int]): Effect[Result[int]] =
+        task.join()
+
     def joined_label(delta: int): Effect[Result[String]] =
         pure("value:" + (this.seed + delta)).start().join()
 }

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInteropCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInteropCapyTest.cfun
@@ -13,6 +13,7 @@ fun tests(): Effect[TestFile] =
         async_all_preserves_object_method_results().map(assertion => test("async all preserves object method results", () => assertion)),
         coo_method_can_return_async_handle().map(assertion => test("coo method can return async handle", () => assertion)),
         coo_method_can_join_async_result().map(assertion => test("coo method can join async result", () => assertion)),
+        coo_method_can_join_cfun_created_async_result().map(assertion => test("coo method can join cfun-created async result", () => assertion)),
         coo_method_can_join_string_async_result().map(assertion => test("coo method can join string async result", () => assertion)),
     ])
 
@@ -47,6 +48,12 @@ fun coo_method_can_return_async_handle(): Effect[Assert] =
 fun coo_method_can_join_async_result(): Effect[Assert] =
     let calculator <- AsyncCalculator(40)
     let result <- calculator.join_add(2)
+    assert_that(success_or(result, 0)).is_equal_to(42)
+
+fun coo_method_can_join_cfun_created_async_result(): Effect[Assert] =
+    let calculator <- AsyncCalculator(0)
+    let task = pure(42).start()
+    let result <- calculator.join_external(task)
     assert_that(success_or(result, 0)).is_equal_to(42)
 
 fun coo_method_can_join_string_async_result(): Effect[Assert] =

--- a/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInteropCapyTest.cfun
+++ b/capy/src/e2e-coo/capybara/dev/capylang/test/ObjectAsyncInteropCapyTest.cfun
@@ -1,0 +1,78 @@
+from /capy/lang/Async import { * }
+from /capy/lang/Effect import { * }
+from /capy/lang/Result import { * }
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+from ObjectAsyncInterop import { AsyncCalculator }
+
+fun tests(): Effect[TestFile] =
+    test_file("/dev/capylang/test/ObjectAsyncInterop.coo", [
+        async_constructor_effect_can_be_joined().map(assertion => test("async constructor effect can be joined", () => assertion)),
+        async_object_method_effect_can_be_joined().map(assertion => test("async object method effect can be joined", () => assertion)),
+        async_object_method_effect_can_be_mapped().map(assertion => test("async object method effect can be mapped", () => assertion)),
+        async_all_preserves_object_method_results().map(assertion => test("async all preserves object method results", () => assertion)),
+        coo_method_can_return_async_handle().map(assertion => test("coo method can return async handle", () => assertion)),
+        coo_method_can_join_async_result().map(assertion => test("coo method can join async result", () => assertion)),
+        coo_method_can_join_string_async_result().map(assertion => test("coo method can join string async result", () => assertion)),
+    ])
+
+fun async_constructor_effect_can_be_joined(): Effect[Assert] =
+    let result <- AsyncCalculator(40).start().join()
+    assert_that(is_success(result)).is_true()
+
+fun async_object_method_effect_can_be_joined(): Effect[Assert] =
+    let calculator <- AsyncCalculator(40)
+    let result <- calculator.add(2).start().join()
+    assert_that(success_or(result, 0)).is_equal_to(42)
+
+fun async_object_method_effect_can_be_mapped(): Effect[Assert] =
+    let calculator <- AsyncCalculator(40)
+    let result <- calculator.add(2).start().map(value => "value:" + value).join()
+    assert_that(string_success_or(result, "missing")).is_equal_to("value:42")
+
+fun async_all_preserves_object_method_results(): Effect[Assert] =
+    let calculator <- AsyncCalculator(40)
+    let results <- all([
+        calculator.add(1).start(),
+        calculator.add(2).start(),
+    ])
+    assert_that(success_values(results)).is_equal_to([41, 42])
+
+fun coo_method_can_return_async_handle(): Effect[Assert] =
+    let calculator <- AsyncCalculator(40)
+    let task <- calculator.start_add(2)
+    let result <- task.join()
+    assert_that(success_or(result, 0)).is_equal_to(42)
+
+fun coo_method_can_join_async_result(): Effect[Assert] =
+    let calculator <- AsyncCalculator(40)
+    let result <- calculator.join_add(2)
+    assert_that(success_or(result, 0)).is_equal_to(42)
+
+fun coo_method_can_join_string_async_result(): Effect[Assert] =
+    let calculator <- AsyncCalculator(40)
+    let result <- calculator.joined_label(2)
+    assert_that(string_success_or(result, "missing")).is_equal_to("value:42")
+
+private fun success_or(result: Result[int], fallback: int): int =
+    match result with
+    case Success { value } -> value
+    case Error _ -> fallback
+
+private fun is_success(result: Result[T]): bool =
+    match result with
+    case Success _ -> true
+    case Error _ -> false
+
+private fun string_success_or(result: Result[String], fallback: String): String =
+    match result with
+    case Success { value } -> value
+    case Error _ -> fallback
+
+private fun success_values(results: List[Result[int]]): List[int] =
+    match results[0] with
+    case None -> []
+    case Some { value } ->
+        match value with
+        case Success { value } -> [value] + success_values(results[1:])
+        case Error _ -> [-1] + success_values(results[1:])


### PR DESCRIPTION
Closes #333.

## What changed
- Added `ObjectAsyncInterop.coo` with an `AsyncCalculator` fixture that creates async handles and joins async results inside COO methods.
- Added `ObjectAsyncInteropCapyTest.cfun` with coverage for async constructor joins, async object method joins, explicit `Async.map`, `all`, COO-returned async handles, COO methods that join async results, and a `.cfun`-created async handle joined from `.coo`.

## Impacted modules
- `capy` e2e COO test sources only.

## Validation
- `./gradlew :capy:check`
- Isolated JavaScript compile/generate for the new COO fixture and companion test, followed by direct generated test execution: 8 test cases, 0 failures.
- `./gradlew :capy:e2e-javascript-coo` currently fails before running tests on pre-existing unsupported COO constructs in `ObjectOrientedRuntime.coo` and `ObjectOrientedFpInterop.coo`; the new files are not part of that failure list.