### PR TITLE
fix(#349): make Clock.now native

### DIFF
--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/EffectBindCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/EffectBindCapyTest.cfun
@@ -2,6 +2,8 @@ from /capy/test/Assert import { * }
 from /capy/test/CapyTest import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/System import { current_millis, nano_time }
+from /capy/date_time/Clock import { now }
+from /capy/date_time/DateTime import { * }
 from EffectBind import { * }
 
 fun tests(): Effect[TestFile] =
@@ -9,7 +11,7 @@ fun tests(): Effect[TestFile] =
         binds_effects_lazily().map(assertion => test("binds effects lazily", () => assertion)),
         test("constructing delayed failure does not run thunk", () => constructing_delayed_failure_does_not_run_thunk()),
         effect_delay_is_lazy_and_non_memoized().map(assertion => test("effect delay is lazy and non-memoized", () => assertion)),
-        clock_now_returns_iso_date_time_effect().map(assertion => test("clock now returns ISO date-time effect", () => assertion)),
+        clock_now_returns_current_date_time_effect().map(assertion => test("clock now returns current date-time effect", () => assertion)),
         current_millis_returns_bounded_current_time_effect().map(assertion => test("current millis returns bounded current time effect", () => assertion)),
         nano_time_returns_bounded_monotonic_time_effect().map(assertion => test("nano time returns bounded monotonic time effect", () => assertion)),
     ])
@@ -46,10 +48,13 @@ private fun effect_delay_assertions(): Effect[Assert] =
 private fun consume_time(count: int): int =
     if count == 0 then 0 else 1 + consume_time(count - 1)
 
-fun clock_now_returns_iso_date_time_effect(): Effect[Assert] =
-    clock_now_iso().map(value =>
-        assert_that(value).contains("T")
-    )
+fun clock_now_returns_current_date_time_effect(): Effect[Assert] =
+    let current <- now()
+    let currentIso <- clock_now_iso()
+    assert_all([
+        assert_that(current.greater_than(UNIX_EPOCH)).is_true(),
+        assert_that(currentIso).contains("T"),
+    ])
 
 fun current_millis_returns_bounded_current_time_effect(): Effect[Assert] =
     current_millis_assertions()

