### PR TITLE
chore(#360): document standard library API

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/collection/CollectionTypes.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/CollectionTypes.cfun
@@ -2,6 +2,13 @@ from /capy/lang/Primitives import { * }
 from /capy/lang/Result import { * }
 
 /// Zero-based collection position.
+///
+/// Example:
+/// ```cfun
+/// let first = FIRST_ELEMENT
+/// let second <- first.next()
+/// second == 1
+/// ```
 type index -> int with constructor {
     if value >= 0
     then Success { value }
@@ -15,67 +22,106 @@ type size -> int with constructor {
     else Error { kind: "capy.lang.number.out_of_range", message: "size must be greater than or equal to 0" }
 }
 
+/// Index of the first element in a collection.
 const FIRST_ELEMENT: index = index! { 0 }
+
+/// Size of an empty collection.
 const EMPTY: size = size! { 0 }
 
+/// Converts this index to a collection size with the same numeric value.
 fun index.to_size(): size = size! { this.value }
+
+/// Converts this size to an index with the same numeric value.
 fun size.to_index(): index = index! { this.value }
 
+/// Returns the next index, or an error when incrementing would overflow.
 fun index.next(): Result[index] =
     if this.value == MAX_INT_VALUE
     then Error { kind: "capy.lang.index.out_of_bounds", message: "index increment overflow" }
     else Success { index! { this.value + 1 } }
 
+/// Adds a non-negative size to this index, returning an error on overflow.
 fun index.plus(offset: size): Result[index] =
     if this.value > MAX_INT_VALUE - offset.value
     then Error { kind: "capy.lang.index.out_of_bounds", message: "index addition overflow" }
     else Success { index! { this.value + offset.value } }
 
+/// Adds a non-negative integer to this index, returning an error for negative values or overflow.
 fun index.plus(offset: int): Result[index] =
     let parsed_offset <- size { offset }
     this.plus(parsed_offset)
 
+/// Operator form of `index.plus(offset)` for a size offset.
 fun index.`+`(offset: size): Result[index] = this.plus(offset)
+/// Operator form of `index.plus(offset)` for an integer offset.
 fun index.`+`(offset: int): Result[index] = this.plus(offset)
 
+/// Returns whether this index is greater than `other`.
 fun index.`>`(other: index): bool = this.value > other.value
+/// Returns whether this index is greater than the integer `other`.
 fun index.`>`(other: int): bool = this.value > other
+/// Returns whether this index is greater than or equal to `other`.
 fun index.`>=`(other: index): bool = this.value >= other.value
+/// Returns whether this index is greater than or equal to the integer `other`.
 fun index.`>=`(other: int): bool = this.value >= other
+/// Returns whether this index is less than `other`.
 fun index.`<`(other: index): bool = this.value < other.value
+/// Returns whether this index is less than the integer `other`.
 fun index.`<`(other: int): bool = this.value < other
+/// Returns whether this index is less than or equal to `other`.
 fun index.`<=`(other: index): bool = this.value <= other.value
+/// Returns whether this index is less than or equal to the integer `other`.
 fun index.`<=`(other: int): bool = this.value <= other
+/// Returns whether this index has the same value as `other`.
 fun index.`==`(other: index): bool = this.value == other.value
+/// Returns whether this index has the same value as the integer `other`.
 fun index.`==`(other: int): bool = this.value == other
 
+/// Adds two sizes, returning an error on overflow.
 fun size.plus(other: size): Result[size] =
     if this.value > MAX_INT_VALUE - other.value
     then Error { kind: "capy.lang.number.out_of_range", message: "size addition overflow" }
     else Success { size! { this.value + other.value } }
 
+/// Adds a non-negative integer to this size, returning an error for negative values or overflow.
 fun size.plus(other: int): Result[size] =
     let parsed_other <- size { other }
     this.plus(parsed_other)
 
+/// Operator form of `size.plus(other)` for another size.
 fun size.`+`(other: size): Result[size] = this.plus(other)
+/// Operator form of `size.plus(other)` for an integer.
 fun size.`+`(other: int): Result[size] = this.plus(other)
 
+/// Subtracts another size, returning an error when the result would be negative.
 fun size.minus(other: size): Result[size] =
     size { this.value - other.value }
 
+/// Subtracts an integer, returning an error when the result would be negative.
 fun size.minus(other: int): Result[size] =
     size { this.value - other }
 
+/// Operator form of `size.minus(other)` for another size.
 fun size.`-`(other: size): Result[size] = this.minus(other)
+/// Operator form of `size.minus(other)` for an integer.
 fun size.`-`(other: int): Result[size] = this.minus(other)
+/// Returns whether this size is greater than `other`.
 fun size.`>`(other: size): bool = this.value > other.value
+/// Returns whether this size is greater than the integer `other`.
 fun size.`>`(other: int): bool = this.value > other
+/// Returns whether this size is greater than or equal to `other`.
 fun size.`>=`(other: size): bool = this.value >= other.value
+/// Returns whether this size is greater than or equal to the integer `other`.
 fun size.`>=`(other: int): bool = this.value >= other
+/// Returns whether this size is less than `other`.
 fun size.`<`(other: size): bool = this.value < other.value
+/// Returns whether this size is less than the integer `other`.
 fun size.`<`(other: int): bool = this.value < other
+/// Returns whether this size is less than or equal to `other`.
 fun size.`<=`(other: size): bool = this.value <= other.value
+/// Returns whether this size is less than or equal to the integer `other`.
 fun size.`<=`(other: int): bool = this.value <= other
+/// Returns whether this size has the same value as `other`.
 fun size.`==`(other: size): bool = this.value == other.value
+/// Returns whether this size has the same value as the integer `other`.
 fun size.`==`(other: int): bool = this.value == other

--- a/lib/capybara-lib/src/main/capybara/capy/collection/Tuple.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/collection/Tuple.cfun
@@ -2,6 +2,12 @@ from /capy/collection/CollectionTypes import { * }
 
 /// Native fixed-size ordered collection type backed by the runtime Tuple implementation.
 /// Tuple literals use parentheses with at least two values: (1, "two").
+///
+/// Example:
+/// ```cfun
+/// let pair = ("answer", 42)
+/// pair[index! { 1 }] == 42
+/// ```
 data Tuple { <native> }
 
 /// Returns the value at idx using the same literal-index rules as tuple[idx].

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Date.cfun
@@ -10,25 +10,44 @@ type month -> int with constructor {
     else Error { message: "month must be between 1 and 12" }
 }
 
+/// January, represented by month number 1.
 const JANUARY: month = month! { 1 }
+/// February, represented by month number 2.
 const FEBRUARY: month = month! { 2 }
+/// March, represented by month number 3.
 const MARCH: month = month! { 3 }
+/// April, represented by month number 4.
 const APRIL: month = month! { 4 }
+/// May, represented by month number 5.
 const MAY: month = month! { 5 }
+/// June, represented by month number 6.
 const JUNE: month = month! { 6 }
+/// July, represented by month number 7.
 const JULY: month = month! { 7 }
+/// August, represented by month number 8.
 const AUGUST: month = month! { 8 }
+/// September, represented by month number 9.
 const SEPTEMBER: month = month! { 9 }
+/// October, represented by month number 10.
 const OCTOBER: month = month! { 10 }
+/// November, represented by month number 11.
 const NOVEMBER: month = month! { 11 }
+/// December, represented by month number 12.
 const DECEMBER: month = month! { 12 }
 
+/// Returns whether this month is later in the year than `other`.
 fun month.`>`(other: month): bool = this.value > other.value
+/// Returns whether this month is the same as or later in the year than `other`.
 fun month.`>=`(other: month): bool = this.value >= other.value
+/// Returns whether this month is earlier in the year than `other`.
 fun month.`<`(other: month): bool = this.value < other.value
+/// Returns whether this month is the same as or earlier in the year than `other`.
 fun month.`<=`(other: month): bool = this.value <= other.value
+/// Returns whether this month has the same month number as `other`.
 fun month.`==`(other: month): bool = this.value == other.value
+/// Returns the following month, wrapping December to January.
 fun month.next(): month = if this == DECEMBER then JANUARY else month! { this.value + 1 }
+/// Returns the preceding month, wrapping January to December.
 fun month.previous(): month = if this == JANUARY then DECEMBER else month! { this.value - 1 }
 
 /// Checks whether a year is a leap year in the Gregorian calendar.
@@ -71,6 +90,7 @@ data Date {
     else Success {* { day, month, year }}
 }
 
+/// Unix epoch date, 1970-01-01.
 const UNIX_DATE: Date = Date! { day: 1, month: JANUARY, year: 1970 }
 
 /// Returns `true` when this date is in a leap year.

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Duration.cfun
@@ -58,6 +58,7 @@ data DateDuration {
 /// ```
 data WeekDuration { weeks: int }
 
+/// Duration with every component set to zero.
 const ZERO: Duration = DateDuration { years: 0, months: 0, days: 0, hours: 0, minutes: 0, seconds: 0 }
 
 /// Formats this duration as a canonical ISO 8601 string.

--- a/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/date_time/Time.cfun
@@ -3,12 +3,19 @@ from /capy/lang/Option import { * }
 from /capy/lang/String import { * }
 from /capy/meta_prog/Recursive import { Recursive }
 
+/// Number of hours in a day.
 const HOURS_IN_DAY: int = 24
+/// Number of minutes in an hour.
 const MINUTES_IN_HOUR: int = 60
+/// Number of seconds in a minute.
 const SECONDS_IN_MINUTE: int = 60
+/// Number of seconds in an hour.
 const SECONDS_IN_HOUR: int = MINUTES_IN_HOUR * SECONDS_IN_MINUTE
+/// Number of minutes in a day.
 const MINUTES_IN_DAY: int = HOURS_IN_DAY * MINUTES_IN_HOUR
+/// Number of seconds in a day.
 const SECONDS_IN_DAY: int = HOURS_IN_DAY * SECONDS_IN_HOUR
+/// Largest supported absolute UTC offset, in minutes.
 const MAX_OFFSET_MINUTES: int = 23 * MINUTES_IN_HOUR + 59
 
 /// Hour of day in 24-hour clock, in the range 0..23.
@@ -39,27 +46,46 @@ type offset_minutes -> int with constructor {
     else Error { message: "offset minutes must be between -1439 and 1439" }
 }
 
+/// Start-of-day hour value.
 const ZERO_HOUR: hour = hour! { 0 }
+/// Noon hour value.
 const NOON_HOUR: hour = hour! { 12 }
+/// Start-of-hour minute value.
 const ZERO_MINUTE: minute = minute! { 0 }
+/// Start-of-minute second value.
 const ZERO_SECOND: second = second! { 0 }
 
+/// Returns whether this hour is greater than `other`.
 fun hour.`>`(other: hour): bool = this.value > other.value
+/// Returns whether this hour is greater than or equal to `other`.
 fun hour.`>=`(other: hour): bool = this.value >= other.value
+/// Returns whether this hour is less than `other`.
 fun hour.`<`(other: hour): bool = this.value < other.value
+/// Returns whether this hour is less than or equal to `other`.
 fun hour.`<=`(other: hour): bool = this.value <= other.value
+/// Returns whether this hour has the same value as `other`.
 fun hour.`==`(other: hour): bool = this.value == other.value
 
+/// Returns whether this minute is greater than `other`.
 fun minute.`>`(other: minute): bool = this.value > other.value
+/// Returns whether this minute is greater than or equal to `other`.
 fun minute.`>=`(other: minute): bool = this.value >= other.value
+/// Returns whether this minute is less than `other`.
 fun minute.`<`(other: minute): bool = this.value < other.value
+/// Returns whether this minute is less than or equal to `other`.
 fun minute.`<=`(other: minute): bool = this.value <= other.value
+/// Returns whether this minute has the same value as `other`.
 fun minute.`==`(other: minute): bool = this.value == other.value
 
+/// Returns whether this second is greater than `other`.
 fun second.`>`(other: second): bool = this.value > other.value
+/// Returns whether this second is greater than or equal to `other`.
 fun second.`>=`(other: second): bool = this.value >= other.value
+/// Returns whether this second is less than `other`.
 fun second.`<`(other: second): bool = this.value < other.value
+/// Returns whether this second is less than or equal to `other`.
 fun second.`<=`(other: second): bool = this.value <= other.value
+/// Returns whether this second has the same value as `other`.
 fun second.`==`(other: second): bool = this.value == other.value
 
 /// Clock time represented in 24-hour format.
@@ -81,7 +107,9 @@ data Time {
     offset_minutes: Option[offset_minutes]
 }
 
+/// Midnight without a UTC offset.
 const MIDNIGHT: Time = Time { hour: ZERO_HOUR, minute: ZERO_MINUTE, second: ZERO_SECOND, offset_minutes: None {} }
+/// Noon without a UTC offset.
 const NOON: Time = Time { hour: NOON_HOUR, minute: ZERO_MINUTE, second: ZERO_SECOND, offset_minutes: None {} }
 
 /// Converts this time to seconds since midnight.

--- a/lib/capybara-lib/src/main/capybara/capy/io/ByteSize.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/io/ByteSize.cfun
@@ -1,8 +1,11 @@
 from /capy/lang/Primitives import { * }
 from /capy/lang/Result import { * }
 
+/// Number of bytes in one kibibyte.
 const BYTES_IN_KIB: double = 1024.0
+/// Number of bytes in one mebibyte.
 const BYTES_IN_MIB: double = 1048576.0
+/// Number of bytes in one gibibyte.
 const BYTES_IN_GIB: double = 1073741824.0
 
 /// Non-negative number of bytes.
@@ -12,9 +15,13 @@ type byte_count -> long with constructor {
     else Error { kind: "capy.lang.number.out_of_range", message: "byte_count must be greater than or equal to 0" }
 }
 
+/// Byte count representing zero bytes.
 const ZERO_BYTES: byte_count = byte_count! { 0L }
+/// Byte count representing one kibibyte.
 const ONE_KIB: byte_count = byte_count! { 1024L }
+/// Byte count representing one mebibyte.
 const ONE_MIB: byte_count = byte_count! { 1048576L }
+/// Byte count representing one gibibyte.
 const ONE_GIB: byte_count = byte_count! { 1073741824L }
 
 /// Adds two byte counts, returning `Error` on long overflow.
@@ -29,6 +36,7 @@ fun byte_count.plus(other: byte_count): Result[byte_count] =
     then Error { kind: "capy.lang.number.out_of_range", message: "byte_count addition overflow" }
     else Success { byte_count! { this.value + other.value } }
 
+/// Operator form of `byte_count.plus(other)`.
 fun byte_count.`+`(other: byte_count): Result[byte_count] = this.plus(other)
 
 /// Subtracts `other` from this byte count.
@@ -37,6 +45,7 @@ fun byte_count.`+`(other: byte_count): Result[byte_count] = this.plus(other)
 fun byte_count.minus(other: byte_count): Result[byte_count] =
     byte_count { this.value - other.value }
 
+/// Operator form of `byte_count.minus(other)`.
 fun byte_count.`-`(other: byte_count): Result[byte_count] = this.minus(other)
 
 /// Converts this byte count to kibibytes.
@@ -53,10 +62,15 @@ fun byte_count.to_mib(): double =
 fun byte_count.to_gib(): double =
     this.value / BYTES_IN_GIB
 
+/// Returns whether this byte count is greater than `other`.
 fun byte_count.`>`(other: byte_count): bool = this.value > other.value
+/// Returns whether this byte count is greater than or equal to `other`.
 fun byte_count.`>=`(other: byte_count): bool = this.value >= other.value
+/// Returns whether this byte count is less than `other`.
 fun byte_count.`<`(other: byte_count): bool = this.value < other.value
+/// Returns whether this byte count is less than or equal to `other`.
 fun byte_count.`<=`(other: byte_count): bool = this.value <= other.value
+/// Returns whether this byte count has the same value as `other`.
 fun byte_count.`==`(other: byte_count): bool = this.value == other.value
 
 /// Function form of `left + right`.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Async.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Async.cfun
@@ -4,6 +4,13 @@ from /capy/lang/Result import { Result }
 /// Handle for an Effect that has been started by the host runtime.
 ///
 /// Async values are inert handles. Observing completion is an Effect.
+///
+/// Example:
+/// ```cfun
+/// let task = compute(() => 21).map(value => value * 2)
+/// let result <- task.join()
+/// result
+/// ```
 data Async[T] { <native> }
 
 /// Starts a deferred computation on the host runtime's asynchronous execution facility.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/BoundedNumber.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/BoundedNumber.cfun
@@ -1,6 +1,12 @@
 from /capy/lang/Result import { * }
 
 /// Fractional value between zero and one.
+///
+/// Example:
+/// ```cfun
+/// let half = ratio! { 0.5 }
+/// half.to_percentage() == percentage! { 50.0 }
+/// ```
 type ratio -> double with constructor {
     if value >= 0.0 & value <= 1.0
     then Success { value }
@@ -21,47 +27,76 @@ type probability -> double with constructor {
     else Error { kind: "capy.lang.number.out_of_range", message: "probability must be between 0.0 and 1.0" }
 }
 
+/// Ratio representing zero.
 const ZERO_RATIO: ratio = ratio! { 0.0 }
+/// Ratio representing one whole.
 const WHOLE_RATIO: ratio = ratio! { 1.0 }
+/// Percentage representing zero percent.
 const ZERO_PERCENTAGE: percentage = percentage! { 0.0 }
+/// Percentage representing one hundred percent.
 const FULL_PERCENTAGE: percentage = percentage! { 100.0 }
+/// Probability representing an impossible event.
 const IMPOSSIBLE_PROBABILITY: probability = probability! { 0.0 }
+/// Probability representing a certain event.
 const CERTAIN_PROBABILITY: probability = probability! { 1.0 }
 
+/// Converts this ratio to a percentage.
 fun ratio.to_percentage(): percentage =
     percentage! { this.value * 100.0 }
 
+/// Converts this ratio to a probability with the same value.
 fun ratio.to_probability(): probability =
     probability! { this.value }
 
+/// Converts this percentage to a ratio.
 fun percentage.to_ratio(): ratio =
     ratio! { this.value / 100.0 }
 
+/// Converts this probability to a ratio with the same value.
 fun probability.to_ratio(): ratio =
     ratio! { this.value }
 
+/// Returns whether this ratio is greater than `other`.
 fun ratio.`>`(other: ratio): bool = this.value > other.value
+/// Returns whether this ratio is greater than or equal to `other`.
 fun ratio.`>=`(other: ratio): bool = this.value >= other.value
+/// Returns whether this ratio is less than `other`.
 fun ratio.`<`(other: ratio): bool = this.value < other.value
+/// Returns whether this ratio is less than or equal to `other`.
 fun ratio.`<=`(other: ratio): bool = this.value <= other.value
+/// Returns whether this ratio has the same value as `other`.
 fun ratio.`==`(other: ratio): bool = this.value == other.value
 
+/// Returns whether this percentage is greater than `other`.
 fun percentage.`>`(other: percentage): bool = this.value > other.value
+/// Returns whether this percentage is greater than or equal to `other`.
 fun percentage.`>=`(other: percentage): bool = this.value >= other.value
+/// Returns whether this percentage is less than `other`.
 fun percentage.`<`(other: percentage): bool = this.value < other.value
+/// Returns whether this percentage is less than or equal to `other`.
 fun percentage.`<=`(other: percentage): bool = this.value <= other.value
+/// Returns whether this percentage has the same value as `other`.
 fun percentage.`==`(other: percentage): bool = this.value == other.value
 
+/// Returns whether this probability is greater than `other`.
 fun probability.`>`(other: probability): bool = this.value > other.value
+/// Returns whether this probability is greater than or equal to `other`.
 fun probability.`>=`(other: probability): bool = this.value >= other.value
+/// Returns whether this probability is less than `other`.
 fun probability.`<`(other: probability): bool = this.value < other.value
+/// Returns whether this probability is less than or equal to `other`.
 fun probability.`<=`(other: probability): bool = this.value <= other.value
+/// Returns whether this probability has the same value as `other`.
 fun probability.`==`(other: probability): bool = this.value == other.value
 
+/// Function form of `value.to_percentage()`.
 fun ratio_to_percentage(value: ratio): percentage = value.to_percentage()
 
+/// Function form of `value.to_probability()`.
 fun ratio_to_probability(value: ratio): probability = value.to_probability()
 
+/// Function form of `value.to_ratio()` for a percentage.
 fun percentage_to_ratio(value: percentage): ratio = value.to_ratio()
 
+/// Function form of `value.to_ratio()` for a probability.
 fun probability_to_ratio(value: probability): ratio = value.to_ratio()

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Either.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Either.cfun
@@ -4,6 +4,12 @@ from /capy/lang/Result import { * }
 ///
 /// `Left` is commonly used for the alternate or error branch, and `Right` for
 /// the primary success branch.
+///
+/// Example:
+/// ```cfun
+/// let value: Either[String, int] = Right { value: 21 }
+/// value.map_right(number => number * 2) == Right { value: 42 }
+/// ```
 union Either[L, R] = Left[L, R] | Right[L, R]
 
 /// The left branch of `Either`.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Math.cfun
@@ -1,6 +1,9 @@
 from /capy/lang/Option import { * }
 from /capy/meta_prog/Recursive import { Recursive }
 
+/// Returns the number of decimal digits in an integer, excluding its sign.
+///
+/// Example: `digits(-123)` returns `3`.
 fun digits(number: int): int =
     @Recursive
     fun digits(number: int, acc: int): int =
@@ -13,8 +16,14 @@ fun digits(number: int): int =
     then 10
     else digits(abs(number), 1)
 
+/// Returns the absolute value of a long integer.
+///
+/// Example: `abs(-42L)` returns `42L`.
 fun abs(number: long): long = if number < 0 then -number else number
 
+/// Returns the absolute value of an integer.
+///
+/// Example: `abs(-42)` returns `42`.
 fun abs(number: int): int = if number < 0 then -number else number
 
 /// Floor division for integers.
@@ -123,6 +132,7 @@ fun max(values: List[long]): Option[long] =
     case None -> None {}
     case Some { v } -> Some { max(v, values[1:]) }
 
+/// Rounding policy used by `round` when converting a double to a long.
 enum RoundMode { FLOOR, CEILING, HALF_UP, HALF_DOWN, HALF_EVEN }
 
 /// Rounds `value` to a `long` using the selected `RoundMode`.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Ordering.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Ordering.cfun
@@ -1,4 +1,10 @@
 /// The result of comparing two values.
+///
+/// Example:
+/// ```cfun
+/// from_int(-10) == LESS
+/// reverse(LESS) == GREATER
+/// ```
 enum Ordering { LESS, EQUAL, GREATER }
 
 /// Converts a negative, zero, or positive integer comparison result to

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Primitives.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Primitives.cfun
@@ -1,9 +1,13 @@
 from /capy/lang/Result import { * }
 
+/// Largest value representable by `int`.
 const MAX_INT_VALUE: int = 2147483647
+/// Smallest value representable by `int`.
 const MIN_INT_VALUE: int = -2147483648
 
+/// Largest value representable by `long`.
 const MAX_LONG_VALUE: long = 9223372036854775807L
+/// Smallest value representable by `long`.
 const MIN_LONG_VALUE: long = -9223372036854775808L
 
 /// Number of distinct mantissa steps used to map random long values into `float`.
@@ -19,6 +23,8 @@ const FLOAT_BOUND_AS_FLOAT: float = 16777216.0f
 const DOUBLE_BOUND_AS_DOUBLE: double = 9007199254740992.0
 
 /// Parses this String as an int.
+///
+/// Example: `to_int("42")` returns `Success { value: 42 }`.
 fun to_int(s: String): Result[int] = <native>
 
 /// Parses this String as a long.
@@ -33,6 +39,7 @@ fun to_float(s: String): Result[float] = <native>
 /// Parses this String as a bool.
 fun to_bool(s: String): Result[bool] = <native>
 
+/// Clamps a long to the inclusive int range.
 fun clamp_long_to_int(value: long): int =
     if value > MAX_INT_VALUE
     then MAX_INT_VALUE
@@ -40,6 +47,7 @@ fun clamp_long_to_int(value: long): int =
     then MIN_INT_VALUE
     else value.to_int()
 
+/// Converts a long to int, returning an error when it is outside the int range.
 fun safe_long_to_int(value: long): Result[int] =
     if value > MAX_INT_VALUE
     then Error { kind: "capy.lang.number.out_of_range", message: "long value `{value}` is greater than max int value" }

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Program.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Program.cfun
@@ -1,4 +1,9 @@
 /// Process result returned by an executable Capybara `main` function.
+///
+/// Example:
+/// ```cfun
+/// fun main(): Program = Success {}
+/// ```
 union Program = Success | Failed
 
 /// Successful program completion with exit code `0`.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Random.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Random.cfun
@@ -6,6 +6,13 @@ from /capy/collection/Seq import { * }
 fun seed(): seed = <native>
 
 /// Immutable random generator state.
+///
+/// Example:
+/// ```cfun
+/// let first = seed { 123L }.random_int()
+/// let second = first.seed.random_int()
+/// second.value
+/// ```
 type seed -> long
 
 /// Random value paired with the seed to use for the next random step.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
@@ -6,6 +6,12 @@ from /capy/lang/Option import { * }
 /// Expected, recoverable failures should be represented in return types as
 /// `Result[T]` or `Effect[Result[T]]` instead of Java-style checked
 /// exceptions.
+///
+/// Example:
+/// ```cfun
+/// let result: Result[int] = Success { value: 21 }
+/// result.map(value => value * 2) == Success { value: 42 }
+/// ```
 union Result[T] = Success[T] | Error
 
 /// Successful Result value.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/String.cfun
@@ -10,6 +10,11 @@ from /capy/meta_prog/Recursive import { Recursive }
 
 /// Native String type backed by the runtime String implementation.
 /// String literals use quotes: "hello".
+///
+/// Example:
+/// ```cfun
+/// "Capybara".to_lower_case() == "capybara"
+/// ```
 data String { <native> }
 
 /// Returns the number of characters in this String.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/System.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/System.cfun
@@ -4,6 +4,12 @@ from /capy/lang/Option import { Option }
 /// Returns an effect that reads the current system time in milliseconds since the Unix epoch.
 ///
 /// The value is captured when the effect is run.
+///
+/// Example:
+/// ```cfun
+/// let timestamp <- current_millis()
+/// timestamp
+/// ```
 fun current_millis(): Effect[long] = <native>
 
 /// Returns an effect that reads the current monotonic JVM time in nanoseconds.

--- a/lib/capybara-lib/src/main/capybara/capy/lang/TimeUnit.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/TimeUnit.cfun
@@ -1,4 +1,12 @@
 /// Time duration measured in nanoseconds.
+///
+/// Example:
+/// ```cfun
+/// second { 2L }.to_milli_seconds() == milli_second { 2000L }
+/// milli_second { 1500L }.to_seconds() == second { 1L }
+/// ```
+///
+/// Conversions to a coarser unit use integer division and discard the remainder.
 type nano_second -> long
 
 /// Time duration measured in microseconds.
@@ -39,74 +47,138 @@ private const MINUTES_PER_DAY: long = MINUTES_PER_HOUR * HOURS_PER_DAY
 private const MINUTES_PER_WEEK: long = MINUTES_PER_DAY * DAYS_PER_WEEK
 private const HOURS_PER_WEEK: long = HOURS_PER_DAY * DAYS_PER_WEEK
 
+/// Returns this nanosecond value unchanged.
 fun nano_second.to_nano_seconds(): nano_second = this
+/// Converts this microsecond value to nanoseconds.
 fun micro_second.to_nano_seconds(): nano_second = nano_second { this.value * NANO_SECONDS_PER_MICRO_SECOND }
+/// Converts this millisecond value to nanoseconds.
 fun milli_second.to_nano_seconds(): nano_second = nano_second { this.value * NANO_SECONDS_PER_MILLI_SECOND }
+/// Converts this second value to nanoseconds.
 fun second.to_nano_seconds(): nano_second = nano_second { this.value * NANO_SECONDS_PER_SECOND }
+/// Converts this minute value to nanoseconds.
 fun minute.to_nano_seconds(): nano_second = nano_second { this.value * SECONDS_PER_MINUTE * NANO_SECONDS_PER_SECOND }
+/// Converts this hour value to nanoseconds.
 fun hour.to_nano_seconds(): nano_second = nano_second { this.value * SECONDS_PER_HOUR * NANO_SECONDS_PER_SECOND }
+/// Converts this day value to nanoseconds.
 fun day.to_nano_seconds(): nano_second = nano_second { this.value * SECONDS_PER_DAY * NANO_SECONDS_PER_SECOND }
+/// Converts this week value to nanoseconds.
 fun week.to_nano_seconds(): nano_second = nano_second { this.value * SECONDS_PER_WEEK * NANO_SECONDS_PER_SECOND }
 
+/// Converts this nanosecond value to microseconds, discarding any remainder.
 fun nano_second.to_micro_seconds(): micro_second = micro_second { this.value / NANO_SECONDS_PER_MICRO_SECOND }
+/// Returns this microsecond value unchanged.
 fun micro_second.to_micro_seconds(): micro_second = this
+/// Converts this millisecond value to microseconds.
 fun milli_second.to_micro_seconds(): micro_second = micro_second { this.value * MICRO_SECONDS_PER_MILLI_SECOND }
+/// Converts this second value to microseconds.
 fun second.to_micro_seconds(): micro_second = micro_second { this.value * MICRO_SECONDS_PER_SECOND }
+/// Converts this minute value to microseconds.
 fun minute.to_micro_seconds(): micro_second = micro_second { this.value * SECONDS_PER_MINUTE * MICRO_SECONDS_PER_SECOND }
+/// Converts this hour value to microseconds.
 fun hour.to_micro_seconds(): micro_second = micro_second { this.value * SECONDS_PER_HOUR * MICRO_SECONDS_PER_SECOND }
+/// Converts this day value to microseconds.
 fun day.to_micro_seconds(): micro_second = micro_second { this.value * SECONDS_PER_DAY * MICRO_SECONDS_PER_SECOND }
+/// Converts this week value to microseconds.
 fun week.to_micro_seconds(): micro_second = micro_second { this.value * SECONDS_PER_WEEK * MICRO_SECONDS_PER_SECOND }
 
+/// Converts this nanosecond value to milliseconds, discarding any remainder.
 fun nano_second.to_milli_seconds(): milli_second = milli_second { this.value / NANO_SECONDS_PER_MILLI_SECOND }
+/// Converts this microsecond value to milliseconds, discarding any remainder.
 fun micro_second.to_milli_seconds(): milli_second = milli_second { this.value / MICRO_SECONDS_PER_MILLI_SECOND }
+/// Returns this millisecond value unchanged.
 fun milli_second.to_milli_seconds(): milli_second = this
+/// Converts this second value to milliseconds.
 fun second.to_milli_seconds(): milli_second = milli_second { this.value * MILLI_SECONDS_PER_SECOND }
+/// Converts this minute value to milliseconds.
 fun minute.to_milli_seconds(): milli_second = milli_second { this.value * SECONDS_PER_MINUTE * MILLI_SECONDS_PER_SECOND }
+/// Converts this hour value to milliseconds.
 fun hour.to_milli_seconds(): milli_second = milli_second { this.value * SECONDS_PER_HOUR * MILLI_SECONDS_PER_SECOND }
+/// Converts this day value to milliseconds.
 fun day.to_milli_seconds(): milli_second = milli_second { this.value * SECONDS_PER_DAY * MILLI_SECONDS_PER_SECOND }
+/// Converts this week value to milliseconds.
 fun week.to_milli_seconds(): milli_second = milli_second { this.value * SECONDS_PER_WEEK * MILLI_SECONDS_PER_SECOND }
 
+/// Converts this nanosecond value to seconds, discarding any remainder.
 fun nano_second.to_seconds(): second = second { this.value / NANO_SECONDS_PER_SECOND }
+/// Converts this microsecond value to seconds, discarding any remainder.
 fun micro_second.to_seconds(): second = second { this.value / MICRO_SECONDS_PER_SECOND }
+/// Converts this millisecond value to seconds, discarding any remainder.
 fun milli_second.to_seconds(): second = second { this.value / MILLI_SECONDS_PER_SECOND }
+/// Returns this second value unchanged.
 fun second.to_seconds(): second = this
+/// Converts this minute value to seconds.
 fun minute.to_seconds(): second = second { this.value * SECONDS_PER_MINUTE }
+/// Converts this hour value to seconds.
 fun hour.to_seconds(): second = second { this.value * SECONDS_PER_HOUR }
+/// Converts this day value to seconds.
 fun day.to_seconds(): second = second { this.value * SECONDS_PER_DAY }
+/// Converts this week value to seconds.
 fun week.to_seconds(): second = second { this.value * SECONDS_PER_WEEK }
 
+/// Converts this nanosecond value to minutes, discarding any remainder.
 fun nano_second.to_minutes(): minute = minute { this.value / (SECONDS_PER_MINUTE * NANO_SECONDS_PER_SECOND) }
+/// Converts this microsecond value to minutes, discarding any remainder.
 fun micro_second.to_minutes(): minute = minute { this.value / (SECONDS_PER_MINUTE * MICRO_SECONDS_PER_SECOND) }
+/// Converts this millisecond value to minutes, discarding any remainder.
 fun milli_second.to_minutes(): minute = minute { this.value / (SECONDS_PER_MINUTE * MILLI_SECONDS_PER_SECOND) }
+/// Converts this second value to minutes, discarding any remainder.
 fun second.to_minutes(): minute = minute { this.value / SECONDS_PER_MINUTE }
+/// Returns this minute value unchanged.
 fun minute.to_minutes(): minute = this
+/// Converts this hour value to minutes.
 fun hour.to_minutes(): minute = minute { this.value * MINUTES_PER_HOUR }
+/// Converts this day value to minutes.
 fun day.to_minutes(): minute = minute { this.value * MINUTES_PER_DAY }
+/// Converts this week value to minutes.
 fun week.to_minutes(): minute = minute { this.value * MINUTES_PER_WEEK }
 
+/// Converts this nanosecond value to hours, discarding any remainder.
 fun nano_second.to_hours(): hour = hour { this.value / (SECONDS_PER_HOUR * NANO_SECONDS_PER_SECOND) }
+/// Converts this microsecond value to hours, discarding any remainder.
 fun micro_second.to_hours(): hour = hour { this.value / (SECONDS_PER_HOUR * MICRO_SECONDS_PER_SECOND) }
+/// Converts this millisecond value to hours, discarding any remainder.
 fun milli_second.to_hours(): hour = hour { this.value / (SECONDS_PER_HOUR * MILLI_SECONDS_PER_SECOND) }
+/// Converts this second value to hours, discarding any remainder.
 fun second.to_hours(): hour = hour { this.value / SECONDS_PER_HOUR }
+/// Converts this minute value to hours, discarding any remainder.
 fun minute.to_hours(): hour = hour { this.value / MINUTES_PER_HOUR }
+/// Returns this hour value unchanged.
 fun hour.to_hours(): hour = this
+/// Converts this day value to hours.
 fun day.to_hours(): hour = hour { this.value * HOURS_PER_DAY }
+/// Converts this week value to hours.
 fun week.to_hours(): hour = hour { this.value * HOURS_PER_WEEK }
 
+/// Converts this nanosecond value to days, discarding any remainder.
 fun nano_second.to_days(): day = day { this.value / (SECONDS_PER_DAY * NANO_SECONDS_PER_SECOND) }
+/// Converts this microsecond value to days, discarding any remainder.
 fun micro_second.to_days(): day = day { this.value / (SECONDS_PER_DAY * MICRO_SECONDS_PER_SECOND) }
+/// Converts this millisecond value to days, discarding any remainder.
 fun milli_second.to_days(): day = day { this.value / (SECONDS_PER_DAY * MILLI_SECONDS_PER_SECOND) }
+/// Converts this second value to days, discarding any remainder.
 fun second.to_days(): day = day { this.value / SECONDS_PER_DAY }
+/// Converts this minute value to days, discarding any remainder.
 fun minute.to_days(): day = day { this.value / MINUTES_PER_DAY }
+/// Converts this hour value to days, discarding any remainder.
 fun hour.to_days(): day = day { this.value / HOURS_PER_DAY }
+/// Returns this day value unchanged.
 fun day.to_days(): day = this
+/// Converts this week value to days.
 fun week.to_days(): day = day { this.value * DAYS_PER_WEEK }
 
+/// Converts this nanosecond value to weeks, discarding any remainder.
 fun nano_second.to_weeks(): week = week { this.value / (SECONDS_PER_WEEK * NANO_SECONDS_PER_SECOND) }
+/// Converts this microsecond value to weeks, discarding any remainder.
 fun micro_second.to_weeks(): week = week { this.value / (SECONDS_PER_WEEK * MICRO_SECONDS_PER_SECOND) }
+/// Converts this millisecond value to weeks, discarding any remainder.
 fun milli_second.to_weeks(): week = week { this.value / (SECONDS_PER_WEEK * MILLI_SECONDS_PER_SECOND) }
+/// Converts this second value to weeks, discarding any remainder.
 fun second.to_weeks(): week = week { this.value / SECONDS_PER_WEEK }
+/// Converts this minute value to weeks, discarding any remainder.
 fun minute.to_weeks(): week = week { this.value / MINUTES_PER_WEEK }
+/// Converts this hour value to weeks, discarding any remainder.
 fun hour.to_weeks(): week = week { this.value / HOURS_PER_WEEK }
+/// Converts this day value to weeks, discarding any remainder.
 fun day.to_weeks(): week = week { this.value / DAYS_PER_WEEK }
+/// Returns this week value unchanged.
 fun week.to_weeks(): week = this

--- a/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/serialization/Json.cfun
@@ -72,13 +72,17 @@ data JsonString { value: String }
 /// Integers and longs use `JsonNumberLong`; fractional values use
 /// `JsonNumberDouble`.
 union JsonNumber = JsonNumberDouble | JsonNumberLong
+/// JSON number represented as a double-precision value.
 data JsonNumberDouble { value: double }
+/// JSON number represented as a long integer value.
 data JsonNumberLong { value: long }
 /// JSON object value wrapper.
 data JsonValueObject { value: JsonObject }
+/// Returns the JSON value stored under `key`, or `None` when the key is absent.
 fun JsonValueObject.get(key: String): Option[Json] = this.value.get(key)
 /// JSON array value wrapper.
 data JsonValueArray { value: JsonArray }
+/// Returns the JSON value at `idx`, or `None` when the index is out of bounds.
 fun JsonValueArray.get(idx: index): Option[Json] = this.value.get(idx)
 /// JSON boolean value.
 data JsonBool { value: bool }

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -43,23 +43,41 @@ fun Assert.failed(): bool = (this.assertions | supplier => supplier().result).an
 fun Assert.succeeded(): bool = !this.failed()
 
 private data TechnicalAssert { assertions: List[() => Assertion] }
+/// Chainable assertions for a string value.
 data StringAssert { value: String }
+/// Chainable assertions for an int value.
 data IntAssert { value: int }
+/// Chainable assertions for a long value.
 data LongAssert { value: long }
+/// Chainable assertions for a double value.
 data DoubleAssert { value: double }
+/// Chainable assertions for a float value.
 data FloatAssert { value: float }
+/// Chainable assertions for a boolean value.
 data BoolAssert { value: bool }
+/// Chainable assertions for an arbitrary data value.
 data DataAssert { value: data }
+/// Chainable assertions for an optional value.
 data OptionAssert[T] { value: /capy/lang/Option[T] }
+/// Chainable assertions for a result value.
 data ResultAssert[T] { value: /capy/lang/Result[T] }
+/// Chainable assertions for a date value.
 data DateAssert { value: Date }
+/// Chainable assertions for a time value.
 data TimeAssert { value: Time }
+/// Chainable assertions for a date-time value.
 data DateTimeAssert { value: DateTime }
+/// Chainable assertions for a duration value.
 data DurationAssert { value: Duration }
+/// Chainable assertions for an interval value.
 data IntervalAssert { value: Interval }
+/// Chainable assertions for a list value.
 data ListAssert[T] { value: List[T] }
+/// Chainable assertions for a set value.
 data SetAssert[T] { value: Set[T] }
+/// Chainable assertions for a dictionary value.
 data DictAssert[T] { value: Dict[T] }
+/// Chainable assertions for a sequence value.
 data SeqAssert[T] { value: Seq[T] }
 
 /// Combines several assertion chains into one `Assert`.
@@ -102,6 +120,7 @@ fun StringAssert.starts_with(other: String): StringAssert =
        assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the string does not start with `other`.
 fun StringAssert.does_not_start_with(other: String): StringAssert =
     let assertion = Assertion {
        result: this.value.starts_with(other) != true,
@@ -137,6 +156,7 @@ fun IntAssert.is_equal_to(other: int): IntAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the int is greater than `other`.
 fun IntAssert.is_greater_than(other: int): IntAssert =
     let assertion = Assertion {
         result: this.value > other,
@@ -145,6 +165,7 @@ fun IntAssert.is_greater_than(other: int): IntAssert =
     }
     IntAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the int is less than `other`.
 fun IntAssert.is_less_than(other: int): IntAssert =
     let assertion = Assertion {
         result: this.value < other,
@@ -153,6 +174,7 @@ fun IntAssert.is_less_than(other: int): IntAssert =
     }
     IntAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the int is greater than or equal to `other`.
 fun IntAssert.is_greater_or_equals_than(other: int): IntAssert =
     let assertion = Assertion {
         result: this.value >= other,
@@ -161,6 +183,7 @@ fun IntAssert.is_greater_or_equals_than(other: int): IntAssert =
     }
     IntAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the int is less than or equal to `other`.
 fun IntAssert.is_less_or_equals_than(other: int): IntAssert =
     let assertion = Assertion {
         result: this.value <= other,
@@ -169,12 +192,15 @@ fun IntAssert.is_less_or_equals_than(other: int): IntAssert =
     }
     IntAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the int is zero.
 fun IntAssert.is_zero(): IntAssert = this.is_equal_to(0)
+/// Adds an assertion that the int is one.
 fun IntAssert.is_one(): IntAssert = this.is_equal_to(1)
 /// Adds assertions that the int is between `start` and `end`, inclusive.
 fun IntAssert.is_between(start: int, end: int): IntAssert =
     this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
+/// Adds a long equality assertion to the chain.
 fun LongAssert.is_equal_to(other: long): LongAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -186,6 +212,7 @@ fun LongAssert.is_equal_to(other: long): LongAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the long is greater than `other`.
 fun LongAssert.is_greater_than(other: long): LongAssert =
     let assertion = Assertion {
         result: this.value > other,
@@ -194,6 +221,7 @@ fun LongAssert.is_greater_than(other: long): LongAssert =
     }
     LongAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the long is less than `other`.
 fun LongAssert.is_less_than(other: long): LongAssert =
     let assertion = Assertion {
         result: this.value < other,
@@ -202,6 +230,7 @@ fun LongAssert.is_less_than(other: long): LongAssert =
     }
     LongAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the long is greater than or equal to `other`.
 fun LongAssert.is_greater_or_equals_than(other: long): LongAssert =
     let assertion = Assertion {
         result: this.value >= other,
@@ -210,6 +239,7 @@ fun LongAssert.is_greater_or_equals_than(other: long): LongAssert =
     }
     LongAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the long is less than or equal to `other`.
 fun LongAssert.is_less_or_equals_than(other: long): LongAssert =
     let assertion = Assertion {
         result: this.value <= other,
@@ -218,11 +248,15 @@ fun LongAssert.is_less_or_equals_than(other: long): LongAssert =
     }
     LongAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the long is zero.
 fun LongAssert.is_zero(): LongAssert = this.is_equal_to(0L)
+/// Adds an assertion that the long is one.
 fun LongAssert.is_one(): LongAssert = this.is_equal_to(1L)
+/// Adds assertions that the long is between `start` and `end`, inclusive.
 fun LongAssert.is_between(start: long, end: long): LongAssert =
     this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
+/// Adds a double equality assertion to the chain.
 fun DoubleAssert.is_equal_to(other: double): DoubleAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -234,6 +268,7 @@ fun DoubleAssert.is_equal_to(other: double): DoubleAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an approximate double equality assertion using `epsilon` as the tolerance.
 fun DoubleAssert.is_equal_to(other: double, epsilon: double): DoubleAssert =
     let assertion = Assertion {
         result: if this.value >= other - epsilon then this.value <= other + epsilon else false,
@@ -245,6 +280,7 @@ fun DoubleAssert.is_equal_to(other: double, epsilon: double): DoubleAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the double is greater than `other`.
 fun DoubleAssert.is_greater_than(other: double): DoubleAssert =
     let assertion = Assertion {
         result: this.value > other,
@@ -253,6 +289,7 @@ fun DoubleAssert.is_greater_than(other: double): DoubleAssert =
     }
     DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the double is less than `other`.
 fun DoubleAssert.is_less_than(other: double): DoubleAssert =
     let assertion = Assertion {
         result: this.value < other,
@@ -261,6 +298,7 @@ fun DoubleAssert.is_less_than(other: double): DoubleAssert =
     }
     DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the double is greater than or equal to `other`.
 fun DoubleAssert.is_greater_or_equals_than(other: double): DoubleAssert =
     let assertion = Assertion {
         result: this.value >= other,
@@ -269,6 +307,7 @@ fun DoubleAssert.is_greater_or_equals_than(other: double): DoubleAssert =
     }
     DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the double is less than or equal to `other`.
 fun DoubleAssert.is_less_or_equals_than(other: double): DoubleAssert =
     let assertion = Assertion {
         result: this.value <= other,
@@ -277,11 +316,15 @@ fun DoubleAssert.is_less_or_equals_than(other: double): DoubleAssert =
     }
     DoubleAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the double is zero.
 fun DoubleAssert.is_zero(): DoubleAssert = this.is_equal_to(0.0)
+/// Adds an assertion that the double is one.
 fun DoubleAssert.is_one(): DoubleAssert = this.is_equal_to(1.0)
+/// Adds assertions that the double is between `start` and `end`, inclusive.
 fun DoubleAssert.is_between(start: double, end: double): DoubleAssert =
     this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
+/// Adds a float equality assertion to the chain.
 fun FloatAssert.is_equal_to(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -293,6 +336,7 @@ fun FloatAssert.is_equal_to(other: float): FloatAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an approximate float equality assertion using `epsilon` as the tolerance.
 fun FloatAssert.is_equal_to(other: float, epsilon: float): FloatAssert =
     let assertion = Assertion {
         result: if this.value >= other - epsilon then this.value <= other + epsilon else false,
@@ -304,6 +348,7 @@ fun FloatAssert.is_equal_to(other: float, epsilon: float): FloatAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the float is greater than `other`.
 fun FloatAssert.is_greater_than(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value > other,
@@ -312,6 +357,7 @@ fun FloatAssert.is_greater_than(other: float): FloatAssert =
     }
     FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the float is less than `other`.
 fun FloatAssert.is_less_than(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value < other,
@@ -320,6 +366,7 @@ fun FloatAssert.is_less_than(other: float): FloatAssert =
     }
     FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the float is greater than or equal to `other`.
 fun FloatAssert.is_greater_or_equals_than(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value >= other,
@@ -328,6 +375,7 @@ fun FloatAssert.is_greater_or_equals_than(other: float): FloatAssert =
     }
     FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the float is less than or equal to `other`.
 fun FloatAssert.is_less_or_equals_than(other: float): FloatAssert =
     let assertion = Assertion {
         result: this.value <= other,
@@ -336,6 +384,7 @@ fun FloatAssert.is_less_or_equals_than(other: float): FloatAssert =
     }
     FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the float is zero.
 fun FloatAssert.is_zero(): FloatAssert =
     let assertion = Assertion {
         result: this.value == 0,
@@ -344,6 +393,7 @@ fun FloatAssert.is_zero(): FloatAssert =
     }
     FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
 
+/// Adds an assertion that the float is one.
 fun FloatAssert.is_one(): FloatAssert =
     let assertion = Assertion {
         result: this.value == 1,
@@ -351,9 +401,11 @@ fun FloatAssert.is_one(): FloatAssert =
         type: 'FloatAssert.is_one'
     }
     FloatAssert { value: this.value, assertions: this.assertions + () => assertion }
+/// Adds assertions that the float is between `start` and `end`, inclusive.
 fun FloatAssert.is_between(start: float, end: float): FloatAssert =
     this.is_greater_or_equals_than(start).is_less_or_equals_than(end)
 
+/// Adds a boolean equality assertion to the chain.
 fun BoolAssert.is_equal_to(other: bool): BoolAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -389,6 +441,7 @@ fun BoolAssert.is_false(): BoolAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a structural equality assertion for a data value.
 fun DataAssert.is_equal_to(other: data): DataAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -400,6 +453,7 @@ fun DataAssert.is_equal_to(other: data): DataAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that at least one field of the data value equals `other`.
 fun DataAssert.contains(other: any): DataAssert =
     let assertion = Assertion {
         result: ('' + this.value) ? ('' + other),
@@ -411,6 +465,7 @@ fun DataAssert.contains(other: any): DataAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an equality assertion for an optional value.
 fun OptionAssert[T].is_equal_to(other: /capy/lang/Option[T]): OptionAssert[T] =
     let assertion = Assertion {
         result: this.value == other,
@@ -450,6 +505,7 @@ fun OptionAssert[T].is_empty(): OptionAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an equality assertion for a result value.
 fun ResultAssert[T].is_equal_to(other: /capy/lang/Result[T]): ResultAssert[T] =
     let assertion = Assertion {
         result: this.value == other,
@@ -623,6 +679,7 @@ fun ResultAssert[T].fails(assert: Error => Assert): ResultAssert[T] =
         assertions: this.assertions + assertions
     }
 
+/// Adds a date equality assertion to the chain.
 fun DateAssert.is_equal_to(other: Date): DateAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -634,9 +691,11 @@ fun DateAssert.is_equal_to(other: Date): DateAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a date equality assertion using numeric date components.
 fun DateAssert.is_equal_to(day: int, month: int, year: int): DateAssert =
     this.has_day(day).has_month(month).has_year(year)
 
+/// Adds an assertion that the date has day `other`.
 fun DateAssert.has_day(other: int): DateAssert =
     let assertion = Assertion {
         result: this.value.day == other,
@@ -648,6 +707,7 @@ fun DateAssert.has_day(other: int): DateAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date has month number `other`.
 fun DateAssert.has_month(other: int): DateAssert =
     let assertion = Assertion {
         result: this.value.month.value == other,
@@ -659,6 +719,7 @@ fun DateAssert.has_month(other: int): DateAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date has year `other`.
 fun DateAssert.has_year(other: int): DateAssert =
     let assertion = Assertion {
         result: this.value.year == other,
@@ -670,6 +731,7 @@ fun DateAssert.has_year(other: int): DateAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a time equality assertion to the chain.
 fun TimeAssert.is_equal_to(other: Time): TimeAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -681,9 +743,11 @@ fun TimeAssert.is_equal_to(other: Time): TimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a local-time equality assertion using numeric clock components.
 fun TimeAssert.is_equal_to(hour: int, minute: int, second: int): TimeAssert =
     this.has_hour(hour).has_minute(minute).has_second(second)
 
+/// Adds an assertion that the time has hour `other`.
 fun TimeAssert.has_hour(other: int): TimeAssert =
     let assertion = Assertion {
         result: this.value.hour.value == other,
@@ -695,6 +759,7 @@ fun TimeAssert.has_hour(other: int): TimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the time has minute `other`.
 fun TimeAssert.has_minute(other: int): TimeAssert =
     let assertion = Assertion {
         result: this.value.minute.value == other,
@@ -706,6 +771,7 @@ fun TimeAssert.has_minute(other: int): TimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the time has second `other`.
 fun TimeAssert.has_second(other: int): TimeAssert =
     let assertion = Assertion {
         result: this.value.second.value == other,
@@ -717,6 +783,7 @@ fun TimeAssert.has_second(other: int): TimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion for the optional UTC offset in minutes.
 fun TimeAssert.has_offset_minutes(other: /capy/lang/Option[offset_minutes]): TimeAssert =
     let assertion = Assertion {
         result: this.value.offset_minutes == other,
@@ -728,6 +795,7 @@ fun TimeAssert.has_offset_minutes(other: /capy/lang/Option[offset_minutes]): Tim
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion for a present UTC offset with the given number of minutes.
 fun TimeAssert.has_offset_minutes(other: int): TimeAssert =
     match offset_minutes { other } with
     case Success { parsed } -> this.has_offset_minutes(/capy/lang/Option.Some { parsed })
@@ -742,6 +810,7 @@ fun TimeAssert.has_offset_minutes(other: int): TimeAssert =
             assertions: this.assertions + () => assertion
         }
 
+/// Adds a date-time equality assertion to the chain.
 fun DateTimeAssert.is_equal_to(other: DateTime): DateTimeAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -753,6 +822,7 @@ fun DateTimeAssert.is_equal_to(other: DateTime): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time has date `other`.
 fun DateTimeAssert.has_date(other: Date): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.date == other,
@@ -764,9 +834,11 @@ fun DateTimeAssert.has_date(other: Date): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a date-component assertion using numeric values.
 fun DateTimeAssert.has_date(day: int, month: int, year: int): DateTimeAssert =
     this.has_day(day).has_month(month).has_year(year)
 
+/// Adds an assertion that the date-time has time `other`.
 fun DateTimeAssert.has_time(other: Time): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.time == other,
@@ -778,9 +850,11 @@ fun DateTimeAssert.has_time(other: Time): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a time-component assertion using numeric values.
 fun DateTimeAssert.has_time(hour: int, minute: int, second: int): DateTimeAssert =
     this.has_hour(hour).has_minute(minute).has_second(second)
 
+/// Adds an assertion that the date-time has year `other`.
 fun DateTimeAssert.has_year(other: int): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.date.year == other,
@@ -792,6 +866,7 @@ fun DateTimeAssert.has_year(other: int): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time has month number `other`.
 fun DateTimeAssert.has_month(other: int): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.date.month.value == other,
@@ -803,6 +878,7 @@ fun DateTimeAssert.has_month(other: int): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time has day `other`.
 fun DateTimeAssert.has_day(other: int): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.date.day == other,
@@ -814,6 +890,7 @@ fun DateTimeAssert.has_day(other: int): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time has hour `other`.
 fun DateTimeAssert.has_hour(other: int): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.time.hour.value == other,
@@ -825,6 +902,7 @@ fun DateTimeAssert.has_hour(other: int): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time has minute `other`.
 fun DateTimeAssert.has_minute(other: int): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.time.minute.value == other,
@@ -836,6 +914,7 @@ fun DateTimeAssert.has_minute(other: int): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time has second `other`.
 fun DateTimeAssert.has_second(other: int): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.time.second.value == other,
@@ -847,6 +926,7 @@ fun DateTimeAssert.has_second(other: int): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time is later than `other`.
 fun DateTimeAssert.is_greater_than(other: DateTime): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.greater_than(other),
@@ -858,6 +938,7 @@ fun DateTimeAssert.is_greater_than(other: DateTime): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the date-time is earlier than `other`.
 fun DateTimeAssert.is_less_than(other: DateTime): DateTimeAssert =
     let assertion = Assertion {
         result: this.value.less_than(other),
@@ -869,6 +950,7 @@ fun DateTimeAssert.is_less_than(other: DateTime): DateTimeAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a duration equality assertion to the chain.
 fun DurationAssert.is_equal_to(other: Duration): DurationAssert =
     let assertion = Assertion {
         result: this.value == other,
@@ -880,6 +962,7 @@ fun DurationAssert.is_equal_to(other: Duration): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` years.
 fun DurationAssert.has_years(other: int): DurationAssert =
     let assertion = Assertion {
         result: this.value.years() == other,
@@ -891,6 +974,7 @@ fun DurationAssert.has_years(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` months.
 fun DurationAssert.has_months(other: int): DurationAssert =
     let assertion = Assertion {
         result: this.value.months() == other,
@@ -902,6 +986,7 @@ fun DurationAssert.has_months(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` days.
 fun DurationAssert.has_days(other: int): DurationAssert =
     let assertion = Assertion {
         result: this.value.days() == other,
@@ -913,6 +998,7 @@ fun DurationAssert.has_days(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` hours.
 fun DurationAssert.has_hours(other: int): DurationAssert =
     let assertion = Assertion {
         result: this.value.hours() == other,
@@ -924,6 +1010,7 @@ fun DurationAssert.has_hours(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` minutes.
 fun DurationAssert.has_minutes(other: int): DurationAssert =
     let assertion = Assertion {
         result: this.value.minutes() == other,
@@ -935,6 +1022,7 @@ fun DurationAssert.has_minutes(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` seconds.
 fun DurationAssert.has_seconds(other: int): DurationAssert =
     let assertion = Assertion {
         result: this.value.seconds() == other,
@@ -946,6 +1034,7 @@ fun DurationAssert.has_seconds(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the duration has `other` weeks.
 fun DurationAssert.has_weeks(other: int): DurationAssert =
     let assertion = Assertion {
         result: match this.value with
@@ -959,6 +1048,7 @@ fun DurationAssert.has_weeks(other: int): DurationAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an interval equality assertion to the chain.
 fun IntervalAssert.is_equal_to(other: Interval): IntervalAssert =
     let assertion = Assertion {
         result: this.value.to_iso_8601() == other.to_iso_8601(),
@@ -970,6 +1060,7 @@ fun IntervalAssert.is_equal_to(other: Interval): IntervalAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the interval starts at `other`.
 fun IntervalAssert.has_start(other: DateTime): IntervalAssert =
     let assertion = Assertion {
         result: this.value.start() == other,
@@ -981,6 +1072,7 @@ fun IntervalAssert.has_start(other: DateTime): IntervalAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the interval ends at `other`.
 fun IntervalAssert.has_end(other: DateTime): IntervalAssert =
     let assertion = Assertion {
         result: this.value.end() == other,
@@ -992,6 +1084,7 @@ fun IntervalAssert.has_end(other: DateTime): IntervalAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the interval has duration `other`.
 fun IntervalAssert.has_duration(other: Duration): IntervalAssert =
     let assertion = Assertion {
         result: this.value.duration() == other,
@@ -1003,6 +1096,7 @@ fun IntervalAssert.has_duration(other: Duration): IntervalAssert =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a list equality assertion to the chain.
 fun ListAssert[T].is_equal_to(other: List[T]): ListAssert[T] =
     let assertion = Assertion {
         result: this.value == other,
@@ -1026,6 +1120,7 @@ fun ListAssert[T].has_size(other: int): ListAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the list is empty.
 fun ListAssert[T].is_empty(): ListAssert[T] =
     let assertion = Assertion {
         result: this.value.size() == 0,
@@ -1049,6 +1144,7 @@ fun ListAssert[T].contains(other: T): ListAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the list does not contain `other`.
 fun ListAssert[T].does_not_contain(other: T): ListAssert[T] =
     let assertion = Assertion {
         result: this.value.any(v => v == other) == false,
@@ -1060,6 +1156,7 @@ fun ListAssert[T].does_not_contain(other: T): ListAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a set equality assertion to the chain.
 fun SetAssert[T].is_equal_to(other: Set[T]): SetAssert[T] =
     let assertion = Assertion {
         result: this.value == other,
@@ -1071,6 +1168,7 @@ fun SetAssert[T].is_equal_to(other: Set[T]): SetAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the set has size `other`.
 fun SetAssert[T].has_size(other: int): SetAssert[T] =
     let assertion = Assertion {
         result: this.value.size() == other,
@@ -1082,6 +1180,7 @@ fun SetAssert[T].has_size(other: int): SetAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the set is empty.
 fun SetAssert[T].is_empty(): SetAssert[T] =
     let assertion = Assertion {
         result: this.value.size() == 0,
@@ -1093,6 +1192,7 @@ fun SetAssert[T].is_empty(): SetAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the set contains `other`.
 fun SetAssert[T].contains(other: T): SetAssert[T] =
     let assertion = Assertion {
         result: this.value.any(v => v == other),
@@ -1104,6 +1204,7 @@ fun SetAssert[T].contains(other: T): SetAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the set does not contain `other`.
 fun SetAssert[T].does_not_contain(other: T): SetAssert[T] =
     let assertion = Assertion {
         result: this.value.any(v => v == other) == false,
@@ -1115,6 +1216,7 @@ fun SetAssert[T].does_not_contain(other: T): SetAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a dictionary equality assertion to the chain.
 fun DictAssert[T].is_equal_to(other: Dict[T]): DictAssert[T] =
     let assertion = Assertion {
         result: this.value == other,
@@ -1126,6 +1228,7 @@ fun DictAssert[T].is_equal_to(other: Dict[T]): DictAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the dictionary has size `other`.
 fun DictAssert[T].has_size(other: int): DictAssert[T] =
     let assertion = Assertion {
         result: this.value.size() == other,
@@ -1137,6 +1240,7 @@ fun DictAssert[T].has_size(other: int): DictAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the dictionary is empty.
 fun DictAssert[T].is_empty(): DictAssert[T] =
     let assertion = Assertion {
         result: this.value.size() == 0,
@@ -1160,6 +1264,7 @@ fun DictAssert[T].contains_key(other: String): DictAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the dictionary does not contain key `other`.
 fun DictAssert[T].does_not_contain_key(other: String): DictAssert[T] =
     let assertion = Assertion {
         result: this.value.any((k, v) => k == other) == false,
@@ -1171,6 +1276,7 @@ fun DictAssert[T].does_not_contain_key(other: String): DictAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the dictionary contains value `other`.
 fun DictAssert[T].contains_value(other: T): DictAssert[T] =
     let assertion = Assertion {
         result: this.value.any((k, v) => v == other),
@@ -1182,6 +1288,7 @@ fun DictAssert[T].contains_value(other: T): DictAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds a sequence equality assertion to the chain.
 fun SeqAssert[T].is_equal_to(other: Seq[T]): SeqAssert[T] =
     let assertion = Assertion {
         result: this.value.as_list() == other.as_list(),
@@ -1193,6 +1300,7 @@ fun SeqAssert[T].is_equal_to(other: Seq[T]): SeqAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the sequence has size `other`.
 fun SeqAssert[T].has_size(other: int): SeqAssert[T] =
     let assertion = Assertion {
         result: this.value.as_list().size() == other,
@@ -1204,6 +1312,7 @@ fun SeqAssert[T].has_size(other: int): SeqAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the sequence is empty.
 fun SeqAssert[T].is_empty(): SeqAssert[T] =
     let assertion = Assertion {
         result: this.value.as_list().size() == 0,
@@ -1215,6 +1324,7 @@ fun SeqAssert[T].is_empty(): SeqAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the sequence contains `other`.
 fun SeqAssert[T].contains(other: T): SeqAssert[T] =
     let assertion = Assertion {
         result: this.value.as_list().any(v => v == other),
@@ -1226,6 +1336,7 @@ fun SeqAssert[T].contains(other: T): SeqAssert[T] =
         assertions: this.assertions + () => assertion
     }
 
+/// Adds an assertion that the sequence does not contain `other`.
 fun SeqAssert[T].does_not_contain(other: T): SeqAssert[T] =
     let assertion = Assertion {
         result: this.value.as_list().any(v => v == other) == false,
@@ -1244,23 +1355,35 @@ fun SeqAssert[T].does_not_contain(other: T): SeqAssert[T] =
 /// assert_that("capybara").starts_with("capy").contains("bara")
 /// ```
 fun assert_that(value: String) = StringAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a collection size.
 fun assert_that(value: size) = IntAssert { value: value.value, assertions: [] }
 /// Starts an int assertion chain.
 fun assert_that(value: int) = IntAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a long value.
 fun assert_that(value: long) = LongAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a double value.
 fun assert_that(value: double) = DoubleAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a float value.
 fun assert_that(value: float) = FloatAssert { value: value, assertions: [] }
 /// Starts a bool assertion chain.
 fun assert_that(value: bool) = BoolAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a date value.
 fun assert_that(value: Date) = DateAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a time value.
 fun assert_that(value: Time) = TimeAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a date-time value.
 fun assert_that(value: DateTime) = DateTimeAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a duration value.
 fun assert_that(value: Duration) = DurationAssert { value: value, assertions: [] }
+/// Starts an assertion chain for an interval value.
 fun assert_that(value: Interval) = IntervalAssert { value: value, assertions: [] }
 /// Starts a list assertion chain.
 fun assert_that(value: List[T]): ListAssert[T] = ListAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a set value.
 fun assert_that(value: Set[T]): SetAssert[T] = SetAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a dictionary value.
 fun assert_that(value: Dict[T]): DictAssert[T] = DictAssert { value: value, assertions: [] }
+/// Starts an assertion chain for a sequence value.
 fun assert_that(value: Seq[T]): SeqAssert[T] = SeqAssert { value: value, assertions: [] }
 /// Starts an option assertion chain.
 fun assert_that(value: Option[T]) = OptionAssert { value: value, assertions: [] }

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -183,7 +183,10 @@ data JUnitTestSuite {
 /// file        (not implemented) Source code file of this test case
 /// line        (not implemented) Source code line number of the start of this test case
 data JUnitTestCase { name: String, classname: String, assertions: int, failure: /capy/lang/Option[JUnitFailure] }
+/// Failure details parsed from a JUnit XML report.
 data JUnitFailure { message: String, jtype: String, call_stack: String }
+
+/// Appends text to this failure message while preserving its type and call stack.
 fun JUnitFailure.`+`(other_message: String): JUnitFailure =
     JUnitFailure {
         message: this.message + '\n' + other_message,
@@ -341,8 +344,10 @@ private fun async_test_output_results(results: List[Result[Result[Path]]]): Resu
                 case Error e -> e
                 case Success { written_paths } -> Success { [written_path] + written_paths }
 
+/// File used to track test-run output artifacts for cleanup.
 const OUTPUT_MANIFEST_FILE = '.capy-test-output-manifest'
 
+/// Formats a human-readable summary of failed test files.
 fun failure_summary(test_files: List[TestFile]): String =
     let failures = (test_files | test_file => failure_summary_file(test_file)).as_list()
         |> '', (acc, failure) => acc + failure
@@ -365,6 +370,7 @@ private fun failure_summary_message(test_case: TestCase): String =
     case Passed -> ''
     case Failed { message, type } -> normalize_failure_message(message)
 
+/// Normalizes line endings and indentation in a captured failure message.
 fun normalize_failure_message(message: String): String =
     message
         .replace('\\r\\n', '\n')
@@ -416,6 +422,7 @@ private fun print_test_finished(log_type: LogType, test_name: String): Effect[St
     case LOG -> println("Test finished: {test_name}")
     case TEAM_CITY -> println("##teamcity[testFinished name='{team_city_escape(test_name)}']")
 
+/// Builds console log lines for the supplied test files and their test cases.
 fun test_log_lines(test_files: List[TestFile]): List[String] =
     let initial: List[String] = []
     test_files |> initial, (acc, test_file) => acc + test_log_lines_file(test_file)
@@ -440,6 +447,7 @@ private fun test_log_lines_case(test_case: TestCase): List[String] =
         finished
     ]
 
+/// Builds TeamCity service messages for the supplied test results.
 fun team_city_messages(test_files: List[TestFile]): List[String] =
     let initial: List[String] = []
     test_files |> initial, (acc, test_file) => acc + team_city_messages_file(test_file)
@@ -464,6 +472,7 @@ private fun team_city_messages_case(test_case: TestCase): List[String] =
         finished
     ]
 
+/// Escapes text for inclusion in a TeamCity service-message attribute.
 fun team_city_escape(value: String): String =
     @Recursive
     fun team_city_escape(value: String, acc: String): String =
@@ -653,9 +662,13 @@ private fun path_segments_to_string(segments: List[String]): String =
 
 private fun has_failures(test_outputs: List[TestOutput]): bool = test_outputs.any(output => output.failed)
 
+/// Prefix used for generated JUnit XML report files.
 const JUNIT_PREFIX = 'TEST-'
+/// Default filename for the generated CTRF report.
 const CTRF_REPORT_FILE = 'ctrf-report.json'
+/// Default filename for the generated Jest-compatible report.
 const JEST_REPORT_FILE = 'jest-report.json'
+/// CTRF specification version emitted by this reporter.
 const CTRF_SPEC_VERSION = '0.0.0'
 
 private fun junit_run_tests(test_files: List[TestFile]): List[TestOutput] = (test_files | :junit_run_test).as_list()
@@ -711,6 +724,7 @@ private fun ctrf_run_tests(test_files: List[TestFile]): List[TestOutput] = [
     }
 ]
 
+/// Serializes test results as a Common Test Report Format JSON document.
 fun ctrf_report(test_files: List[TestFile]): String =
     let start = ctrf_start_millis(test_files)
     let duration = ctrf_total_duration_millis(test_files)
@@ -830,6 +844,7 @@ private fun jest_run_tests(test_files: List[TestFile]): List[TestOutput] = [
     }
 ]
 
+/// Serializes test results as a Jest-compatible JSON report.
 fun jest_report(test_files: List[TestFile]): String =
     let failed_count = ctrf_failed_count(test_files)
     "{"

--- a/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/util/SemVer.cfun
@@ -25,22 +25,37 @@ type patch -> int with constructor {
     else Error { message: "patch must be greater than or equal to 0" }
 }
 
+/// Returns whether this major component is greater than `other`.
 fun major.`>`(other: major): bool = this.value > other.value
+/// Returns whether this major component is greater than or equal to `other`.
 fun major.`>=`(other: major): bool = this.value >= other.value
+/// Returns whether this major component is less than `other`.
 fun major.`<`(other: major): bool = this.value < other.value
+/// Returns whether this major component is less than or equal to `other`.
 fun major.`<=`(other: major): bool = this.value <= other.value
+/// Returns whether this major component has the same value as `other`.
 fun major.`==`(other: major): bool = this.value == other.value
 
+/// Returns whether this minor component is greater than `other`.
 fun minor.`>`(other: minor): bool = this.value > other.value
+/// Returns whether this minor component is greater than or equal to `other`.
 fun minor.`>=`(other: minor): bool = this.value >= other.value
+/// Returns whether this minor component is less than `other`.
 fun minor.`<`(other: minor): bool = this.value < other.value
+/// Returns whether this minor component is less than or equal to `other`.
 fun minor.`<=`(other: minor): bool = this.value <= other.value
+/// Returns whether this minor component has the same value as `other`.
 fun minor.`==`(other: minor): bool = this.value == other.value
 
+/// Returns whether this patch component is greater than `other`.
 fun patch.`>`(other: patch): bool = this.value > other.value
+/// Returns whether this patch component is greater than or equal to `other`.
 fun patch.`>=`(other: patch): bool = this.value >= other.value
+/// Returns whether this patch component is less than `other`.
 fun patch.`<`(other: patch): bool = this.value < other.value
+/// Returns whether this patch component is less than or equal to `other`.
 fun patch.`<=`(other: patch): bool = this.value <= other.value
+/// Returns whether this patch component has the same value as `other`.
 fun patch.`==`(other: patch): bool = this.value == other.value
 
 /// Given a version number MAJOR.MINOR.PATCH, increment the:
@@ -51,6 +66,12 @@ fun patch.`==`(other: patch): bool = this.value == other.value
 ///
 /// Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 /// Full specification: https://semver.org/
+///
+/// Example:
+/// ```cfun
+/// let version <- sem_ver(1, 2, 3, None {}, Some { "build.7" })
+/// version.to_string() == "1.2.3+build.7"
+/// ```
 data SemVer {
     major: major,
     minor: minor,


### PR DESCRIPTION
## Summary

- add Capy Docs to every previously undocumented public standard-library declaration
- document functions, constants, data types, unions, enums, operators, and assertion helpers across 22 modules
- add examples to every public standard-library module, including the reported `Math.abs` overloads

## Why

Generated Capy Docs contained empty API sections because many public declarations had no `///` documentation. This left standard-library users without descriptions or examples for APIs such as `Math.abs`.

## Impact

All generated public API sections now contain documentation, and every public module includes at least one example.

## Validation

- generated the standard-library AsciiDoc with the Capy CLI successfully
- audited 1,005 generated public API sections: 0 blank sections
- audited public modules: 0 modules without examples
- audited source declarations: 1,005 public declarations, 0 undocumented
- `git diff --check`

Closes #360
