### PR TITLE
feat(#354): add String primitive conversions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,11 +42,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Java 21
+      - name: Set up Java 21.0.6
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          # Later Java 21 patch releases reject stack maps emitted by the current self-hosted compiler.
+          java-version: "21.0.6"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,12 +42,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Java 21.0.6
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          # Later Java 21 patch releases reject stack maps emitted by the current self-hosted compiler.
-          java-version: "21.0.6"
+          java-version: "21"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -1,5 +1,5 @@
 from /capy/lang/Option import { * }
-from /capy/lang/Primitives import { to_int, to_long, to_double, to_float, to_bool }
+import /capy/lang/Primitives
 from /capy/lang/Result import { * }
 from /capy/lang/Ordering import { * }
 from /capy/collection/CollectionTypes import { * }
@@ -14,19 +14,19 @@ from /capy/meta_prog/Recursive import { Recursive }
 data String { <native> }
 
 /// Parses this String as an int.
-fun String.to_int(): Result[int] = to_int(this)
+fun String.to_int(): Result[int] = Primitives.to_int(this)
 
 /// Parses this String as a long.
-fun String.to_long(): Result[long] = to_long(this)
+fun String.to_long(): Result[long] = Primitives.to_long(this)
 
 /// Parses this String as a double.
-fun String.to_double(): Result[double] = to_double(this)
+fun String.to_double(): Result[double] = Primitives.to_double(this)
 
 /// Parses this String as a float.
-fun String.to_float(): Result[float] = to_float(this)
+fun String.to_float(): Result[float] = Primitives.to_float(this)
 
 /// Parses this String as a bool.
-fun String.to_bool(): Result[bool] = to_bool(this)
+fun String.to_bool(): Result[bool] = Primitives.to_bool(this)
 
 /// Returns the number of characters in this String.
 fun String.size(): size = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -1,4 +1,5 @@
 from /capy/lang/Option import { * }
+from /capy/lang/Primitives import { to_int, to_long, to_double, to_float, to_bool }
 from /capy/lang/Result import { * }
 from /capy/lang/Ordering import { * }
 from /capy/collection/CollectionTypes import { * }
@@ -11,6 +12,21 @@ from /capy/meta_prog/Recursive import { Recursive }
 /// Native String type backed by the runtime String implementation.
 /// String literals use quotes: "hello".
 data String { <native> }
+
+/// Parses this String as an int.
+fun String.to_int(): Result[int] = to_int(this)
+
+/// Parses this String as a long.
+fun String.to_long(): Result[long] = to_long(this)
+
+/// Parses this String as a double.
+fun String.to_double(): Result[double] = to_double(this)
+
+/// Parses this String as a float.
+fun String.to_float(): Result[float] = to_float(this)
+
+/// Parses this String as a bool.
+fun String.to_bool(): Result[bool] = to_bool(this)
 
 /// Returns the number of characters in this String.
 fun String.size(): size = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -1,5 +1,4 @@
 from /capy/lang/Option import { * }
-import /capy/lang/Primitives
 from /capy/lang/Result import { * }
 from /capy/lang/Ordering import { * }
 from /capy/collection/CollectionTypes import { * }
@@ -14,19 +13,19 @@ from /capy/meta_prog/Recursive import { Recursive }
 data String { <native> }
 
 /// Parses this String as an int.
-fun String.to_int(): Result[int] = Primitives.to_int(this)
+fun String.to_int(): Result[int] = <native>
 
 /// Parses this String as a long.
-fun String.to_long(): Result[long] = Primitives.to_long(this)
+fun String.to_long(): Result[long] = <native>
 
 /// Parses this String as a double.
-fun String.to_double(): Result[double] = Primitives.to_double(this)
+fun String.to_double(): Result[double] = <native>
 
 /// Parses this String as a float.
-fun String.to_float(): Result[float] = Primitives.to_float(this)
+fun String.to_float(): Result[float] = <native>
 
 /// Parses this String as a bool.
-fun String.to_bool(): Result[bool] = Primitives.to_bool(this)
+fun String.to_bool(): Result[bool] = <native>
 
 /// Returns the number of characters in this String.
 fun String.size(): size = <native>

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -1,4 +1,5 @@
 from /capy/lang/Option import { * }
+import /capy/lang/Primitives
 from /capy/lang/Result import { * }
 from /capy/lang/Ordering import { * }
 from /capy/collection/CollectionTypes import { * }
@@ -13,19 +14,19 @@ from /capy/meta_prog/Recursive import { Recursive }
 data String { <native> }
 
 /// Parses this String as an int.
-fun String.to_int(): Result[int] = <native>
+fun String.to_int(): Result[int] = Primitives.to_int(this)
 
 /// Parses this String as a long.
-fun String.to_long(): Result[long] = <native>
+fun String.to_long(): Result[long] = Primitives.to_long(this)
 
 /// Parses this String as a double.
-fun String.to_double(): Result[double] = <native>
+fun String.to_double(): Result[double] = Primitives.to_double(this)
 
 /// Parses this String as a float.
-fun String.to_float(): Result[float] = <native>
+fun String.to_float(): Result[float] = Primitives.to_float(this)
 
 /// Parses this String as a bool.
-fun String.to_bool(): Result[bool] = <native>
+fun String.to_bool(): Result[bool] = Primitives.to_bool(this)
 
 /// Returns the number of characters in this String.
 fun String.size(): size = <native>

--- a/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
@@ -10,6 +10,7 @@ from /capy/test/CapyTest import { * }
 fun tests(): Effect[TestFile] =
     test_file("/capy/lang/String.cfun", [
         test("should report length and emptiness", () => should_report_length_and_emptiness()),
+        test("should parse primitive values", () => should_parse_primitive_values()),
         test("should create chars", () => should_create_chars()),
         test("should get characters by index", () => should_get_characters_by_index()),
         test("should list characters as sequence", () => should_list_characters_as_sequence()),
@@ -38,6 +39,16 @@ fun should_report_length_and_emptiness(): Assert =
         assert_that("capy".size()).is_equal_to(4),
         assert_that("".is_empty()).is_equal_to(true),
         assert_that("capy".is_empty()).is_equal_to(false),
+    ])
+
+fun should_parse_primitive_values(): Assert =
+    assert_all([
+        assert_that("123".to_int()).succeeds(123),
+        assert_that("12345678901".to_long()).succeeds(12345678901L),
+        assert_that("12.5".to_double()).succeeds(12.5),
+        assert_that("1.25".to_float()).succeeds(1.25f),
+        assert_that("true".to_bool()).succeeds(true),
+        assert_that("invalid".to_int()).fails("Cannot parse string to int: invalid"),
     ])
 
 fun should_create_chars(): Assert =


### PR DESCRIPTION
## Summary
- Add String proxy methods for int, long, double, float, and bool parsing.
- Delegate every proxy to the existing Primitives parser.
- Cover parsing success and failure through String library tests.

## Impact
String values can use consistent conversion syntax, such as 42.to_int().

## Validation
- ./gradlew.bat :lib:capybara-lib:testCapybara was attempted twice but exceeded the local two-minute command limit without reporting a diagnostic.