--- a/capy/src/main/capybara/dev/capylang/generator/JavaGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/JavaGenerator.cfun
@@ -1712,7 +1712,9 @@ private fun java_function_body(function: CompiledFunction, returnType: CompiledT
     match nativeProviderScope.declarations.get(function.name) with
     case Some { declaration } -> java_native_provider_function_body(declaration, returnType, nativeProviderScope)
     case None ->
-    if tail_recursive_function(function, env, module, allModules)
+    if java_clock_native_function(function, module)
+    then java_clock_native_function_body()
+    else if tail_recursive_function(function, env, module, allModules)
     then tail_recursive_function_body(function, returnType, env, module, allModules)
     else match function.body with
     case CompiledBlockExpression block ->
@@ -1727,6 +1729,23 @@ private fun java_function_body(function: CompiledFunction, returnType: CompiledT
         if !expression_emittable_as(function.body, returnType, env, module, allModules)
         then "        throw new UnsupportedOperationException(\"Unsupported CFUN expression at " + function.location.line + ":" + function.location.column + "\");" + newline()
         else "        return " + expression_code(function.body, env, returnType, module, allModules) + ";" + newline()
+
+/// Checks whether a function is a Clock native runtime wrapper.
+private fun java_clock_native_function(function: CompiledFunction, module: CompiledModule): bool =
+    module.path == "capy/date_time"
+        & module.name == "Clock"
+        & function.name == "now"
+        & java_native_function_body(function)
+
+/// Checks whether a function body is the native marker.
+private fun java_native_function_body(function: CompiledFunction): bool =
+    match function.body with
+    case CompiledUnsupportedExpression unsupported -> unsupported.source == "<native>"
+    case _ -> false
+
+/// Emits the Clock native runtime wrapper body.
+private fun java_clock_native_function_body(): String =
+    "        return capy.lang.Effect.delay(() -> dev.capylang.DateTimeUtil.fromJavaLocalDateTime(java.time.LocalDateTime.now(java.time.Clock.systemUTC())));" + newline()
 
 private fun java_native_provider_index(catalog: NativeProviderCatalog): JavaNativeProviderIndex =
     JavaNativeProviderIndex {

--- a/capy/src/main/capybara/dev/capylang/generator/JavaScriptGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/JavaScriptGenerator.cfun
@@ -1487,6 +1487,8 @@ private fun java_script_function_body_expression(function: CompiledFunction, mod
         then java_script_system_property_native_function_body(function)
         else if java_script_async_native_function(function, module)
         then java_script_async_native_function_body(function)
+        else if java_script_clock_native_function(function, module)
+        then java_script_clock_native_function_body()
         else java_script_expression_code(function.body, java_script_function_bindings(function), module, allModules)
 
 /// Checks whether a function is a System native runtime wrapper.
@@ -1514,6 +1516,17 @@ private fun java_script_async_native_function(function: CompiledFunction, module
 /// Emits the Async native runtime wrapper body.
 private fun java_script_async_native_function_body(function: CompiledFunction): String =
     "__capy_async_" + function.name + "(" + java_script_identifier(first_function_parameter_name(function)) + ")"
+
+/// Checks whether a function is a Clock native runtime wrapper.
+private fun java_script_clock_native_function(function: CompiledFunction, module: CompiledModule): bool =
+    module.path == "capy/date_time"
+        & module.name == "Clock"
+        & function.name == "now"
+        & java_script_native_function_body(function)
+
+/// Emits the Clock native runtime wrapper body.
+private fun java_script_clock_native_function_body(): String =
+    "__capy_clock_now()"
 
 /// Returns the first function parameter name.
 private fun first_function_parameter_name(function: CompiledFunction): String =

--- a/capy/src/main/capybara/dev/capylang/generator/PythonGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/PythonGenerator.cfun
@@ -730,6 +730,8 @@ private fun python_function_body(function: CompiledFunction, env: List[PythonBin
         then "    return " + python_system_property_native_function_body(function) + python_newline()
         else if python_async_native_function(function, module)
         then "    return " + python_async_native_function_body(function) + python_newline()
+        else if python_clock_native_function(function, module)
+        then "    return " + python_clock_native_function_body() + python_newline()
         else python_return_statement(function.body, env, module, allModules, "    ", function.returnType)
 
 /// Checks whether a function is a System native runtime wrapper.
@@ -757,6 +759,17 @@ private fun python_async_native_function(function: CompiledFunction, module: Com
 /// Emits the Async native runtime wrapper body.
 private fun python_async_native_function_body(function: CompiledFunction): String =
     "__capy_async_" + function.name + "(" + python_identifier(python_first_function_parameter_name(function)) + ")"
+
+/// Checks whether a function is a Clock native runtime wrapper.
+private fun python_clock_native_function(function: CompiledFunction, module: CompiledModule): bool =
+    module.path == "capy/date_time"
+        & module.name == "Clock"
+        & function.name == "now"
+        & python_native_placeholder_function(function)
+
+/// Emits the Clock native runtime wrapper body.
+private fun python_clock_native_function_body(): String =
+    "__capy_clock_now()"
 
 /// Returns the first function parameter name.
 private fun python_first_function_parameter_name(function: CompiledFunction): String =

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Clock.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Clock.cfun
@@ -10,5 +10,4 @@ from /capy/lang/Effect import { * }
 /// ```
 /// The value is effectful because the current time comes from the runtime
 /// environment.
-fun now(): Effect[DateTime] =
-    delay(() => UNIX_EPOCH)
+fun now(): Effect[DateTime] = <native>


### PR DESCRIPTION
## What changed
- Changed `/capy/date_time/Clock.now()` to use the native marker instead of returning `delay(() => UNIX_EPOCH)`.
- Added Java, JavaScript, and Python generator wrappers so direct generated `Clock.now` functions delegate to the runtime clock hooks.
- Tightened the functional e2e coverage so `Clock.now()` must return a value after `UNIX_EPOCH`, which catches the old stub.

## Why
`Clock.now()` is effectful but previously always returned the Unix epoch. The generators already had backend clock runtime helpers, but the library declaration and direct generated function body needed to route through them.

Closes #349

## Validation
- `git diff --check`
- Source scan confirmed no remaining `delay(() => UNIX_EPOCH)` Clock stub and no similar constant-delay `Effect` stubs in production Capybara sources.
- Attempted `./gradlew :lib:capybara-lib:testCapybara :capy:testCapybara :capy:e2e-javascript-cfun :capy:e2e-python-cfun`; interrupted after `:capy:compileCapybara` stayed in the CPU-heavy Java generator phase without reaching task completion.
- Attempted `./gradlew :capy:compileCapybara --console=plain`; also interrupted after the same long generator phase did not complete within the local validation window.