### PR TITLE
fix(#357): restore master build

### DIFF
--- a/capy/build.gradle
+++ b/capy/build.gradle
@@ -432,7 +432,12 @@ def intellijE2eTestSourceDirs = files(
 def capybaraJavaScriptTestRunner = project(':lib:capybara-lib').layout.projectDirectory.file('src/test/js/run-capybara-tests.js')
 def capybaraPythonTestRunner = project(':lib:capybara-lib').layout.projectDirectory.file('src/test/py/run-capybara-tests.py')
 def capyRuntimeDependencies = configurations.runtimeClasspath.incoming.artifactView {
-    componentFilter { componentIdentifier -> !(componentIdentifier instanceof ProjectComponentIdentifier) }
+    componentFilter { componentIdentifier ->
+        !(componentIdentifier instanceof ProjectComponentIdentifier) &&
+                !(componentIdentifier instanceof ModuleComponentIdentifier &&
+                        componentIdentifier.group == 'dev.capylang' &&
+                        componentIdentifier.module == 'capybara-lib')
+    }
 }.files
 def capyRuntimeClasspath = files(
         capyClassesDir,

--- a/capy/src/e2e-cfun/capybara/dev/capylang/test/SystemPropertiesCapyTest.cfun
+++ b/capy/src/e2e-cfun/capybara/dev/capylang/test/SystemPropertiesCapyTest.cfun
@@ -18,12 +18,14 @@ fun set_system_property_stores_value_and_returns_previous(): Effect[Assert] =
     let first <- system_property(key)
     let overwritten <- set_system_property(key, "second")
     let second <- system_property(key)
+    let cleaned_up <- clear_system_property(key)
     assert_all([
         assert_that(missing).is_empty(),
         assert_that(previous).is_empty(),
         assert_that(first).contains("first"),
         assert_that(overwritten).contains("first"),
         assert_that(second).contains("second"),
+        assert_that(cleaned_up).contains("second"),
     ])
 
 fun set_system_property_empty_name_returns_none(): Effect[Assert] =

--- a/lib/capybara-lib/src/test/capybara/capy/lang/SystemTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/SystemTest.cfun
@@ -22,12 +22,14 @@ fun set_system_property_round_trips_value(): Effect[Assert] =
     let first <- system_property(key)
     let overwritten <- set_system_property(key, "second")
     let second <- system_property(key)
+    let cleaned_up <- clear_system_property(key)
     assert_all([
         assert_that(missing).is_empty(),
         assert_that(previous).is_empty(),
         assert_that(first).contains("first"),
         assert_that(overwritten).contains("first"),
         assert_that(second).contains("second"),
+        assert_that(cleaned_up).contains("second"),
     ])
 
 fun set_system_property_empty_name_returns_none(): Effect[Assert] =


### PR DESCRIPTION
## Summary

- exclude the standalone `capybara-lib` artifact from the isolated compiler runtime classpath
- keep the normal compiler compile-time dependency unchanged
- clean up system-property test state and assert the cleanup result in unit and e2e coverage

## Root cause

The in-process compiler runtime loaded both `capy-0.8.1.jar` and `capybara-lib-0.8.1.jar`. Both artifacts contain `capy.lang.Result`, but with incompatible bytecode shapes. Depending on classpath ordering, the JVM resolved `Result` and `Result.Success` from incompatible implementations and rejected `dev.capylang.cli.Capy` with inconsistent stack-map frames.

The clean Windows verification also exposed test state leaking between system-property tests when two monotonic clock reads returned the same value. Cleaning up the key removes that clock-resolution dependency.

## Validation

- `./gradlew :lib:capybara-lib:linkCapybaraLinkedOnly --stacktrace --no-daemon`
- `./gradlew :lib:capybara-lib:testCapybaraPython --no-daemon`
- `./gradlew check --no-daemon`
- `git diff --check`

Fixes #357
