### PR TITLE
chore(#363): split branch and full checks

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -1,9 +1,11 @@
-name: Build & Check
+name: Branch Build & Check
 
 on:
   push:
     branches:
-      - "master"
+      - "**"
+      - "!master"
+      - "!merge-back/**"
     paths:
       - ".github/workflows/**"
       - "build-tool/**"
@@ -15,19 +17,6 @@ on:
       - "gradle.properties"
       - "gradlew"
       - "gradlew.bat"
-  pull_request:
-    paths:
-      - ".github/workflows/**"
-      - "build-tool/**"
-      - "buildSrc/**"
-      - "capy/**"
-      - "gradle/**"
-      - "lib/**"
-      - "settings.gradle"
-      - "gradle.properties"
-      - "gradlew"
-      - "gradlew.bat"
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -54,14 +43,14 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Run Gradle check
-        run: ./gradlew clean check --no-daemon
+      - name: Run basic Gradle tests
+        run: ./gradlew clean test --no-daemon
 
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-check-test-reports
+          name: branch-build-check-test-reports
           path: |
             **/build/reports/tests/**
             **/build/test-results/**/*.xml

--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "**"
       - "!master"
+      - "!release/**"
       - "!merge-back/**"
     paths:
       - ".github/workflows/**"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "release/**"
     paths:
       - ".github/workflows/**"
       - "build-tool/**"


### PR DESCRIPTION
## Summary

- add a branch-only Build & Check workflow that runs `clean test`
- keep the existing full `clean check` workflow for `master`, pull requests, and manual dispatches
- continue excluding merge-back branches from branch-push checks

## Why

Branch pushes currently run the full integration check even before a pull request is opened. Splitting the triggers gives branches faster basic feedback while preserving the full validation gate on pull requests and the default branch.

Closes #363.

## Validation

- both workflow files parsed successfully as YAML
- `git diff --check`
- `./gradlew.bat test --no-daemon --console=plain --max-workers=2` remained active but exceeded the 10-minute local validation window
- `./gradlew.bat :capy:test --no-daemon --console=plain --max-workers=2` remained active but exceeded the 5-minute local validation window
