### PR TITLE
chore(#363): compile branch builds only

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -44,16 +44,5 @@ jobs:
       - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Run basic Gradle tests
-        run: ./gradlew clean test --no-daemon
-
-      - name: Upload test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: branch-build-check-test-reports
-          path: |
-            **/build/reports/tests/**
-            **/build/test-results/**/*.xml
-          if-no-files-found: ignore
-          retention-days: 5
+      - name: Compile
+        run: ./gradlew clean compileJava --no-daemon


### PR DESCRIPTION
## Summary

- compile branch pushes with `clean compileJava` instead of running the test suite
- remove the branch-only test report upload because branch builds no longer run tests
- leave the full `clean check` workflow for pull requests and `master` unchanged

## Why

The simple branch check still takes too long because it runs the test suite on every branch push. Full validation continues to run for pull requests and `master`.

## Validation

- `git diff --check`
- `gradlew.bat clean compileJava --no-daemon` attempted locally; Gradle setup and compilation exceeded the four-minute execution limit without reporting a compilation failure
