### PR TITLE
fix(#311): preserve only version during merge back

### DIFF
--- a/.github/workflows/merge_back.yml
+++ b/.github/workflows/merge_back.yml
@@ -54,6 +54,53 @@ jobs:
             exit 1
           fi
 
+          resolve_gradle_properties_conflict() {
+            local version_side="$1"
+            local version_stage
+            local content_stage
+            case "${version_side}" in
+              --ours)
+                version_stage=2
+                content_stage=3
+                ;;
+              --theirs)
+                version_stage=3
+                content_stage=2
+                ;;
+              *)
+                echo "::error::Unsupported gradle.properties side: ${version_side}"
+                exit 1
+                ;;
+            esac
+
+            local version_line
+            version_line="$(git show ":${version_stage}:gradle.properties" | grep -m 1 '^version=')"
+            if [[ -z "${version_line}" ]]; then
+              echo "::error::Could not find version in ${version_side} gradle.properties."
+              exit 1
+            fi
+
+            git show ":${content_stage}:gradle.properties" > gradle.properties
+            local resolved_file
+            resolved_file="$(mktemp)"
+            if ! awk -v version_line="${version_line}" '
+              BEGIN { replaced = 0 }
+              /^version=/ {
+                print version_line
+                replaced = 1
+                next
+              }
+              { print }
+              END { if (replaced == 0) exit 1 }
+            ' gradle.properties > "${resolved_file}"; then
+              rm -f "${resolved_file}"
+              echo "::error::Could not replace version in resolved gradle.properties."
+              exit 1
+            fi
+            mv "${resolved_file}" gradle.properties
+            git add gradle.properties
+          }
+
           resolve_conflicts() {
             local gradle_side="$1"
             local conflicts
@@ -63,8 +110,7 @@ jobs:
             fi
 
             if [[ "${conflicts}" == "gradle.properties" ]]; then
-              git checkout "${gradle_side}" gradle.properties
-              git add gradle.properties
+              resolve_gradle_properties_conflict "${gradle_side}"
             else
               echo "::error::Merge conflict outside gradle.properties. Conflicting files:"
               printf '%s\n' "${conflicts}"


### PR DESCRIPTION
## What changed
- Change merge-back conflict handling for `gradle.properties` so only the selected side's `version=` line is preserved.
- Keep every other `gradle.properties` value from the side being merged, so release-side changes such as `capybaraVersion` are not discarded.

## Why
- The previous resolver checked out the whole `gradle.properties` file from one side. That preserved `master`'s snapshot version, but also accidentally reverted unrelated release-side properties during merge-back.

## Impacted modules
- `.github/workflows/merge_back.yml`

## Verification
- `git diff --check`
- Temporary git merge simulation for release-to-master conflict: kept master `version`, kept release `capybaraVersion`.
- Temporary git merge simulation for state-branch update conflict: kept default-branch `version`, kept state/release `capybaraVersion`.
- Parsed `.github/workflows/merge_back.yml` with Python `yaml.safe_load`.

Note: `actionlint` and Ruby were not installed in the local environment.
