### PR TITLE
feat(#378): package JavaScript and Python test runners

### DIFF
--- a/capy/build.gradle
+++ b/capy/build.gradle
@@ -429,8 +429,8 @@ def intellijE2eTestSourceDirs = files(
         'src/e2e-coo-js-native',
         'src/e2e-coo-py-native'
 )
-def capybaraJavaScriptTestRunner = project(':lib:capybara-lib').layout.projectDirectory.file('src/test/js/run-capybara-tests.js')
-def capybaraPythonTestRunner = project(':lib:capybara-lib').layout.projectDirectory.file('src/test/py/run-capybara-tests.py')
+def capybaraJavaScriptTestRunner = project(':lib:capybara-lib').layout.projectDirectory.file('src/main/resources/test-runner/js/run-capybara-tests.js')
+def capybaraPythonTestRunner = project(':lib:capybara-lib').layout.projectDirectory.file('src/main/resources/test-runner/python/run-capybara-tests.py')
 def capyRuntimeDependencies = configurations.runtimeClasspath.incoming.artifactView {
     componentFilter { componentIdentifier ->
         !(componentIdentifier instanceof ProjectComponentIdentifier) &&
@@ -825,10 +825,13 @@ processResources {
     from(capybaraStdlibLinkedDir) {
         into 'capy'
     }
+    from(project(':lib:capybara-lib').layout.projectDirectory.dir('src/main/resources/test-runner')) {
+        into 'test-runner'
+    }
 }
 
 application {
-    mainClass = 'dev.capylang.cli.Capy'
+    mainClass = 'dev.capylang.cli.CapyLauncher'
 }
 
 def integrationTests = tasks.register('integrationTest', Test) {

--- a/capy/src/main/capybara/dev/capylang/cli/Capy.cfun
+++ b/capy/src/main/capybara/dev/capylang/cli/Capy.cfun
@@ -532,7 +532,7 @@ private fun help_text(): String =
     + "  capy generate <java|python|javascript|js> [-i|--input <dir>] -o|--output <dir> [--skip-java-lib] [--log <DEBUG|INFO|WARN|ERROR>]\n"
     + "  capy docs [-l|--libs <dir1,dir2,...>] [--native-wiring <file>] -i|--input <dir> -o|--output <dir> [--log <DEBUG|INFO|WARN|ERROR>]\n"
     + "  capy package (-ci|--compiled-input <dir> | -i|--input <dir>) -m|--module <capy.yml> [--capy.<field> <value>] [--log <DEBUG|INFO|WARN|ERROR>]\n"
-    + "  capy test <java|js|python> --generated-dir <dir> [--output-dir <dir> --report-type <JUNIT|CTRF|JEST>] [--log <NONE|LOG|TC|TEAM_CITY>] [--tests <selector>] [--available-tests]\n"
+    + "  capy test <java|js|python> --generated-dir <dir> [--output-dir <dir> --report-type <JUNIT|CTRF|JEST|ADOC>] [--log <NONE|LOG|TC|TEAM_CITY>] [--tests <selector>] [--available-tests]\n"
     + "\n"
     + "Notes:\n"
     + "  compile output directory may be reused; stale generated files are pruned automatically.\n"

--- a/capy/src/main/capybara/dev/capylang/cli/Capy.cfun
+++ b/capy/src/main/capybara/dev/capylang/cli/Capy.cfun
@@ -532,6 +532,7 @@ private fun help_text(): String =
     + "  capy generate <java|python|javascript|js> [-i|--input <dir>] -o|--output <dir> [--skip-java-lib] [--log <DEBUG|INFO|WARN|ERROR>]\n"
     + "  capy docs [-l|--libs <dir1,dir2,...>] [--native-wiring <file>] -i|--input <dir> -o|--output <dir> [--log <DEBUG|INFO|WARN|ERROR>]\n"
     + "  capy package (-ci|--compiled-input <dir> | -i|--input <dir>) -m|--module <capy.yml> [--capy.<field> <value>] [--log <DEBUG|INFO|WARN|ERROR>]\n"
+    + "  capy test <java|js|python> --generated-dir <dir> [--output-dir <dir> --report-type <JUNIT|CTRF|JEST>] [--log <NONE|LOG|TC|TEAM_CITY>] [--tests <selector>] [--available-tests]\n"
     + "\n"
     + "Notes:\n"
     + "  compile output directory may be reused; stale generated files are pruned automatically.\n"

--- a/capy/src/main/java/dev/capylang/cli/CapyLauncher.java
+++ b/capy/src/main/java/dev/capylang/cli/CapyLauncher.java
@@ -1,0 +1,21 @@
+package dev.capylang.cli;
+
+import capy.lang.Program;
+
+import java.util.List;
+
+/** Entry point for the packaged Capybara CLI. */
+public final class CapyLauncher {
+    private CapyLauncher() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length > 0 && "test".equals(args[0])) {
+            System.exit(TestCommand.execute(java.util.Arrays.copyOfRange(args, 1, args.length)));
+        }
+        var program = Capy.main(List.of(args)).unsafeRun();
+        if (program instanceof Program.Failed failed) {
+            System.exit(failed.exit_code());
+        }
+    }
+}

--- a/capy/src/main/java/dev/capylang/cli/TestCommand.java
+++ b/capy/src/main/java/dev/capylang/cli/TestCommand.java
@@ -29,8 +29,8 @@ final class TestCommand {
             var options = Options.parse(args);
             return switch (options.backend()) {
                 case JAVA -> runJava(options);
-                case JAVASCRIPT -> runScript(options, "node", JAVASCRIPT_RUNNER, ".js");
-                case PYTHON -> runScript(options, "python3", PYTHON_RUNNER, ".py");
+                case JAVASCRIPT -> runScript(options, "node", JAVASCRIPT_RUNNER, ".js", false);
+                case PYTHON -> runScript(options, pythonExecutable(System.getProperty("os.name", "")), PYTHON_RUNNER, ".py", true);
             };
         } catch (CommandException | IllegalArgumentException exception) {
             System.err.println(exception.getMessage());
@@ -42,7 +42,8 @@ final class TestCommand {
             Options options,
             String executable,
             String resource,
-            String suffix
+            String suffix,
+            boolean unbuffered
     ) throws CommandException {
         Path temporaryDirectory = null;
         try {
@@ -51,7 +52,7 @@ final class TestCommand {
             extractResource(resource, runner);
             var command = new ArrayList<String>();
             command.add(executable);
-            if ("python3".equals(executable)) {
+            if (unbuffered) {
                 command.add("-u");
             }
             command.add(runner.toString());
@@ -130,9 +131,15 @@ final class TestCommand {
     private static String runtimeName(String executable) {
         return switch (executable) {
             case "node" -> "Node.js";
-            case "python3" -> "Python";
+            case "python3", "python.exe" -> "Python";
             default -> "Java";
         };
+    }
+
+    static String pythonExecutable(String operatingSystemName) {
+        return operatingSystemName.toLowerCase(Locale.ROOT).contains("windows")
+                ? "python.exe"
+                : "python3";
     }
 
     private static void extractResource(String resource, Path target) throws IOException, CommandException {
@@ -200,7 +207,7 @@ final class TestCommand {
                 Options:
                   --generated-dir <directory>  Generated test sources or classes (required)
                   --output-dir <directory>     Test report output directory (required unless --available-tests)
-                  --report-type <type>         JUNIT, CTRF, or JEST (required unless --available-tests)
+                  --report-type <type>         JUNIT, CTRF, JEST, or ADOC (required unless --available-tests)
                   --log <type>                 NONE, LOG, TC, or TEAM_CITY (default: NONE)
                   --tests <selector>           Run matching tests; may be repeated
                   --available-tests            Print available test selectors without running tests
@@ -277,8 +284,8 @@ final class TestCommand {
             if (!availableTests && reportType == null) {
                 throw new IllegalArgumentException("Missing --report-type");
             }
-            if (reportType != null && !List.of("JUNIT", "CTRF", "JEST").contains(reportType)) {
-                throw new IllegalArgumentException("Unknown report type `%s`. Use JUNIT, CTRF, or JEST.".formatted(reportType));
+            if (reportType != null && !List.of("JUNIT", "CTRF", "JEST", "ADOC").contains(reportType)) {
+                throw new IllegalArgumentException("Unknown report type `%s`. Use JUNIT, CTRF, JEST, or ADOC.".formatted(reportType));
             }
             if (!List.of("NONE", "LOG", "TC", "TEAM_CITY").contains(logType)) {
                 throw new IllegalArgumentException("Unknown log type `%s`. Use NONE, LOG, TC, or TEAM_CITY.".formatted(logType));

--- a/capy/src/main/java/dev/capylang/cli/TestCommand.java
+++ b/capy/src/main/java/dev/capylang/cli/TestCommand.java
@@ -1,0 +1,336 @@
+package dev.capylang.cli;
+
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+final class TestCommand {
+    private static final String JAVASCRIPT_RUNNER = "/test-runner/js/run-capybara-tests.js";
+    private static final String PYTHON_RUNNER = "/test-runner/python/run-capybara-tests.py";
+
+    private TestCommand() {
+    }
+
+    static int execute(String[] args) {
+        if (Arrays.asList(args).contains("--help") || Arrays.asList(args).contains("-h")) {
+            printHelp();
+            return 0;
+        }
+        try {
+            var options = Options.parse(args);
+            return switch (options.backend()) {
+                case JAVA -> runJava(options);
+                case JAVASCRIPT -> runScript(options, "node", JAVASCRIPT_RUNNER, ".js");
+                case PYTHON -> runScript(options, "python3", PYTHON_RUNNER, ".py");
+            };
+        } catch (CommandException | IllegalArgumentException exception) {
+            System.err.println(exception.getMessage());
+            return 2;
+        }
+    }
+
+    private static int runScript(
+            Options options,
+            String executable,
+            String resource,
+            String suffix
+    ) throws CommandException {
+        Path temporaryDirectory = null;
+        try {
+            temporaryDirectory = Files.createTempDirectory("capy-test-runner-");
+            var runner = temporaryDirectory.resolve("run-capybara-tests" + suffix);
+            extractResource(resource, runner);
+            var command = new ArrayList<String>();
+            command.add(executable);
+            if ("python3".equals(executable)) {
+                command.add("-u");
+            }
+            command.add(runner.toString());
+            command.addAll(options.runnerArguments(true));
+            return start(command, executable);
+        } catch (IOException exception) {
+            throw new CommandException("Unable to prepare the packaged %s test runner: %s"
+                    .formatted(options.backend().displayName(), exception.getMessage()));
+        } finally {
+            deleteRecursively(temporaryDirectory);
+        }
+    }
+
+    private static int runJava(Options options) throws CommandException {
+        Path temporaryDirectory = null;
+        try {
+            var classPathRoot = options.generatedDir();
+            var javaSources = regularFiles(options.generatedDir(), ".java");
+            if (!javaSources.isEmpty()) {
+                temporaryDirectory = Files.createTempDirectory("capy-test-java-");
+                classPathRoot = temporaryDirectory.resolve("classes");
+                Files.createDirectories(classPathRoot);
+                compileJava(javaSources, classPathRoot, options.generatedDir());
+            }
+
+            if (options.outputDir() != null) {
+                Files.createDirectories(options.outputDir());
+            }
+            var command = new ArrayList<String>();
+            command.add(javaExecutable().toString());
+            command.add("-cp");
+            command.add(javaClassPath(classPathRoot, options.generatedDir()));
+            command.add("dev.capylang.test.TestRunner");
+            command.addAll(options.runnerArguments(false));
+            return start(command, "java");
+        } catch (IOException exception) {
+            throw new CommandException("Unable to prepare generated Java tests: " + exception.getMessage());
+        } finally {
+            deleteRecursively(temporaryDirectory);
+        }
+    }
+
+    private static void compileJava(List<Path> sources, Path output, Path generatedDir) throws CommandException, IOException {
+        var compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new CommandException("Generated Java tests contain source files, but no Java compiler is available. Run Capybara with a JDK or pass a directory containing compiled test classes.");
+        }
+        try (var fileManager = compiler.getStandardFileManager(null, Locale.ROOT, null)) {
+            var units = fileManager.getJavaFileObjectsFromPaths(sources);
+            var options = List.of(
+                    "-d", output.toString(),
+                    "-classpath", System.getProperty("java.class.path") + java.io.File.pathSeparator + generatedDir
+            );
+            var succeeded = compiler.getTask(null, fileManager, null, options, null, units).call();
+            if (!Boolean.TRUE.equals(succeeded)) {
+                throw new CommandException("Unable to compile generated Java tests.");
+            }
+        }
+    }
+
+    private static int start(List<String> command, String runtime) throws CommandException {
+        try {
+            return new ProcessBuilder(command)
+                    .inheritIO()
+                    .start()
+                    .waitFor();
+        } catch (IOException exception) {
+            throw new CommandException("Required %s runtime is unavailable. Ensure `%s` is installed and available on PATH."
+                    .formatted(runtimeName(runtime), runtime));
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new CommandException("Interrupted while waiting for the %s test runner.".formatted(runtimeName(runtime)));
+        }
+    }
+
+    private static String runtimeName(String executable) {
+        return switch (executable) {
+            case "node" -> "Node.js";
+            case "python3" -> "Python";
+            default -> "Java";
+        };
+    }
+
+    private static void extractResource(String resource, Path target) throws IOException, CommandException {
+        try (InputStream input = TestCommand.class.getResourceAsStream(resource)) {
+            if (input == null) {
+                throw new CommandException("Packaged test runner resource is missing: " + resource);
+            }
+            Files.copy(input, target);
+        }
+    }
+
+    private static List<Path> regularFiles(Path directory, String suffix) throws IOException {
+        try (var paths = Files.walk(directory)) {
+            return paths.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().endsWith(suffix))
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    private static String javaClassPath(Path classes, Path generatedDir) {
+        return classes + java.io.File.pathSeparator
+                + generatedDir + java.io.File.pathSeparator
+                + System.getProperty("java.class.path");
+    }
+
+    private static Path javaExecutable() {
+        var executable = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("windows")
+                ? "java.exe"
+                : "java";
+        return Path.of(System.getProperty("java.home"), "bin", executable);
+    }
+
+    private static void deleteRecursively(Path directory) {
+        if (directory == null || Files.notExists(directory)) {
+            return;
+        }
+        try {
+            Files.walkFileTree(directory, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exception) throws IOException {
+                    if (exception != null) {
+                        throw exception;
+                    }
+                    Files.deleteIfExists(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException ignored) {
+            // Temporary runner cleanup must not hide the test process exit code.
+        }
+    }
+
+    private static void printHelp() {
+        System.out.println("""
+                Usage:
+                  capy test <java|js|python> --generated-dir <directory> [options]
+
+                Options:
+                  --generated-dir <directory>  Generated test sources or classes (required)
+                  --output-dir <directory>     Test report output directory (required unless --available-tests)
+                  --report-type <type>         JUNIT, CTRF, or JEST (required unless --available-tests)
+                  --log <type>                 NONE, LOG, TC, or TEAM_CITY (default: NONE)
+                  --tests <selector>           Run matching tests; may be repeated
+                  --available-tests            Print available test selectors without running tests
+                  -h, --help                   Show this help
+                """);
+    }
+
+    private enum Backend {
+        JAVA("Java"),
+        JAVASCRIPT("JavaScript"),
+        PYTHON("Python");
+
+        private final String displayName;
+
+        Backend(String displayName) {
+            this.displayName = displayName;
+        }
+
+        String displayName() {
+            return displayName;
+        }
+
+        static Backend parse(String value) {
+            return switch (value.toLowerCase(Locale.ROOT)) {
+                case "java" -> JAVA;
+                case "js", "javascript" -> JAVASCRIPT;
+                case "py", "python" -> PYTHON;
+                default -> throw new IllegalArgumentException("Unknown test backend `%s`. Use java, js, or python.".formatted(value));
+            };
+        }
+    }
+
+    private record Options(
+            Backend backend,
+            Path generatedDir,
+            Path outputDir,
+            String reportType,
+            String logType,
+            List<String> tests,
+            boolean availableTests
+    ) {
+        static Options parse(String[] args) {
+            if (args.length == 0) {
+                throw new IllegalArgumentException("Missing test backend. Use java, js, or python.");
+            }
+            var backend = Backend.parse(args[0]);
+            Path generatedDir = null;
+            Path outputDir = null;
+            String reportType = null;
+            String logType = "NONE";
+            var tests = new ArrayList<String>();
+            var availableTests = false;
+            for (var index = 1; index < args.length; index++) {
+                switch (args[index]) {
+                    case "--generated-dir" -> generatedDir = Path.of(nextValue(args, ++index, "--generated-dir"));
+                    case "--output-dir" -> outputDir = Path.of(nextValue(args, ++index, "--output-dir"));
+                    case "--report-type" -> reportType = nextValue(args, ++index, "--report-type").toUpperCase(Locale.ROOT);
+                    case "--log" -> logType = nextValue(args, ++index, "--log").toUpperCase(Locale.ROOT);
+                    case "--tests" -> tests.add(nextValue(args, ++index, "--tests"));
+                    case "--available-tests" -> availableTests = true;
+                    default -> throw new IllegalArgumentException("Unknown test option: " + args[index]);
+                }
+            }
+            if (generatedDir == null) {
+                throw new IllegalArgumentException("Missing --generated-dir");
+            }
+            generatedDir = generatedDir.toAbsolutePath().normalize();
+            if (!Files.isDirectory(generatedDir)) {
+                throw new IllegalArgumentException("Generated test directory does not exist or is not a directory: " + generatedDir);
+            }
+            if (!availableTests && outputDir == null) {
+                throw new IllegalArgumentException("Missing --output-dir");
+            }
+            if (!availableTests && reportType == null) {
+                throw new IllegalArgumentException("Missing --report-type");
+            }
+            if (reportType != null && !List.of("JUNIT", "CTRF", "JEST").contains(reportType)) {
+                throw new IllegalArgumentException("Unknown report type `%s`. Use JUNIT, CTRF, or JEST.".formatted(reportType));
+            }
+            if (!List.of("NONE", "LOG", "TC", "TEAM_CITY").contains(logType)) {
+                throw new IllegalArgumentException("Unknown log type `%s`. Use NONE, LOG, TC, or TEAM_CITY.".formatted(logType));
+            }
+            for (var test : tests) {
+                if (test.isBlank()) {
+                    throw new IllegalArgumentException("Test selector must not be blank");
+                }
+            }
+            outputDir = outputDir == null ? null : outputDir.toAbsolutePath().normalize();
+            return new Options(backend, generatedDir, outputDir, reportType, logType, List.copyOf(tests), availableTests);
+        }
+
+        List<String> runnerArguments(boolean includeGeneratedDir) {
+            var arguments = new ArrayList<String>();
+            if (includeGeneratedDir) {
+                arguments.add("--generated-dir");
+                arguments.add(generatedDir.toString());
+            }
+            if (outputDir != null) {
+                arguments.add("--output-dir");
+                arguments.add(outputDir.toString());
+            }
+            if (reportType != null) {
+                arguments.add("--report-type");
+                arguments.add(reportType);
+            }
+            if (!"NONE".equals(logType)) {
+                arguments.add("--log");
+                arguments.add(logType);
+            }
+            for (var test : tests) {
+                arguments.add("--tests");
+                arguments.add(test);
+            }
+            if (availableTests) {
+                arguments.add("--available-tests");
+            }
+            return arguments;
+        }
+
+        private static String nextValue(String[] args, int index, String option) {
+            if (index >= args.length) {
+                throw new IllegalArgumentException("Missing value for " + option);
+            }
+            return args[index];
+        }
+    }
+
+    private static final class CommandException extends Exception {
+        private CommandException(String message) {
+            super(message);
+        }
+    }
+}

--- a/capy/src/test/java/dev/capylang/cli/TestCommandTest.java
+++ b/capy/src/test/java/dev/capylang/cli/TestCommandTest.java
@@ -29,11 +29,18 @@ class TestCommandTest {
                 "js",
                 "--generated-dir", tempDir.toString(),
                 "--output-dir", tempDir.resolve("reports").toString(),
-                "--report-type", "ADOC"
+                "--report-type", "HTML"
         );
 
         assertThat(result.exitCode()).isEqualTo(2);
-        assertThat(result.error()).contains("Use JUNIT, CTRF, or JEST");
+        assertThat(result.error()).contains("Use JUNIT, CTRF, JEST, or ADOC");
+    }
+
+    @Test
+    void selectsPythonExecutableForOperatingSystem() {
+        assertThat(TestCommand.pythonExecutable("Windows 11")).isEqualTo("python.exe");
+        assertThat(TestCommand.pythonExecutable("Linux")).isEqualTo("python3");
+        assertThat(TestCommand.pythonExecutable("Mac OS X")).isEqualTo("python3");
     }
 
     @Test
@@ -76,6 +83,21 @@ class TestCommandTest {
             assertThat(generatedFiles.filter(Files::isRegularFile))
                     .allMatch(path -> path.equals(source));
         }
+    }
+
+    @Test
+    void acceptsAdocReportTypeDuringValidation() {
+        var result = executeWithCapturedError(
+                "js",
+                "--generated-dir", tempDir.toString(),
+                "--output-dir", tempDir.resolve("reports").toString(),
+                "--report-type", "ADOC",
+                "--log", "INVALID"
+        );
+
+        assertThat(result.exitCode()).isEqualTo(2);
+        assertThat(result.error()).contains("Unknown log type");
+        assertThat(result.error()).doesNotContain("Unknown report type");
     }
 
     private static Execution executeWithCapturedError(String... args) {

--- a/capy/src/test/java/dev/capylang/cli/TestCommandTest.java
+++ b/capy/src/test/java/dev/capylang/cli/TestCommandTest.java
@@ -1,0 +1,94 @@
+package dev.capylang.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ResourceLock(Resources.SYSTEM_ERR)
+class TestCommandTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void packagesJavaScriptAndPythonRunners() {
+        assertThat(TestCommand.class.getResource("/test-runner/js/run-capybara-tests.js")).isNotNull();
+        assertThat(TestCommand.class.getResource("/test-runner/python/run-capybara-tests.py")).isNotNull();
+    }
+
+    @Test
+    void rejectsUnsupportedReportTypeBeforeStartingRuntime() {
+        var result = executeWithCapturedError(
+                "js",
+                "--generated-dir", tempDir.toString(),
+                "--output-dir", tempDir.resolve("reports").toString(),
+                "--report-type", "ADOC"
+        );
+
+        assertThat(result.exitCode()).isEqualTo(2);
+        assertThat(result.error()).contains("Use JUNIT, CTRF, or JEST");
+    }
+
+    @Test
+    void rejectsMissingGeneratedDirectory() {
+        var missing = tempDir.resolve("missing");
+
+        var result = executeWithCapturedError(
+                "python",
+                "--generated-dir", missing.toString(),
+                "--available-tests"
+        );
+
+        assertThat(result.exitCode()).isEqualTo(2);
+        assertThat(result.error()).contains("does not exist or is not a directory");
+    }
+
+    @Test
+    void runsGeneratedJavaSourcesAndWritesReportsOutsideGeneratedDirectory() throws Exception {
+        var generated = tempDir.resolve("generated Java tests with spaces");
+        var source = generated.resolve("capy/test/CapyTestRuntime.java");
+        Files.createDirectories(source.getParent());
+        try (var input = TestCommandTest.class.getResourceAsStream("/test-runner/java/capy/test/CapyTestRuntime.java")) {
+            assertThat(input).isNotNull();
+            Files.copy(input, source);
+        }
+        var output = tempDir.resolve("Java reports with spaces");
+
+        var exitCode = TestCommand.execute(new String[]{
+                "java",
+                "--generated-dir", generated.toString(),
+                "--output-dir", output.toString(),
+                "--report-type", "JUNIT",
+                "--log", "TC"
+        });
+
+        assertThat(exitCode).isZero();
+        assertThat(output.resolve("TEST-sample.JavaRunnerTest.cfun.xml")).isRegularFile();
+        assertThat(Files.readString(source)).contains("passes from packaged Java runner");
+        try (var generatedFiles = Files.walk(generated)) {
+            assertThat(generatedFiles.filter(Files::isRegularFile))
+                    .allMatch(path -> path.equals(source));
+        }
+    }
+
+    private static Execution executeWithCapturedError(String... args) {
+        var originalError = System.err;
+        var error = new ByteArrayOutputStream();
+        try {
+            System.setErr(new PrintStream(error));
+            return new Execution(TestCommand.execute(args), error.toString());
+        } finally {
+            System.setErr(originalError);
+        }
+    }
+
+    private record Execution(int exitCode, String error) {
+    }
+}

--- a/capy/src/test/resources/test-runner/java/capy/test/CapyTestRuntime.java
+++ b/capy/src/test/resources/test-runner/java/capy/test/CapyTestRuntime.java
@@ -1,0 +1,19 @@
+package capy.test;
+
+import java.util.List;
+
+public final class CapyTestRuntime {
+    private CapyTestRuntime() {
+    }
+
+    public static List<Object> gatherTests() {
+        return List.of(new CapyTest.TestFile(
+                "/sample/JavaRunnerTest.cfun",
+                List.of(CapyTest.test(
+                        "passes from packaged Java runner",
+                        () -> Assert.assertThat__int(1).isEqualTo(1)
+                )),
+                0L
+        ));
+    }
+}

--- a/lib/capybara-lib/build.gradle
+++ b/lib/capybara-lib/build.gradle
@@ -546,8 +546,8 @@ def capybaraLinkedMainDir = layout.buildDirectory.dir('generated/sources/capybar
 def capybaraTestResultsDir = layout.buildDirectory.dir('test-results/capybara')
 def capybaraJsTestResultsDir = layout.buildDirectory.dir('test-results/capybara-js')
 def capybaraPyTestResultsDir = layout.buildDirectory.dir('test-results/capybara-python')
-def capybaraJsTestRunner = layout.projectDirectory.file('src/test/js/run-capybara-tests.js')
-def capybaraPyTestRunner = layout.projectDirectory.file('src/test/py/run-capybara-tests.py')
+def capybaraJsTestRunner = layout.projectDirectory.file('src/main/resources/test-runner/js/run-capybara-tests.js')
+def capybaraPyTestRunner = layout.projectDirectory.file('src/main/resources/test-runner/python/run-capybara-tests.py')
 def capybaraTestRuntimeClasspath = files(capyRuntimeClasspath, sourceSets.main.runtimeClasspath, sourceSets.test.output.classesDirs)
 def directoryContainsFile = { directory, matcher = { true } ->
     Path root = directory.asFile.toPath()

--- a/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/CapyTest.cfun
@@ -126,7 +126,7 @@ private fun execute_test_case(log_type: LogType, test_case: TestCase): Effect[Te
         assert_supplier: test_case.assert_supplier
     }
     let failed <- print_test_failed(log_type, executed_test_case)
-    let finished <- print_test_finished(log_type, test_case.name)
+    let finished <- print_test_finished(log_type, executed_test_case)
     executed_test_case
 
 private fun execute(assertions: List[() => Assertion]): TestResult =
@@ -419,11 +419,11 @@ private fun print_test_failed(log_type: LogType, test_case: TestCase): Effect[St
         case TEAM_CITY ->
             println("##teamcity[testFailed name='{team_city_escape(test_case.name)}' message='assertion failed' details='{team_city_escape(normalize_failure_message(message))}']")
 
-private fun print_test_finished(log_type: LogType, test_name: String): Effect[String] =
+private fun print_test_finished(log_type: LogType, test_case: TestCase): Effect[String] =
     match log_type with
-    case NONE -> pure(test_name)
-    case LOG -> println("Test finished: {test_name}")
-    case TEAM_CITY -> println("##teamcity[testFinished name='{team_city_escape(test_name)}']")
+    case NONE -> pure(test_case.name)
+    case LOG -> println("Test finished: {test_case.name}")
+    case TEAM_CITY -> println("##teamcity[testFinished name='{team_city_escape(test_case.name)}' duration='{ctrf_duration_millis(test_case)}']")
 
 /// Builds console log lines for the supplied test files and their test cases.
 fun test_log_lines(test_files: List[TestFile]): List[String] =
@@ -466,7 +466,7 @@ private fun team_city_messages_file(test_file: TestFile): List[String] =
 private fun team_city_messages_case(test_case: TestCase): List[String] =
     let test_name = team_city_escape(test_case.name)
     let started = "##teamcity[testStarted name='{test_name}']"
-    let finished = "##teamcity[testFinished name='{test_name}']"
+    let finished = "##teamcity[testFinished name='{test_name}' duration='{ctrf_duration_millis(test_case)}']"
     match test_case.result with
     case Passed -> [started, finished]
     case Failed { message, type } -> [

--- a/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
+++ b/lib/capybara-lib/src/main/java/dev/capylang/test/TestRunner.java
@@ -155,9 +155,10 @@ public class TestRunner {
 
     private static LogType parseLogType(String value) {
         return switch (value.toUpperCase(Locale.ROOT)) {
+            case "NONE" -> LogType.NONE;
             case "LOG" -> LogType.LOG;
             case "TC", "TEAM_CITY" -> LogType.TEAM_CITY;
-            default -> throw new IllegalArgumentException("Unknown log type `" + value + "`. Use LOG, TC, or TEAM_CITY.");
+            default -> throw new IllegalArgumentException("Unknown log type `" + value + "`. Use NONE, LOG, TC, or TEAM_CITY.");
         };
     }
 

--- a/lib/capybara-lib/src/main/resources/test-runner/js/run-capybara-tests.js
+++ b/lib/capybara-lib/src/main/resources/test-runner/js/run-capybara-tests.js
@@ -43,6 +43,9 @@ function parseArgs(argv) {
     if (!options.availableTests && !supportedReportTypes().includes(options.reportType)) {
         throw new Error(`Supported report types are ${supportedReportTypes().join(', ')}`);
     }
+    if (!['NONE', 'LOG', 'TC', 'TEAM_CITY'].includes(options.log)) {
+        throw new Error('Supported log types are NONE, LOG, TC, TEAM_CITY');
+    }
     return options;
 }
 
@@ -382,31 +385,42 @@ function teamCityEscape(value) {
 }
 
 function logSuiteStarted(logType, name) {
-    if (logType === 'TC' || logType === 'TEAM_CITY') {
+    if (logType === 'LOG') {
+        console.log(`Test suite started: ${name}`);
+    } else if (logType === 'TC' || logType === 'TEAM_CITY') {
         console.log(`##teamcity[testSuiteStarted name='${teamCityEscape(name)}']`);
     }
 }
 
 function logSuiteFinished(logType, name) {
-    if (logType === 'TC' || logType === 'TEAM_CITY') {
+    if (logType === 'LOG') {
+        console.log(`Test suite finished: ${name}`);
+    } else if (logType === 'TC' || logType === 'TEAM_CITY') {
         console.log(`##teamcity[testSuiteFinished name='${teamCityEscape(name)}']`);
     }
 }
 
 function logTestStarted(logType, name) {
-    if (logType === 'TC' || logType === 'TEAM_CITY') {
+    if (logType === 'LOG') {
+        console.log(`Test started: ${name}`);
+    } else if (logType === 'TC' || logType === 'TEAM_CITY') {
         console.log(`##teamcity[testStarted name='${teamCityEscape(name)}']`);
     }
 }
 
-function logTestFinished(logType, name) {
-    if (logType === 'TC' || logType === 'TEAM_CITY') {
-        console.log(`##teamcity[testFinished name='${teamCityEscape(name)}']`);
+function logTestFinished(logType, name, durationMs) {
+    if (logType === 'LOG') {
+        console.log(`Test finished: ${name}`);
+    } else if (logType === 'TC' || logType === 'TEAM_CITY') {
+        console.log(`##teamcity[testFinished name='${teamCityEscape(name)}' duration='${durationMs}']`);
     }
 }
 
 function logTestFailed(logType, name, message) {
-    if (logType === 'TC' || logType === 'TEAM_CITY') {
+    if (logType === 'LOG') {
+        console.log(`Test failed: ${name}`);
+        console.log(message);
+    } else if (logType === 'TC' || logType === 'TEAM_CITY') {
         console.log(`##teamcity[testFailed name='${teamCityEscape(name)}' message='${teamCityEscape(message)}']`);
     }
 }
@@ -648,7 +662,7 @@ function run(options) {
                 failed = true;
                 logTestFailed(options.log, testCase.name, result.failed.message);
             }
-            logTestFinished(options.log, testCase.name);
+            logTestFinished(options.log, testCase.name, result.durationMs);
             results.push(result);
         }
         logSuiteFinished(options.log, fileName);

--- a/lib/capybara-lib/src/main/resources/test-runner/python/run-capybara-tests.py
+++ b/lib/capybara-lib/src/main/resources/test-runner/python/run-capybara-tests.py
@@ -10,6 +10,7 @@ import time
 import traceback
 
 SUPPORTED_REPORT_TYPES = ("JUNIT", "CTRF", "JEST", "ADOC")
+SUPPORTED_LOG_TYPES = ("NONE", "LOG", "TC", "TEAM_CITY")
 
 
 def parse_args(argv):
@@ -17,7 +18,7 @@ def parse_args(argv):
     parser.add_argument("--generated-dir", required=True)
     parser.add_argument("--output-dir")
     parser.add_argument("--report-type", default="JUNIT", type=str.upper, choices=SUPPORTED_REPORT_TYPES)
-    parser.add_argument("--log", default="NONE")
+    parser.add_argument("--log", default="NONE", type=str.upper, choices=SUPPORTED_LOG_TYPES)
     parser.add_argument("--tests", action="append", default=[])
     parser.add_argument("--available-tests", action="store_true")
     args = parser.parse_args(argv)
@@ -503,6 +504,19 @@ def teamcity_escape(value):
 
 
 def log_teamcity(log_type, event, **attrs):
+    if log_type == "LOG":
+        name = attrs.get("name", "")
+        labels = {
+            "testSuiteStarted": "Test suite started",
+            "testSuiteFinished": "Test suite finished",
+            "testStarted": "Test started",
+            "testFinished": "Test finished",
+            "testFailed": "Test failed",
+        }
+        print(f"{labels[event]}: {name}")
+        if event == "testFailed":
+            print(attrs.get("message", ""))
+        return
     if log_type not in ("TC", "TEAM_CITY"):
         return
     payload = " ".join(f"{key}='{teamcity_escape(value)}'" for key, value in attrs.items())
@@ -717,7 +731,7 @@ def main(argv):
             if result["failed"]:
                 failed = True
                 log_teamcity(args.log, "testFailed", name=case_name, message=result["failed"]["message"])
-            log_teamcity(args.log, "testFinished", name=case_name)
+            log_teamcity(args.log, "testFinished", name=case_name, duration=result["durationMs"])
             results.append(result)
         log_teamcity(args.log, "testSuiteFinished", name=file_name)
         suites.append({"testFile": test_file, "fileName": file_name, "results": results})

--- a/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
+++ b/lib/capybara-lib/src/test/java/dev/capylang/test/TestRunnerTest.java
@@ -245,6 +245,11 @@ class TestRunnerTest {
 
     @Test
     void shouldParseOptionalLogOutputType() {
+        var noneArguments = TestRunner.parseArguments(new String[]{
+                "-o", tempDir.toString(),
+                "-rt", "JUNIT",
+                "--log", "NONE"
+        });
         var logArguments = TestRunner.parseArguments(new String[]{
                 "-o", tempDir.toString(),
                 "-rt", "JUNIT",
@@ -261,6 +266,7 @@ class TestRunnerTest {
                 "--log", "TEAM_CITY"
         });
 
+        assertEquals(CapyTest.LogType.NONE, noneArguments.logType());
         assertEquals(CapyTest.LogType.LOG, logArguments.logType());
         assertEquals(CapyTest.LogType.TEAM_CITY, teamCityArguments.logType());
         assertEquals(CapyTest.LogType.TEAM_CITY, longTeamCityArguments.logType());
@@ -504,10 +510,10 @@ class TestRunnerTest {
                 List.of(
                         "##teamcity[testSuiteStarted name='/capy/lang/StringTest.cfun']",
                         "##teamcity[testStarted name='starts_with should pass']",
-                        "##teamcity[testFinished name='starts_with should pass']",
+                        "##teamcity[testFinished name='starts_with should pass' duration='0']",
                         "##teamcity[testStarted name='starts_with should fail']",
                         "##teamcity[testFailed name='starts_with should fail' message='assertion failed' details='Expected string:|ncapybara|nto start with:|nbara']",
-                        "##teamcity[testFinished name='starts_with should fail']",
+                        "##teamcity[testFinished name='starts_with should fail' duration='0']",
                         "##teamcity[testSuiteFinished name='/capy/lang/StringTest.cfun']"
                 ),
                 messages
@@ -654,7 +660,7 @@ class TestRunnerTest {
         var testStarted = output.indexOf("##teamcity[testStarted name='starts_with should fail']");
         var assertionBody = output.indexOf("ASSERTION_BODY");
         var testFailed = output.indexOf("##teamcity[testFailed name='starts_with should fail' message='assertion failed' details='Expected string:|ncapybara|nto start with:|nbara']");
-        var testFinished = output.indexOf("##teamcity[testFinished name='starts_with should fail']");
+        var testFinished = output.indexOf("##teamcity[testFinished name='starts_with should fail' duration='");
         var suiteFinished = output.indexOf("##teamcity[testSuiteFinished name='/capy/lang/StringTest.cfun']");
 
         assertTrue(suiteStarted >= 0);


### PR DESCRIPTION
## Summary

- promote the JavaScript and Python Capybara test runners to maintained production resources
- package both runners in `capy.jar` and add the unified `capy test <java|js|python>` CLI
- extract packaged script runners to temporary files, inherit process I/O, and forward runtime exit codes
- support report selection, test selectors, available-test discovery, plain logging, and TeamCity service messages across backends
- update Capybara's Gradle tasks to use the production runner locations

## Why

Consumer projects currently have to copy the JavaScript and Python runner scripts or depend on a Capybara source checkout. This makes the official runners available directly from the released JAR, matching the existing Java runner distribution model.

## Impact

Consumers need only `capy.jar` and the relevant backend runtime. Reports are written to the requested output directory, generated sources remain untouched, and direct `dev.capylang.test.TestRunner` execution remains supported.

## Validation

- `./gradlew.bat --no-daemon --max-workers=1 --console=plain :capy:compileJava`
- `./gradlew.bat --no-daemon --max-workers=1 --console=plain :capy:test`
- `./gradlew.bat --no-daemon --max-workers=1 --console=plain :capy:jar`
- focused Java runner and TeamCity tests through `:lib:capybara-lib:test`
- standalone `capy.jar` Java and JavaScript execution, including paths with spaces, JUnit/CTRF/Jest reports, selectors, and available tests
- missing Node.js and Python runtime diagnostics and exit codes
