### PR TITLE
feat(#375): add AsciiDoc test reports

### DIFF
--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -151,9 +151,9 @@ fun TestCase.failed(): bool =
     case Failed -> true
 
 /// Report format emitted by the test runner.
-enum ReportType { JUNIT, CTRF, JEST }
+enum ReportType { JUNIT, CTRF, JEST, ADOC }
 /// Generated test report value.
-union Report = JUnitReport | CtrfReport | JestReport
+union Report = JUnitReport | CtrfReport | JestReport | AdocReport
 
 /// See: [Complete JUnit XML example](https://github.com/testmoapp/junitxml/blob/main/examples/junit-complete.xml)
 data JUnitReport { suites: List[JUnitTestSuite] }
@@ -198,6 +198,8 @@ fun JUnitFailure.`+`(other_message: String): JUnitFailure =
 data CtrfReport { report: String }
 /// Jest JSON report payload.
 data JestReport { report: String }
+/// AsciiDoc report payload.
+data AdocReport { report: String }
 
 /// One generated test report output.
 data TestOutput { path: Path, content: String, failed: bool }
@@ -233,6 +235,7 @@ fun run_tests(rtype: ReportType, test_files: List[TestFile]): List[TestOutput] =
     case JUNIT -> junit_run_tests(test_files)
     case CTRF -> ctrf_run_tests(test_files)
     case JEST -> jest_run_tests(test_files)
+    case ADOC -> adoc_run_tests(test_files)
 
 /// Runs test files, writes reports under `output_dir`, and returns the written
 /// output summary.
@@ -668,6 +671,8 @@ const JUNIT_PREFIX = 'TEST-'
 const CTRF_REPORT_FILE = 'ctrf-report.json'
 /// Default filename for the generated Jest-compatible report.
 const JEST_REPORT_FILE = 'jest-report.json'
+/// Prefix used for generated AsciiDoc report files.
+const ADOC_PREFIX = 'TEST-'
 /// CTRF specification version emitted by this reporter.
 const CTRF_SPEC_VERSION = '0.0.0'
 
@@ -916,3 +921,86 @@ private fun jest_failed_count(test_file: TestFile): int =
 
 private fun jest_duration_millis(test_file: TestFile): long =
     test_file.test_cases |> 0L, (acc, test_case) => acc + ctrf_duration_millis(test_case)
+
+private fun adoc_run_tests(test_files: List[TestFile]): List[TestOutput] =
+    (test_files | :adoc_run_test).as_list()
+
+private fun adoc_run_test(test_file: TestFile): TestOutput =
+    TestOutput {
+        path: from_string(ADOC_PREFIX + adoc_file_name(test_file.file_name) + '.adoc'),
+        content: adoc_report(test_file),
+        failed: adoc_failed_count(test_file) > 0
+    }
+
+private fun adoc_file_name(file_name: String): String =
+    let without_root = if file_name.starts_with('/') then file_name[1, file_name.size()] else file_name
+    let flattened = without_root.replace('/', '.')
+    if flattened.end_with('.cfun')
+    then flattened[0, flattened.size().value - 5]
+    else if flattened.end_with('.coo')
+    then flattened[0, flattened.size().value - 4]
+    else flattened
+
+/// Serializes one test file as a human-readable AsciiDoc report.
+fun adoc_report(test_file: TestFile): String =
+    let tests = test_file.test_cases.size()
+    let failures = adoc_failed_count(test_file)
+    let passed = tests.value - failures
+    let rows = test_file.test_cases |> '', (acc, test_case) => acc + adoc_test_row(test_case)
+    '= Test results: ' + adoc_inline(test_file.file_name) + '\n\n'
+    + '[cols="3,1,1,1",options="header"]\n'
+    + '|===\n'
+    + '|Test |Status |Assertions |Time (seconds)\n\n'
+    + rows
+    + '|===\n\n'
+    + '*Tests:* ' + tests + ' +\n'
+    + '*Passed:* ' + passed + ' +\n'
+    + '*Failed:* ' + failures + '\n'
+    + adoc_failures(test_file.test_cases)
+
+private fun adoc_test_row(test_case: TestCase): String =
+    '|' + adoc_table_cell(test_case.name) + '\n'
+    + '|' + (if adoc_test_case_failed(test_case) then 'FAIL' else 'PASS') + '\n'
+    + '|' + test_case.assertions_count + '\n'
+    + '|' + test_case.execution_time + '\n\n'
+
+private fun adoc_failures(test_cases: List[TestCase]): String =
+    let content = test_cases |> '', (acc, test_case) => acc + adoc_failure(test_case)
+    if content.is_empty()
+    then ''
+    else '\n== Failures\n\n' + content
+
+private fun adoc_failure(test_case: TestCase): String =
+    match test_case.result with
+    case Passed -> ''
+    case Failed { message, type } ->
+        '=== ' + adoc_inline(test_case.name) + '\n\n'
+        + '*Type:* `' + adoc_inline(type) + '`\n\n'
+        + '[listing]\n....\n'
+        + adoc_listing(normalize_failure_message(message)) + '\n'
+        + '....\n\n'
+
+private fun adoc_inline(value: String): String =
+    value
+        .replace('\\', '\\\\')
+        .replace('\r\n', ' ')
+        .replace('\n', ' ')
+        .replace('\r', ' ')
+        .replace('{', '\\{')
+        .replace('}', '\\}')
+
+private fun adoc_table_cell(value: String): String =
+    adoc_inline(value).replace('|', '\\|')
+
+private fun adoc_listing(value: String): String =
+    let escaped = value.replace('\n....', '\n\\....')
+    if escaped.starts_with('....') then '\\' + escaped else escaped
+
+private fun adoc_failed_count(test_file: TestFile): int =
+    test_file.test_cases |> 0, (acc, test_case) =>
+        if adoc_test_case_failed(test_case) then acc + 1 else acc
+
+private fun adoc_test_case_failed(test_case: TestCase): bool =
+    match test_case.result with
+    case Passed -> false
+    case Failed -> true

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
@@ -130,7 +130,8 @@ public class TestRunner {
     public enum ReportType {
         JUNIT,
         CTRF,
-        JEST
+        JEST,
+        ADOC
     }
 
     public enum LogType {
@@ -144,7 +145,7 @@ public class TestRunner {
                 Usage: java -jar test-runner.jar [options]
                 Options:
                   -o, --output-dir <dir>    Output directory for test reports (required)
-                  -rt, --report-type <type> Report type (required, JUNIT, CTRF, JEST)
+                  -rt, --report-type <type> Report type (required, JUNIT, CTRF, JEST, ADOC)
                   -l, --log <type>          Log output type (optional, LOG, TC, TEAM_CITY)
                   --tests <selector>        Run only tests matching selector; can be repeated
                   --available-tests         Print available test selectors and exit

--- a/lib/capybara-lib/src/test/capybara/capy/test/CapyTestTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/test/CapyTestTest.cfun
@@ -1,0 +1,45 @@
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+from /capy/lang/Effect import { * }
+from /capy/collection/List import { * }
+
+fun tests(): Effect[TestFile] =
+    test_file("/capy/test/CapyTestTest.cfun", [
+        test("should render adoc test report", () => should_render_adoc_test_report()),
+    ])
+
+fun should_render_adoc_test_report(): Assert =
+    let report = adoc_report(adoc_test_file())
+    assert_that(report)
+        .starts_with("= Test results: /capy/lang/StringTest.cfun\n\n")
+        .contains('|starts_with \\| \\{value\\}\n|PASS\n|1\n|0.25')
+        .contains("|starts_with should fail\n|FAIL\n|2\n|0.5")
+        .contains("*Tests:* 2 +\n*Passed:* 1 +\n*Failed:* 1")
+        .contains("== Failures\n\n=== starts_with should fail")
+        .contains('*Type:* `assertion \\{failed\\}`')
+        .contains("[listing]\n....\nExpected string:\n\\....\ncapybara\nto start with:\nbara\n....")
+
+private fun adoc_test_file(): TestFile =
+    TestFile {
+        file_name: "/capy/lang/StringTest.cfun",
+        test_cases: [
+            TestCase {
+                name: 'starts_with | {value}',
+                result: Passed {},
+                assertions_count: 1,
+                execution_time: 0.25,
+                assert_supplier: () => assert_that(true).is_true()
+            },
+            TestCase {
+                name: "starts_with should fail",
+                result: Failed {
+                    message: "Expected string:\n....\ncapybara\nto start with:\nbara",
+                    type: 'assertion {failed}'
+                },
+                assertions_count: 2,
+                execution_time: 0.5,
+                assert_supplier: () => assert_that(false).is_true()
+            }
+        ],
+        timestamp_millis: 0L
+    }

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
@@ -277,7 +277,7 @@ class TestRunnerTest {
     }
 
     @Test
-    void shouldParseCtrfReportOutputTypes() {
+    void shouldParseReportOutputTypes() {
         var ctrfArguments = TestRunner.parseArguments(new String[]{
                 "-o", tempDir.toString(),
                 "-rt", "CTRF"
@@ -286,9 +286,14 @@ class TestRunnerTest {
                 "-o", tempDir.toString(),
                 "-rt", "JEST"
         });
+        var adocArguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "adoc"
+        });
 
         assertEquals(TestRunner.ReportType.CTRF, ctrfArguments.reportType());
         assertEquals(TestRunner.ReportType.JEST, jestArguments.reportType());
+        assertEquals(TestRunner.ReportType.ADOC, adocArguments.reportType());
     }
 
     @Test

--- a/lib/capybara-lib/src/test/js/run-capybara-tests.js
+++ b/lib/capybara-lib/src/test/js/run-capybara-tests.js
@@ -47,7 +47,7 @@ function parseArgs(argv) {
 }
 
 function supportedReportTypes() {
-    return ['JUNIT', 'CTRF', 'JEST'];
+    return ['JUNIT', 'CTRF', 'JEST', 'ADOC'];
 }
 
 function requireValue(argv, index, option) {
@@ -452,6 +452,71 @@ function shouldWriteJest(reportType) {
     return reportType === 'JEST';
 }
 
+function shouldWriteAdoc(reportType) {
+    return reportType === 'ADOC';
+}
+
+function adocReportPath(outputDir, fileName) {
+    const normalized = String(fileName)
+        .replace(/^\/+/, '')
+        .replace(/\//g, '.')
+        .replace(/\.(?:cfun|coo)$/, '');
+    return path.join(outputDir, `TEST-${normalized}.adoc`);
+}
+
+function adocInline(value) {
+    return String(value)
+        .replace(/\\/g, '\\\\')
+        .replace(/\r\n|\n|\r/g, ' ')
+        .replace(/\{/g, '\\{')
+        .replace(/}/g, '\\}');
+}
+
+function adocTableCell(value) {
+    return adocInline(value).replace(/\|/g, '\\|');
+}
+
+function adocListing(value) {
+    return String(value).replace(/\r\n|\r/g, '\n').replace(/^\.\.\.\./gm, '\\....');
+}
+
+function adocReport(fileName, results) {
+    const failed = results.filter(result => result.failed).length;
+    const rows = results.map(result => [
+        `|${adocTableCell(result.name)}`,
+        `|${result.failed ? 'FAIL' : 'PASS'}`,
+        `|${result.assertions.length}`,
+        `|${result.time}`,
+        '',
+        '',
+    ].join('\n')).join('');
+    const failures = results.filter(result => result.failed).map(result => [
+        `=== ${adocInline(result.name)}`,
+        '',
+        `*Type:* \`${adocInline(result.failed.type)}\``,
+        '',
+        '[listing]',
+        '....',
+        adocListing(result.failed.message),
+        '....',
+        '',
+    ].join('\n')).join('\n');
+    const failureSection = failures ? `\n== Failures\n\n${failures}` : '';
+    return [
+        `= Test results: ${adocInline(fileName)}`,
+        '',
+        '[cols="3,1,1,1",options="header"]',
+        '|===',
+        '|Test |Status |Assertions |Time (seconds)',
+        '',
+        `${rows}|===`,
+        '',
+        `*Tests:* ${results.length} +`,
+        `*Passed:* ${results.length - failed} +`,
+        `*Failed:* ${failed}`,
+    ].join('\n') + failureSection + '\n';
+}
+
 function ctrfReport(suites, start, stop) {
     const tests = suites.flatMap(suite => suite.results.map(result => {
         const test = {
@@ -581,6 +646,9 @@ function run(options) {
         suites.push({ testFile, fileName, results });
         if (shouldWriteJUnit(options.reportType)) {
             fs.writeFileSync(reportPath(options.outputDir, fileName), suiteReport(testFile, results));
+        }
+        if (shouldWriteAdoc(options.reportType)) {
+            fs.writeFileSync(adocReportPath(options.outputDir, fileName), adocReport(fileName, results));
         }
     }
     if (shouldWriteCtrf(options.reportType)) {

--- a/lib/capybara-lib/src/test/js/run-capybara-tests.js
+++ b/lib/capybara-lib/src/test/js/run-capybara-tests.js
@@ -476,8 +476,17 @@ function adocTableCell(value) {
     return adocInline(value).replace(/\|/g, '\\|');
 }
 
+function normalizeFailureMessage(value) {
+    return String(value)
+        .replace(/\\r\\n/g, '\n')
+        .replace(/\\n/g, '\n')
+        .replace(/\\r/g, '\n')
+        .replace(/\r\n|\r/g, '\n')
+        .replace(/\\t/g, '\t');
+}
+
 function adocListing(value) {
-    return String(value).replace(/\r\n|\r/g, '\n').replace(/^\.\.\.\./gm, '\\....');
+    return normalizeFailureMessage(value).replace(/^\.\.\.\./gm, '\\....');
 }
 
 function adocReport(fileName, results) {

--- a/lib/capybara-lib/src/test/py/run-capybara-tests.py
+++ b/lib/capybara-lib/src/test/py/run-capybara-tests.py
@@ -563,8 +563,18 @@ def adoc_table_cell(value):
     return adoc_inline(value).replace("|", "\\|")
 
 
+def normalize_failure_message(value):
+    return (str(value)
+            .replace("\\r\\n", "\n")
+            .replace("\\n", "\n")
+            .replace("\\r", "\n")
+            .replace("\r\n", "\n")
+            .replace("\r", "\n")
+            .replace("\\t", "\t"))
+
+
 def adoc_listing(value):
-    escaped = str(value).replace("\r\n", "\n").replace("\r", "\n").replace("\n....", "\n\\....")
+    escaped = normalize_failure_message(value).replace("\n....", "\n\\....")
     return "\\" + escaped if escaped.startswith("....") else escaped
 
 

--- a/lib/capybara-lib/src/test/py/run-capybara-tests.py
+++ b/lib/capybara-lib/src/test/py/run-capybara-tests.py
@@ -9,7 +9,7 @@ import sys
 import time
 import traceback
 
-SUPPORTED_REPORT_TYPES = ("JUNIT", "CTRF", "JEST")
+SUPPORTED_REPORT_TYPES = ("JUNIT", "CTRF", "JEST", "ADOC")
 
 
 def parse_args(argv):
@@ -540,12 +540,73 @@ def suite_report(file_name, results):
     )
 
 
+def adoc_report_path(output_dir, file_name):
+    normalized = str(file_name).lstrip("/").replace("/", ".")
+    for suffix in (".cfun", ".coo"):
+        if normalized.endswith(suffix):
+            normalized = normalized[:-len(suffix)]
+            break
+    return pathlib.Path(output_dir, f"TEST-{normalized}.adoc")
+
+
+def adoc_inline(value):
+    return (str(value)
+            .replace("\\", "\\\\")
+            .replace("\r\n", " ")
+            .replace("\n", " ")
+            .replace("\r", " ")
+            .replace("{", "\\{")
+            .replace("}", "\\}"))
+
+
+def adoc_table_cell(value):
+    return adoc_inline(value).replace("|", "\\|")
+
+
+def adoc_listing(value):
+    escaped = str(value).replace("\r\n", "\n").replace("\r", "\n").replace("\n....", "\n\\....")
+    return "\\" + escaped if escaped.startswith("....") else escaped
+
+
+def adoc_report(file_name, results):
+    failed = sum(1 for result in results if result["failed"])
+    rows = "".join(
+        f'|{adoc_table_cell(result["name"])}\n'
+        f'|{"FAIL" if result["failed"] else "PASS"}\n'
+        f'|{len(result["assertions"])}\n'
+        f'|{result["time"]}\n\n'
+        for result in results
+    )
+    failures = "".join(
+        f'=== {adoc_inline(result["name"])}\n\n'
+        f'*Type:* `{adoc_inline(result["failed"]["type"])}`\n\n'
+        f'[listing]\n....\n{adoc_listing(result["failed"]["message"])}\n....\n\n'
+        for result in results if result["failed"]
+    )
+    failure_section = f'\n== Failures\n\n{failures}' if failures else ""
+    return (
+        f'= Test results: {adoc_inline(file_name)}\n\n'
+        '[cols="3,1,1,1",options="header"]\n'
+        '|===\n'
+        '|Test |Status |Assertions |Time (seconds)\n\n'
+        f'{rows}'
+        '|===\n\n'
+        f'*Tests:* {len(results)} +\n'
+        f'*Passed:* {len(results) - failed} +\n'
+        f'*Failed:* {failed}\n'
+        f'{failure_section}'
+    )
+
+
 def write_reports(output_dir, report_type, suites, start_ms, stop_ms):
     output_dir = pathlib.Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     if report_type == "JUNIT":
         for suite in suites:
             report_path(output_dir, suite["fileName"]).write_text(suite_report(suite["fileName"], suite["results"]))
+    if report_type == "ADOC":
+        for suite in suites:
+            adoc_report_path(output_dir, suite["fileName"]).write_text(adoc_report(suite["fileName"], suite["results"]))
     if report_type == "CTRF":
         tests = []
         for suite in suites:


### PR DESCRIPTION
## Summary

- add `ADOC` as a test report type in the Capybara test library
- generate one `TEST-*.adoc` file per suite with results, totals, and failure details
- support ADOC reports in the Java, JavaScript, and Python test runners
- escape AsciiDoc-sensitive table, heading, and listing content

## Impact

Test runs can now produce human-readable AsciiDoc artifacts alongside the existing JUnit, CTRF, and Jest formats.

## Validation

- `./gradlew.bat :lib:capybara-lib:compileJava --no-daemon`
- `./gradlew.bat :lib:capybara-lib:testCapybara --no-daemon`
- JavaScript runner invoked end-to-end with `--report-type ADOC`
- Python runner invoked end-to-end with `--report-type ADOC`
- JavaScript and Python syntax checks
- `git diff --check`

Closes #375
