### PR TITLE
chore(#311): publish release bootstrap artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,8 @@ jobs:
           VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
           cp "capy/build/libs/capy-${VERSION}.jar" "dist/capy-${VERSION}.jar"
+          cp "build-tool/gradle/build/libs/gradle-${VERSION}.jar" "dist/gradle-${VERSION}.jar"
+          cp "lib/capybara-lib/build/libs/capybara-lib-${VERSION}.jar" "dist/capybara-lib-${VERSION}.jar"
           native-image --no-fallback -H:Path=dist -jar "capy/build/libs/capy-${VERSION}.jar"
           mv "dist/capy-${VERSION}" "dist/capy-${VERSION}-linux-x64"
           tar -czf "dist/capy-${VERSION}-linux-x64.tar.gz" -C dist "capy-${VERSION}-linux-x64"


### PR DESCRIPTION
Updates the release workflow to upload the artifacts needed by `capybaraVersion` bootstrapping.

Changes:
- Adds `gradle-<version>.jar` to GitHub release assets.
- Adds `capybara-lib-<version>.jar` to GitHub release assets so `capy/build.gradle` can resolve the runtime library from the same release.

Validation:
- `env GRADLE_USER_HOME=/tmp/capybara-release-artifacts-gradle-home ./gradlew :capy:jar :lib:capybara-lib:jar :build-tool:gradle:jar --no-daemon`