### PR TITLE
feat(#372): add digit type

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/lang/Primitives.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Primitives.cfun
@@ -22,6 +22,42 @@ const FLOAT_BOUND_AS_FLOAT: float = 16777216.0f
 /// Floating-point representation of `DOUBLE_BOUND`.
 const DOUBLE_BOUND_AS_DOUBLE: double = 9007199254740992.0
 
+/// Decimal digit between zero and nine.
+type digit -> int with constructor {
+    if value >= 0 & value <= 9
+    then Success { value }
+    else Error { kind: "capy.lang.number.out_of_range", message: "Digits must be between 0 and 9. Was `{value}`." }
+}
+
+/// Decimal digit zero.
+const ZERO_DIGIT: digit = digit! { 0 }
+/// Decimal digit one.
+const ONE_DIGIT: digit = digit! { 1 }
+/// Decimal digit two.
+const TWO_DIGIT: digit = digit! { 2 }
+/// Decimal digit three.
+const THREE_DIGIT: digit = digit! { 3 }
+/// Decimal digit four.
+const FOUR_DIGIT: digit = digit! { 4 }
+/// Decimal digit five.
+const FIVE_DIGIT: digit = digit! { 5 }
+/// Decimal digit six.
+const SIX_DIGIT: digit = digit! { 6 }
+/// Decimal digit seven.
+const SEVEN_DIGIT: digit = digit! { 7 }
+/// Decimal digit eight.
+const EIGHT_DIGIT: digit = digit! { 8 }
+/// Decimal digit nine.
+const NINE_DIGIT: digit = digit! { 9 }
+
+/// Returns the following digit, wrapping nine to zero.
+fun digit.next(): digit =
+    if this.value == 9 then ZERO_DIGIT else digit! { this.value + 1 }
+
+/// Returns the preceding digit, wrapping zero to nine.
+fun digit.previous(): digit =
+    if this.value == 0 then NINE_DIGIT else digit! { this.value - 1 }
+
 /// Parses this String as an int.
 ///
 /// Example: `to_int("42")` returns `Success { value: 42 }`.

--- a/lib/capybara-lib/src/test/capybara/capy/lang/PrimitivesTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/PrimitivesTest.cfun
@@ -13,6 +13,15 @@ fun tests(): Effect[TestFile] =
         test("DOUBLE_BOUND should match double precision bound", () => assert_that(DOUBLE_BOUND).is_equal_to(9007199254740992L)),
         test("FLOAT_BOUND_AS_FLOAT should match float precision bound", () => assert_that(FLOAT_BOUND_AS_FLOAT).is_equal_to(16777216.0f)),
         test("DOUBLE_BOUND_AS_DOUBLE should match double precision bound", () => assert_that(DOUBLE_BOUND_AS_DOUBLE).is_equal_to(9007199254740992.0)),
+        test("digit should accept zero", () => assert_that(digit { 0 }).succeeds(ZERO_DIGIT)),
+        test("digit should accept nine", () => assert_that(digit { 9 }).succeeds(NINE_DIGIT)),
+        test("digit should reject values below zero", () => assert_that(digit { -1 }).fails("Digits must be between 0 and 9. Was `-1`.")),
+        test("digit should reject values above nine", () => assert_that(digit { 10 }).fails("Digits must be between 0 and 9. Was `10`.")),
+        test("digit constants should represent zero through nine", () => should_define_digit_constants()),
+        test("digit.next should advance middle digits", () => assert_that(FOUR_DIGIT.next()).is_equal_to(FIVE_DIGIT)),
+        test("digit.next should wrap nine to zero", () => assert_that(NINE_DIGIT.next()).is_equal_to(ZERO_DIGIT)),
+        test("digit.previous should rewind middle digits", () => assert_that(FIVE_DIGIT.previous()).is_equal_to(FOUR_DIGIT)),
+        test("digit.previous should wrap zero to nine", () => assert_that(ZERO_DIGIT.previous()).is_equal_to(NINE_DIGIT)),
         test("to_int(\"123\") should succeed with 123", () => assert_that(to_int("123")).succeeds(123)),
         test("to_int(\"abc\") should fail", () => assert_that(to_int("abc")).fails("Cannot parse string to int: abc")),
         test("to_long(\"12345678901\") should succeed with 12345678901L", () => assert_that(to_long("12345678901")).succeeds(12345678901L)),
@@ -52,3 +61,17 @@ private fun should_safely_convert(value: long, expected: int): Assert =
 
 private fun should_fail_safe_conversion(value: long, expected_message: String): Assert =
     assert_that(safe_long_to_int(value)).fails(expected_message)
+
+private fun should_define_digit_constants(): Assert =
+    assert_all([
+        assert_that(ZERO_DIGIT.value).is_equal_to(0),
+        assert_that(ONE_DIGIT.value).is_equal_to(1),
+        assert_that(TWO_DIGIT.value).is_equal_to(2),
+        assert_that(THREE_DIGIT.value).is_equal_to(3),
+        assert_that(FOUR_DIGIT.value).is_equal_to(4),
+        assert_that(FIVE_DIGIT.value).is_equal_to(5),
+        assert_that(SIX_DIGIT.value).is_equal_to(6),
+        assert_that(SEVEN_DIGIT.value).is_equal_to(7),
+        assert_that(EIGHT_DIGIT.value).is_equal_to(8),
+        assert_that(NINE_DIGIT.value).is_equal_to(9),
+    ])


### PR DESCRIPTION
## Summary

- add a validated `digit` primitive-backed type for integer values from 0 through 9
- expose `ZERO_DIGIT` through `NINE_DIGIT`
- add wraparound `digit.next()` and `digit.previous()` methods
- cover constructor boundaries, constants, ordinary movement, and wraparound behavior

## Why

This provides a reusable decimal digit type whose range is enforced at construction time and whose navigation remains within that range.

Closes #372.

## Validation

- `git diff --check`
- compiled the edited module and an API consumer with the current Capybara compiler JAR
- compiled and ran a generated-Java harness covering construction, failures, constants, and wraparound behavior

The Gradle verification tasks were also attempted, but Gradle did not progress past task-graph configuration within the available timeout in this worktree.
