### PR TITLE
chore(#311): rename Gradle release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           VERSION="${{ needs.release-metadata.outputs.release_version }}"
           mkdir -p dist
           cp "capy/build/libs/capy-${VERSION}.jar" "dist/capy-${VERSION}.jar"
-          cp "build-tool/gradle/build/libs/gradle-${VERSION}.jar" "dist/gradle-${VERSION}.jar"
+          cp "build-tool/gradle/build/libs/capy-gradle-${VERSION}.jar" "dist/capy-gradle-${VERSION}.jar"
           cp "lib/capybara-lib/build/libs/capybara-lib-${VERSION}.jar" "dist/capybara-lib-${VERSION}.jar"
           native-image --no-fallback -H:Path=dist -jar "capy/build/libs/capy-${VERSION}.jar"
           mv "dist/capy-${VERSION}" "dist/capy-${VERSION}-linux-x64"

--- a/build-tool/gradle/build.gradle.kts
+++ b/build-tool/gradle/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
 group = "dev.capylang"
 version = rootProject.version
 
+base {
+    archivesName.set("capy-gradle")
+}
+
 val capybaraVersion = providers.gradleProperty("capybaraVersion")
 val githubPackagesUser = providers.environmentVariable("GITHUB_ACTOR")
     .orElse(providers.gradleProperty("gpr.user"))


### PR DESCRIPTION
Renames the Gradle plugin release artifact to `capy-gradle`.

Changes:
- Sets the Gradle plugin jar archive base name to `capy-gradle`.
- Updates the release workflow to publish `capy-gradle-<version>.jar` as the GitHub release asset.

Validation:
- `env GRADLE_USER_HOME=/tmp/capybara-capy-gradle-artifact-gradle-home ./gradlew :build-tool:gradle:jar --no-daemon`