### PR TITLE
fix(#311): update master bootstrap version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4g -Xss64m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8
 group=dev.capylang
 version=0.9.0-SNAPSHOT
-capybaraVersion=0.3.6
+capybaraVersion=0.8.1
 antlrVersion=4.13.2
 junitVersion=5.13.4
 org.gradle.parallel=true


### PR DESCRIPTION
## What changed
- Update `capybaraVersion` on `master` from `0.3.6` to `0.8.1`.

## Why
- `release/0.8.x` was fixed to bootstrap from Capybara `0.8.1`, but the merge-back workflow preserved master-side `gradle.properties`, leaving `master` on the stale bootstrap compiler version.

## Impacted modules
- Root Gradle bootstrap/version configuration.

## Verification
- `git diff --check`
- `./gradlew help --no-daemon --no-configuration-cache`
