### PR TITLE
feat(#380): add unconditional assertions

### DIFF
--- a/capy/src/main/capybara/dev/capylang/generator/JavaGenerator.cfun
+++ b/capy/src/main/capybara/dev/capylang/generator/JavaGenerator.cfun
@@ -3521,10 +3521,12 @@ private fun function_call_code(call: CompiledFunctionCallExpression, env: List[J
     then reflection_call_code(call, env, module, allModules)
     else if object_type_function_call(call, module, allModules)
     then object_type_function_call_code(call, module, allModules)
-    else if call.name == "assert_all"
-    then "capy.test.Assert.assert_all__48_0(" + expression_code(argument(call.arguments, 0), env, list_type(assert_type()), module, allModules) + ")"
-    else if call.name == "assert_that"
+    else if assert_function_call(call, module) & call.name == "assert_all"
+    then assert_stdlib_function_call_code(call, env, module, allModules)
+    else if assert_function_call(call, module) & call.name == "assert_that"
     then assert_that_code(argument(call.arguments, 0), env, module, allModules)
+    else if assert_function_call(call, module)
+    then assert_stdlib_function_call_code(call, env, module, allModules)
     else if call.name == "test"
     then "__capy_data(\"TestCase\", java.util.Map.ofEntries(java.util.Map.entry(\"name\", "
         + expression_code(argument(call.arguments, 0), env, string_type(), module, allModules)
@@ -5814,7 +5816,7 @@ private fun assert_method_call(call: CompiledMethodCallExpression, env: List[Jav
 /// Checks whether an expression has the assert expression shape.
 private fun assert_expression(expression: CompiledExpression, env: List[JavaBinding], module: CompiledModule, allModules: List[CompiledModule]): bool =
     match expression with
-    case CompiledFunctionCallExpression call -> call.name == "assert_that" | call.name == "assert_all"
+    case CompiledFunctionCallExpression call -> assert_function_call(call, module)
     case CompiledMethodCallExpression call -> assert_method_call(call, env, module, allModules) | assert_status_call(call, env, module, allModules)
     case CompiledVariableExpression variable -> lookup_binding(variable.name, env).name == "Assert"
     case _ -> expression_type(expression, env, module, allModules).name == "Assert"
@@ -6531,6 +6533,25 @@ private fun assert_that_code(expression: CompiledExpression, env: List[JavaBindi
 
 private fun java_assert_data(typeName: String, valueCode: String): String =
     "__capy_data(\"" + typeName + "\", java.util.Map.ofEntries(java.util.Map.entry(\"assertions\", java.util.List.of()), java.util.Map.entry(\"value\", " + valueCode + ")))"
+
+/// Emits a call to a generated assertion helper without relying on source-line-specific names.
+private fun assert_stdlib_function_call_code(call: CompiledFunctionCallExpression, env: List[JavaBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
+    match find_assert_function_binding(call.name, module.functionBindings) with
+    case Some { binding } ->
+        java_function_binding_class_name(binding) + "." + java_function_name(binding.function)
+            + "(" + parameter_expression_list_code(binding.function.parameters, call.arguments, env, module, allModules) + ")"
+    case None -> "unsupported(\"assert function call\")"
+
+/// Finds an assertion helper together with its declaring standard-library module.
+private fun find_assert_function_binding(name: String, bindings: List[CompiledFunctionBinding]): /capy/lang/Option[CompiledFunctionBinding] =
+    match bindings[0] with
+    case None -> /capy/lang/Option.None {}
+    case Some { binding } ->
+        if binding.moduleName == "Assert"
+            & normalized_stdlib_path(binding.modulePath) == "capy/test"
+            & binding.function.name == name
+        then /capy/lang/Option.Some { binding }
+        else find_assert_function_binding(name, bindings[1:])
 
 /// Emits generated code for expression list.
 private fun expression_list_code(expressions: List[CompiledExpression], env: List[JavaBinding], module: CompiledModule, allModules: List[CompiledModule]): String =
@@ -7893,7 +7914,7 @@ private fun function_call_type(call: CompiledFunctionCallExpression, env: List[J
     then data_type_reference("DataValueInfo")
     else if object_type_function_call(call, module, allModules)
     then object_type_function_call_type(call, module, allModules)
-    else if call.name == "assert_all" | call.name == "assert_that"
+    else if assert_function_call(call, module)
     then assert_type()
     else if call.name == "test"
     then test_case_type()
@@ -11407,10 +11428,12 @@ private fun function_call_emittable(call: CompiledFunctionCallExpression, env: L
     then reflection_call_emittable(call, env, module, allModules)
     else if object_type_function_call(call, module, allModules)
     then true
-    else if call.name == "assert_all"
+    else if assert_function_call(call, module) & call.name == "assert_all"
     then expressions_emittable(call.arguments, env, module, allModules)
-    else if call.name == "assert_that"
+    else if assert_function_call(call, module) & call.name == "assert_that"
     then assert_that_call_emittable(call.arguments, env, module, allModules)
+    else if assert_function_call(call, module)
+    then one_string_argument(call.arguments, env, module, allModules)
     else if call.name == "test"
     then test_call_emittable(call.arguments, env, module, allModules)
     else if call.name == "test_file"
@@ -12290,6 +12313,20 @@ private fun clock_member_imported(member: String, imports: List[CompiledImportDe
 /// Checks whether result member is imported into the current module scope.
 private fun result_member_imported(member: String, imports: List[CompiledImportDeclaration]): bool =
     module_member_imported(member, imports, "/capy/lang/Result", "capy/lang/Result")
+
+/// Checks whether an assertion helper is imported unambiguously into the current module.
+private fun assert_function_call(call: CompiledFunctionCallExpression, module: CompiledModule): bool =
+    if call.name == "assert_all" | call.name == "assert_that" | call.name == "pass"
+    then !function_defined(call.name, module.functions) & assert_member_imported(call.name, module.imports)
+    else if call.name == "fail"
+    then !function_defined(call.name, module.functions)
+        & assert_member_imported(call.name, module.imports)
+        & !result_member_imported(call.name, module.imports)
+    else false
+
+/// Checks whether an Assert module member is imported into the current module scope.
+private fun assert_member_imported(member: String, imports: List[CompiledImportDeclaration]): bool =
+    module_member_imported(member, imports, "/capy/test/Assert", "capy/test/Assert")
 
 /// Checks whether seq member is imported into the current module scope.
 private fun seq_member_imported(member: String, imports: List[CompiledImportDeclaration]): bool =

--- a/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/lang/Result.cfun
@@ -93,6 +93,9 @@ fun error_full(
     }
 
 /// Returns a failed Result with a generic Error.
+///
+/// When `/capy/test/Assert` is also imported, exclude `fail` from one wildcard
+/// import or selectively import only the intended `fail` function.
 fun fail(message: String): Result[T] = error(message)
 
 /// Returns a failed Result with a stable error kind.

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -43,6 +43,9 @@ fun Assert.failed(): bool = (this.assertions | supplier => supplier().result).an
 fun Assert.succeeded(): bool = !this.failed()
 
 /// Creates an assertion that always fails with `message`.
+///
+/// When `/capy/lang/Result` is also imported, exclude `fail` from one wildcard
+/// import or selectively import only the intended `fail` function.
 fun fail(message: String): Assert =
     let assertion = Assertion { result: false, message: message, type: 'fail' }
     let assertions: List[() => Assertion] = [() => assertion]

--- a/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
+++ b/lib/capybara-lib/src/main/capybara/capy/test/Assert.cfun
@@ -42,6 +42,18 @@ fun Assert.failed(): bool = (this.assertions | supplier => supplier().result).an
 /// Returns true when every assertion in the chain succeeds.
 fun Assert.succeeded(): bool = !this.failed()
 
+/// Creates an assertion that always fails with `message`.
+fun fail(message: String): Assert =
+    let assertion = Assertion { result: false, message: message, type: 'fail' }
+    let assertions: List[() => Assertion] = [() => assertion]
+    TechnicalAssert { assertions: assertions }
+
+/// Creates an assertion that always succeeds with `message`.
+fun pass(message: String): Assert =
+    let assertion = Assertion { result: true, message: message, type: 'pass' }
+    let assertions: List[() => Assertion] = [() => assertion]
+    TechnicalAssert { assertions: assertions }
+
 private data TechnicalAssert { assertions: List[() => Assertion] }
 /// Chainable assertions for a string value.
 data StringAssert { value: String }

--- a/lib/capybara-lib/src/test/capybara/capy/collection/CollectionTypesTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/collection/CollectionTypesTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/collection/CollectionTypes import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Primitives import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/collection/ListTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/collection/ListTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/collection/CollectionTypes import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Ordering import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/collection/SeqTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/collection/SeqTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/collection/CollectionTypes import { * }
 from /capy/collection/List import { * }
 from /capy/lang/Effect import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTest.cfun
@@ -1,5 +1,5 @@
 from /capy/date_time/Date import { * }
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Math import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/DateTimeTest.cfun
@@ -8,7 +8,7 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 from /capy/collection/Seq import { * }
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/test/CapyTest import { * }
 

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/IntervalTest.cfun
@@ -8,7 +8,7 @@ from /capy/collection/List import { * }
 from /capy/collection/Set import { * }
 from /capy/collection/Dict import { * }
 from /capy/collection/Seq import { * }
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/test/CapyTest import { * }
 

--- a/lib/capybara-lib/src/test/capybara/capy/date_time/TimeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/date_time/TimeTest.cfun
@@ -1,5 +1,5 @@
 from /capy/date_time/Time import { * }
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Math import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/io/ByteSizeTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/io/ByteSizeTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Primitives import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/io/IOTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/io/IOTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/test/CapyTest import { * }
 from /capy/collection/List import { * }
 from /capy/io/IO import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/io/PathTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/io/PathTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/test/CapyTest import { * }
 from /capy/collection/List import { * }
 from /capy/io/Path import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/AsyncTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/AsyncTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Async import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/BoundedNumberTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/BoundedNumberTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/BoundedNumber import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/ProgramTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/ProgramTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Program import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/RandomTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/RandomTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/collection/CollectionTypes import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Primitives import { FLOAT_BOUND, DOUBLE_BOUND }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/ResultTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/ResultTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Result import { * }
 from /capy/test/CapyTest import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/StringTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/collection/CollectionTypes import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Ordering import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/lang/TimeUnitTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/lang/TimeUnitTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Result import { * }
 from /capy/lang/TimeUnit import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/serialization/JsonTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/lang/Effect import { * }
 from /capy/lang/Option import { * }
 from /capy/lang/Result import { * }

--- a/lib/capybara-lib/src/test/capybara/capy/test/AssertTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/test/AssertTest.cfun
@@ -1,0 +1,31 @@
+from /capy/test/Assert import { * }
+from /capy/test/CapyTest import { * }
+from /capy/lang/Effect import { * }
+
+fun tests(): Effect[TestFile] =
+    test_file("/capy/test/AssertTest.cfun", [
+        test("fail should always fail with given message", () => fail_should_always_fail_with_given_message()),
+        test("pass should always pass with given message", () => pass_should_always_pass_with_given_message()),
+    ])
+
+fun fail_should_always_fail_with_given_message(): Assert =
+    let result: Assert = fail("expected failure")
+    let assertion = first_assertion(result)
+    assert_all([
+        assert_that(assertion.result).is_false(),
+        assert_that(assertion.message).is_equal_to("expected failure"),
+    ])
+
+fun pass_should_always_pass_with_given_message(): Assert =
+    let result: Assert = pass("expected success")
+    let assertion = first_assertion(result)
+    assert_all([
+        assert_that(assertion.result).is_true(),
+        assert_that(assertion.message).is_equal_to("expected success"),
+    ])
+
+private fun first_assertion(assert: Assert): Assertion =
+    match assert.assertions.get(0) with
+    case Some { value } ->
+        (value)()
+    case None -> Assertion { result: false, message: "Missing assertion", type: 'AssertTest' }

--- a/lib/capybara-lib/src/test/capybara/capy/test/AssertTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/test/AssertTest.cfun
@@ -1,6 +1,7 @@
 from /capy/test/Assert import { * }
 from /capy/test/CapyTest import { * }
 from /capy/lang/Effect import { * }
+from /capy/lang/Result import { * } except { fail }
 
 fun tests(): Effect[TestFile] =
     test_file("/capy/test/AssertTest.cfun", [

--- a/lib/capybara-lib/src/test/capybara/capy/test/ResultAssertTest.cfun
+++ b/lib/capybara-lib/src/test/capybara/capy/test/ResultAssertTest.cfun
@@ -1,4 +1,4 @@
-from /capy/test/Assert import { * }
+from /capy/test/Assert import { * } except { fail }
 from /capy/test/CapyTest import { * }
 from /capy/lang/Effect import { * }
 from /capy/lang/Result import { * }
@@ -11,6 +11,7 @@ fun tests(): Effect[TestFile] =
         test("should assert result error with nested assertions", () => should_assert_result_error_with_nested_assertions()),
         test("should reject wrong result error assertions", () => should_reject_wrong_result_error_assertions()),
         test("should reject result error assertions for success", () => should_reject_result_error_assertions_for_success()),
+        test("should keep Result fail unambiguous", () => should_keep_result_fail_unambiguous()),
     ])
 
 fun should_assert_result_error_kind(): Assert =
@@ -49,3 +50,7 @@ fun should_reject_result_error_assertions_for_success(): Assert =
         assert_that(assert_that(result).fails_with_message_containing("required").failed()).is_true(),
         assert_that(assert_that(result).fails(error => assert_that(error.kind).is_equal_to("capy.test.validation")).failed()).is_true(),
     ])
+
+fun should_keep_result_fail_unambiguous(): Assert =
+    let result: Result[int] = fail("expected result failure")
+    assert_that(result).fails_with_kind("capy.error", "expected result failure")


### PR DESCRIPTION
## Summary

- add `fail(message: String): Assert` for unconditional failures
- add `pass(message: String): Assert` for unconditional successes
- preserve the supplied message in the generated assertion
- add focused tests for both helpers

## Why

Tests sometimes need to produce an explicit assertion result without first asserting against another value. These helpers provide that capability while continuing to use the existing lazy assertion model and test runner.

## Validation

- `:lib:capybara-lib:compileCapybara`
- `:lib:capybara-lib:compileTestCapybara`
- `:lib:capybara-lib:testCapybaraJavaScript`
- `:lib:capybara-lib:testCapybara`
- generated Python assertion checks

Closes #380
